### PR TITLE
add share option for point clouds, revise share button terminology, a…

### DIFF
--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
+from pydantic import UUID4
 from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
@@ -16,7 +17,7 @@ router = APIRouter()
 @router.get("", response_model=schemas.DataProduct)
 def read_shared_data_product_with_public_access(
     request: Request,
-    file_id: str,
+    file_id: UUID4,
     db: Session = Depends(deps.get_db),
 ) -> Any:
     if os.environ.get("RUNNING_TESTS") == "1":
@@ -36,7 +37,7 @@ def read_shared_data_product_with_public_access(
 @router.get("/user_access", response_model=schemas.DataProduct)
 def read_shared_data_product_with_user_access(
     request: Request,
-    file_id: str,
+    file_id: UUID4,
     db: Session = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_approved_user),
 ):

--- a/backend/app/crud/crud_data_product.py
+++ b/backend/app/crud/crud_data_product.py
@@ -71,10 +71,12 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
                 set_url_attr(data_product, upload_dir)
                 return data_product
             elif data_product and user_id:
-                project_id = data_product.flight.project.id
+                project_id = data_product.flight.project_id
+                print(project_id)
                 project_member = crud.project_member.get_by_project_and_member_id(
                     db, project_id=project_id, member_id=user_id
                 )
+                print(project_member)
                 if project_member:
                     set_url_attr(data_product, upload_dir)
                     return data_product

--- a/backend/app/tests/crud/test_project.py
+++ b/backend/app/tests/crud/test_project.py
@@ -58,6 +58,18 @@ def test_create_project_with_team(db: Session) -> None:
     assert project.team_id == team.id
 
 
+def test_create_project_creates_project_member_for_owner(db: Session) -> None:
+    user = create_user(db)
+    project = create_project(db, owner_id=user.id)
+    project_member = crud.project_member.get_by_project_and_member_id(
+        db, project_id=project.id, member_id=user.id
+    )
+    assert project_member
+    assert project_member.role == "owner"
+    assert user.id == project_member.member_id
+    assert project.id == project_member.project_id
+
+
 def test_get_project_by_id(db: Session) -> None:
     project = create_project(db)
     stored_project = crud.project.get(db, id=project.id)

--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   ArrowRightIcon,
   ArrowUpOnSquareIcon,
@@ -6,7 +8,6 @@ import {
   LinkIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
-import { Link } from 'react-router-dom';
 
 interface Button extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
@@ -179,5 +180,29 @@ export function LandingButton({ children, size = 'normal', ...props }: Button) {
     >
       {children}
     </button>
+  );
+}
+
+type CopyURLButton = {
+  copyText: string;
+  copiedText: string;
+  title?: string;
+  url: string;
+};
+export function CopyURLButton({ copyText, copiedText, title, url }: CopyURLButton) {
+  const [buttonText, setButtonText] = useState(copyText);
+
+  return (
+    <Button
+      size="sm"
+      onClick={() => {
+        navigator.clipboard.writeText(url);
+        setButtonText(copiedText);
+        setTimeout(() => setButtonText(copyText), 2000);
+      }}
+      title={title ? title : 'Click to copy URL'}
+    >
+      {buttonText}
+    </Button>
   );
 }

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -59,7 +60,12 @@ export function TableBody({
           ))}
           {actions ? (
             <TableCell align={align}>
-              <div className="w-full h-full flex items-center justify-around">
+              <div
+                className={clsx('w-full h-full grid content-around gap-2', {
+                  'grid-cols-3': actions.length > 2,
+                  'grid-cols-2': actions.length < 3,
+                })}
+              >
                 {actions[i].map((action) =>
                   action.type === 'button' ? (
                     <div key={action.key}>

--- a/frontend/src/components/maps/ShareControls.tsx
+++ b/frontend/src/components/maps/ShareControls.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Alert, { Status } from '../Alert';
-import { Button } from '../Buttons';
+import { CopyURLButton } from '../Buttons';
 import { DataProduct } from '../pages/projects/Project';
 import { useMapContext } from './MapContext';
 import { SymbologySettings } from './Maps';
@@ -21,8 +21,6 @@ export default function ShareControls({
   refreshUrl?: string;
 }) {
   const [accessOption, setAccessOption] = useState<boolean>(dataProduct.public);
-  const [includeSymbology, setIncludeSymbology] = useState(false);
-  const [isCopying, setIsCopying] = useState(false);
   const [status, setStatus] = useState<Status | null>(null);
 
   const navigate = useNavigate();
@@ -149,39 +147,37 @@ export default function ShareControls({
           </div>
         ) : null}
       </fieldset>
-      <div className="flex items-center gap-4">
-        <Button
-          size="sm"
-          onClick={() => {
-            if (includeSymbology) {
-              const newUrl =
+      <div className="grid grid-cols-6 gap-4">
+        <div className="col-span-2">
+          <CopyURLButton
+            copyText="Copy File URL"
+            copiedText="Copied"
+            url={dataProduct.url}
+            title="Copy link that can be used to directly access the data product"
+          />
+        </div>
+        {symbologySettings ? (
+          <div className="col-span-2">
+            <CopyURLButton
+              copyText="Copy Share URL"
+              copiedText="Copied"
+              url={
                 window.origin +
                 `/sharemap?file_id=${dataProduct.id}&symbology=` +
-                btoa(JSON.stringify(symbologySettings));
-              navigator.clipboard.writeText(newUrl);
-            } else {
-              navigator.clipboard.writeText(dataProduct.url);
-            }
-            setIsCopying(true);
-            setTimeout(() => setIsCopying(false), 3000);
-          }}
-        >
-          {isCopying ? 'Copied to clipboard' : 'Copy file link'}
-        </Button>
-        {symbologySettings ? (
-          <div className="flex items-center">
-            <input
-              id="default-checkbox"
-              type="checkbox"
-              className="w-4 h-4 text-slate-600 accent-slate-600 bg-gray-100 border-gray-300 rounded focus:ring-slate-500 dark:focus:ring-slate-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-              onChange={(e) => setIncludeSymbology(e.target.checked)}
+                btoa(JSON.stringify(symbologySettings))
+              }
+              title="Copy link that can be used to share the current map and selected data product"
             />
-            <label
-              htmlFor="default-checkbox"
-              className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"
-            >
-              Include symbology
-            </label>
+          </div>
+        ) : null}
+        {dataProduct.data_type === 'point_cloud' ? (
+          <div className="col-span-2">
+            <CopyURLButton
+              copyText="Copy Share URL"
+              copiedText="Copied"
+              url={window.origin + `/sharepotree?file_id=${dataProduct.id}`}
+              title="Copy link that can be used to share the point cloud with potree"
+            />
           </div>
         ) : null}
       </div>

--- a/frontend/src/components/maps/SharePotreeViewer.tsx
+++ b/frontend/src/components/maps/SharePotreeViewer.tsx
@@ -1,0 +1,333 @@
+import axios, { AxiosResponse } from 'axios';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { DataProduct } from '../pages/projects/Project';
+import { AlertBar, Status } from '../Alert';
+
+function useQuery() {
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
+}
+
+export default function SharePotreeViewer() {
+  const [copcUrl, setCopcUrl] = useState('');
+  const [status, setStatus] = useState<Status | null>(null);
+
+  const query = useQuery();
+  const fileID = query.get('file_id');
+
+  useEffect(() => {
+    async function fetchCOPC(fileID) {
+      try {
+        const response: AxiosResponse<DataProduct> = await axios.get(
+          `${import.meta.env.VITE_API_V1_STR}/public?file_id=${fileID}`
+        );
+        if (response.status === 200) {
+          setCopcUrl(response.data.url);
+        } else {
+          setStatus({ type: 'error', msg: 'Unable to load COPC' });
+        }
+      } catch (_err) {
+        setStatus({ type: 'error', msg: 'Unable to load COPC' });
+      }
+    }
+
+    if (fileID) {
+      fetchCOPC(fileID);
+    }
+  }, []);
+
+  const initialContent = `<!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+      <link href="/potree/libs/potree/potree.css" rel="stylesheet" />
+      <link href="/potree/libs/jquery-ui/jquery-ui.min.css" rel="stylesheet" />
+      <link href="/potree/libs/openlayers3/ol.css" rel="stylesheet" />
+      <link href="/potree/libs/spectrum/spectrum.css" rel="stylesheet" />
+      <link href="/potree/libs/jstree/themes/mixed/style.css" rel="stylesheet" />
+
+      <style>	
+        #potree_toolbar {
+          position: absolute; 
+          z-index: 10000; 
+          left: 100px; 
+          top: 0px;
+          background: black;
+          color: white;
+          padding: 0.3em 0.8em;
+          font-family: "system-ui";
+          border-radius: 0em 0em 0.3em 0.3em;
+          display: flex;
+        }
+
+        .potree_toolbar_label {
+          text-align: center;
+          font-size: smaller;
+          opacity: 0.9;
+        }
+
+        .potree_toolbar_separator {
+          background: white;
+          padding: 0px;
+          margin: 5px 10px;
+          width: 1px;
+        }
+	    </style>
+
+      <base target="_blank">
+    </head>
+    <body>
+      <script src='/potree/libs/jquery/jquery-3.1.1.min.js'></script>
+      <script src='/potree/libs/spectrum/spectrum.js'></script>
+      <script src='/potree/libs/jquery-ui/jquery-ui.min.js'></script>
+      <script src='/potree/libs/other/BinaryHeap.js'></script>
+      <script src='/potree/libs/tween/tween.min.js'></script>
+      <script src='/potree/libs/d3/d3.js'></script>
+      <script src='/potree/libs/proj4/proj4.js'></script>
+      <script src='/potree/libs/openlayers3/ol.js'></script>
+      <script src='/potree/libs/i18next/i18next.js'></script>
+      <script src='/potree/libs/jstree/jstree.js'></script>
+      <script src='/potree/libs/copc/index.js'></script>
+      <script src='/potree/libs/potree/potree.js'></script>
+      <script src='/potree/libs/plasio/js/laslaz.js'></script>
+
+      <div class="potree_container">
+        <div id="potree_render_area">
+          <div id="potree_toolbar"></div>
+        </div>
+        <div id="potree_sidebar_container"></div>
+      </div>
+
+      <script type="module">
+        import * as THREE from "/potree/libs/three.js/build/three.module.js";
+        window.viewer = new Potree.Viewer(document.getElementById("potree_render_area"));
+
+        viewer.setEDLEnabled(true);
+        viewer.setFOV(60);
+        viewer.setPointBudget(2_000_000);
+        viewer.loadSettingsFromURL();
+        viewer.useHQ = true;
+
+        // viewer.setDescription('Loading Entwine-generated EPT format');
+
+        viewer.loadGUI(() => {
+          viewer.setLanguage('en');
+          $("#menu_tools").next().show();
+        });
+        
+        const path = '${copcUrl.replace(window.origin, '')}';
+        const name = 'Potree';
+
+        Potree.loadPointCloud(path, name, function(e) {
+          viewer.scene.addPointCloud(e.pointcloud);
+
+          let material = e.pointcloud.material;
+          material.size = 1;
+          material.shape = Potree.PointShape.CIRCLE;
+          material.pointSizeType = Potree.PointSizeType.ADAPTIVE;
+
+          viewer.fitToScreen(0.5);
+        });
+      </script>
+
+      <script type="module">
+        import * as THREE from "/potree/libs/three.js/build/three.module.js";
+
+        // source: https://github.com/potree/potree/blob/develop/examples/toolbar.html
+        
+        // HTML
+        const elToolbar = $("#potree_toolbar");
+        elToolbar.html(\`
+          <span>
+            <div class="potree_toolbar_label">
+				      Attribute
+			      </div>
+			      <div>
+				      <img name="action_elevation" src="/potree/resources/icons/profile.svg" class="annotation-action-icon" style="width: 2em; height: auto;"/>
+				      <img name="action_rgb" src="/potree/resources/icons/rgb.svg" class="annotation-action-icon" style="width: 2em; height: auto;"/>
+			      </div>
+          </span>
+          
+          <span class="potree_toolbar_separator" />
+        
+          <span>
+            <div class="potree_toolbar_label">
+              Gradient
+            </div>
+			      <div>
+				      <span name="gradient_schemes"></span>
+			      </div>
+		      </span>
+
+          <span class="potree_toolbar_separator" />
+
+		      <span>
+			      <div class="potree_toolbar_label">
+				      Measure
+			      </div>
+			      <div>
+				      <img name="action_measure_point" src="/potree/resources/icons/point.svg" class="annotation-action-icon" style="width: 2em; height: auto;"/>
+				      <img name="action_measure_distance" src="/potree/resources/icons/distance.svg" class="annotation-action-icon" style="width: 2em; height: auto;"/>
+				      <img name="action_measure_circle" src="/potree/resources/icons/circle.svg" class="annotation-action-icon" style="width: 2em; height: auto;"/>
+			      </div>
+		      </span>
+
+          <span class="potree_toolbar_separator" />
+
+          <span>
+            <div class="potree_toolbar_label" style="width: 12em">
+              Material
+            </div>
+            <div>
+              <select id="optMaterial" name="optMaterial"></select>
+            </div>
+          </span>
+
+          <span class="potree_toolbar_separator" />
+
+          <span>
+            <div class="potree_toolbar_label">
+              <span data-i18n="appearance.nb_max_pts">Point Budget</span>: 
+              <span name="lblPointBudget" style="display: inline-block; width: 4em;"></span>
+            </div>
+            <div>
+              <div id="sldPointBudget"></div>
+            </div>
+          </span>
+
+        \`);
+
+        // CONTENT & ACTIONS
+        { // ATTRIBUTE
+          elToolbar.find("img[name=action_elevation]").click( () => {
+            viewer.scene.pointclouds.forEach( pc => pc.material.activeAttributeName = "elevation" );
+          });
+      
+          elToolbar.find("img[name=action_rgb]").click( () => {
+            viewer.scene.pointclouds.forEach( pc => pc.material.activeAttributeName = "rgba" );
+          });
+        }
+
+        { // GRADIENT
+          const schemes = Object.keys(Potree.Gradients).map(name => ({name: name, values: Potree.Gradients[name]}));
+          const elGradientSchemes = elToolbar.find("span[name=gradient_schemes]");
+      
+          for(const scheme of schemes){
+            const elButton = $(\`
+              <span style=""></span>
+            \`);
+      
+            const svg = Potree.Utils.createSvgGradient(scheme.values);
+            svg.setAttributeNS(null, "class", \`button-icon\`);
+            svg.style.height = "2em";
+            svg.style.width = "1.3em";
+      
+            elButton.append($(svg));
+      
+            elButton.click( () => {
+              for(const pointcloud of viewer.scene.pointclouds){
+                pointcloud.material.activeAttributeName = "elevation";
+                pointcloud.material.gradient = Potree.Gradients[scheme.name];
+              }
+            });
+      
+            elGradientSchemes.append(elButton);
+          }
+        }
+      
+        { // MEASURE
+          elToolbar.find("img[name=action_measure_point]").click( () => {
+            const measurement = viewer.measuringTool.startInsertion({
+              showDistances: false,
+              showAngles: false,
+              showCoordinates: true,
+              showArea: false,
+              closed: true,
+              maxMarkers: 1,
+              name: 'Point'
+            });
+          });
+      
+          elToolbar.find("img[name=action_measure_distance]").click( () => {
+            const measurement = viewer.measuringTool.startInsertion({
+              showDistances: true,
+              showArea: false,
+              closed: false,
+              name: 'Distance'
+            });
+          });
+      
+          elToolbar.find("img[name=action_measure_circle]").click( () => {
+            const measurement = viewer.measuringTool.startInsertion({
+              showDistances: false,
+              showHeight: false,
+              showArea: false,
+              showCircle: true,
+              showEdges: false,
+              closed: false,
+              maxMarkers: 3,
+              name: 'Circle'
+            });
+          });
+        }
+      
+        { // MATERIAL
+          let options = [
+            "rgba", 
+            "elevation",
+            "level of detail",
+            "indices",
+            "intensity",
+            "classification",
+            // "source id",
+          ];
+      
+          let attributeSelection = elToolbar.find('#optMaterial');
+          for(let option of options){
+            let elOption = $(\`<option>\${option}</option>\`);
+            attributeSelection.append(elOption);
+          }
+      
+          const updateMaterialSelection = (event, ui) => {
+            let selectedValue = attributeSelection.selectmenu().val();
+      
+            for(const pointcloud of viewer.scene.pointclouds){
+              pointcloud.material.activeAttributeName = selectedValue;
+            }
+          };
+      
+          attributeSelection.selectmenu({change: updateMaterialSelection});
+        }
+      
+        { // POINT BUDGET
+          elToolbar.find('#sldPointBudget').slider({
+            value: viewer.getPointBudget(),
+            min: 100_000,
+            max: 2_000_000,
+            step: 100_000,
+            slide: (event, ui) => { viewer.setPointBudget(ui.value); }
+          });
+      
+          const onBudgetChange = () => {
+            let budget = (viewer.getPointBudget() / (1000_000)).toFixed(1) + "M";
+            elToolbar.find('span[name=lblPointBudget]').html(budget);
+          };
+      
+          onBudgetChange();
+          viewer.addEventListener("point_budget_changed", onBudgetChange);
+        }
+      </script>
+    </body>
+  </html>`;
+  return (
+    <Fragment>
+      <iframe className="h-full w-full" srcDoc={initialContent}></iframe>
+      {status && <AlertBar alertType={status.type}>{status.msg}</AlertBar>}
+    </Fragment>
+  );
+}

--- a/frontend/src/components/pages/projects/flights/dataProducts/DataProductCard.tsx
+++ b/frontend/src/components/pages/projects/flights/dataProducts/DataProductCard.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ExclamationCircleIcon, EyeIcon, PhotoIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowDownTrayIcon,
+  ExclamationCircleIcon,
+  EyeIcon,
+  PhotoIcon,
+} from '@heroicons/react/24/outline';
 
 import Card from '../../../../Card';
 import { DataProductStatus } from '../FlightData';
@@ -108,6 +113,12 @@ export default function DataProductCard({
               <span>{dataProduct.data_type.split('_').join(' ').toUpperCase()}</span>
               {projectRole === 'owner' ? (
                 <div className="flex flex-row gap-4">
+                  <a href={dataProduct.url} target="_blank" download>
+                    <ArrowDownTrayIcon
+                      className="w-5 h-5"
+                      title="Download data product"
+                    />
+                  </a>
                   <DataProductShareModal dataProduct={dataProduct} />
                   <DataProductDeleteModal dataProduct={dataProduct} />
                 </div>

--- a/frontend/src/components/pages/projects/flights/dataProducts/DataProductsTable.tsx
+++ b/frontend/src/components/pages/projects/flights/dataProducts/DataProductsTable.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 import {
+  ArrowDownTrayIcon,
   CheckCircleIcon,
   CogIcon,
   EyeIcon,
@@ -9,7 +10,7 @@ import {
   QuestionMarkCircleIcon,
 } from '@heroicons/react/24/outline';
 
-import { Button } from '../../../../Buttons';
+import { CopyURLButton } from '../../../../Buttons';
 import DataProductDeleteModal from './DataProductDeleteModal';
 import { DataProductStatus } from '../FlightData';
 import { useProjectContext } from '../../ProjectContext';
@@ -55,6 +56,23 @@ function getDataProductActions(
     label: 'Toolbox',
   });
 
+  const getDownloadAction = (dataProduct: DataProductStatus) => ({
+    key: `action-download-${dataProduct.id}`,
+    type: 'component',
+    component: (
+      <a
+        className="flex items-center gap-1 text-sky-600"
+        href={dataProduct.url}
+        target="_blank"
+        download
+      >
+        <ArrowDownTrayIcon className="w-4 h-4" title="Download data product" />
+        <span className="text-sm">Download</span>
+      </a>
+    ),
+    label: 'Download',
+  });
+
   const getShareAction = (dataProduct: DataProductStatus) => ({
     key: `action-share-${dataProduct.id}`,
     type: 'component',
@@ -85,12 +103,14 @@ function getDataProductActions(
     return data.map((dataProduct) => [
       getViewAction(dataProduct),
       getToolboxAction(dataProduct),
+      getDownloadAction(dataProduct),
       getShareAction(dataProduct),
       getDeleteAction(dataProduct),
     ]);
   } else if (role === 'manager') {
     return data.map((dataProduct) => [
       getViewAction(dataProduct),
+      getDownloadAction(dataProduct),
       getToolboxAction(dataProduct),
     ]);
   } else {
@@ -149,12 +169,11 @@ export default function DataProductsTable({ data }: { data: DataProductStatus[] 
                 key={`row-${dataset.id}-file`}
                 className="h-full flex items-center justify-center"
               >
-                <Button
-                  size="sm"
-                  onClick={() => navigator.clipboard.writeText(dataset.url)}
-                >
-                  {isGeoTIFF(dataset.data_type) ? 'Copy COG URL' : 'Copy COPC URL'}
-                </Button>
+                <CopyURLButton
+                  copyText="Copy File URL"
+                  copiedText="Copied"
+                  url={dataset.url}
+                />
               </div>
             ) : (
               <div

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -35,6 +35,7 @@ import ProjectList, {
 } from './components/pages/projects/ProjectList';
 import RegistrationForm from './components/pages/auth/RegistrationForm';
 import ShareMap from './components/maps/ShareMap';
+import SharePotreeViewer from './components/maps/SharePotreeViewer';
 import Teams, { loader as teamsLoader } from './components/pages/teams/Teams';
 import TeamCreate, {
   loader as teamCreateLoader,
@@ -81,6 +82,11 @@ export const router = createBrowserRouter([
         path: '/sharemap',
         element: <RootProtected />,
         children: [{ path: '/sharemap', element: <ShareMap /> }],
+      },
+      {
+        path: '/sharepotree',
+        element: <RootProtected />,
+        children: [{ path: '/sharepotree', element: <SharePotreeViewer /> }],
       },
     ],
   },


### PR DESCRIPTION
- Enables sharing links that load public (and private after auth) point clouds with potree viewer
- Revised share buttons to be more consistent across the site and less confusing to use (hopefully)
- Adds a Copy button component that can be used for copying urls to clipboard
- Add download option in table and card view for data products
- Adjusted actions layout in table view