### PR TITLE
add environment variable to toggle on/off httponly "secure" attribute

### DIFF
--- a/backend.example.env
+++ b/backend.example.env
@@ -16,3 +16,8 @@ MAIL_PORT=587
 MAPBOX_ACCESS_TOKEN=
 
 SECRET_KEY=
+
+# Setting this value to 0 will remove the "Secure" attribute from the HttpOnly cookie,
+# allowing it to be sent over non-HTTPS connections. Only make this change if you fully
+# understand and accept the associated risks.
+HTTP_COOKIE_SECURE=1


### PR DESCRIPTION
Adds backend environment variable "HTTP_ONLY_SECURE". It can be used to toggle on/off the "Secure" attribute when the HttpOnly cookie is created in the "access-token" endpoint. Useful for specific testing scenarios and deployment in testing environments. Should always be set to "1" or "true" in production environment.