### PR TITLE
add optional parameter to filter projects and flights by raster data availability

### DIFF
--- a/backend/app/api/api_v1/endpoints/flights.py
+++ b/backend/app/api/api_v1/endpoints/flights.py
@@ -57,6 +57,7 @@ def read_flights(
     request: Request,
     project_id: UUID,
     include_all: bool = True,
+    has_raster: bool = False,
     current_user: models.User = Depends(deps.get_current_approved_user),
     project: models.Project = Depends(deps.can_read_project),
     db: Session = Depends(deps.get_db),
@@ -72,6 +73,7 @@ def read_flights(
         upload_dir=upload_dir,
         user_id=current_user.id,
         include_all=include_all,
+        has_raster=has_raster,
     )
     return flights
 

--- a/backend/app/api/api_v1/endpoints/projects.py
+++ b/backend/app/api/api_v1/endpoints/projects.py
@@ -72,12 +72,18 @@ def read_projects(
     edit_only: bool = False,
     skip: int = 0,
     limit: int = 100,
+    has_raster: bool = False,
     current_user: models.User = Depends(deps.get_current_approved_user),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     """Retrieve list of projects current user belongs to."""
     projects = crud.project.get_user_project_list(
-        db, user_id=current_user.id, edit_only=edit_only, skip=skip, limit=limit
+        db,
+        user_id=current_user.id,
+        edit_only=edit_only,
+        skip=skip,
+        limit=limit,
+        has_raster=has_raster,
     )
     return projects
 


### PR DESCRIPTION
Adds "has_raster" query parameter to get_projects and get_flights. If set to True, these methods will only return projects/flights that have activate raster data products.

This is useful for the D2S QGIS plugin. It limits the number of requests to D2S and filters out projects/flights that do not have data we can visualize in QGIS.