### PR TITLE
fix disk usage calculation, fix issue with superuser ownership role

### DIFF
--- a/backend/app/crud/crud_project.py
+++ b/backend/app/crud/crud_project.py
@@ -276,7 +276,7 @@ class CRUDProject(CRUDBase[Project, ProjectCreate, ProjectUpdate]):
                     center_y = project[4]
 
                 # skip setting member role if this is a superuser
-                if not user.is_superuser:
+                if not user.is_superuser or (user.is_superuser and not include_all):
                     setattr(
                         project_instance,
                         "is_owner",


### PR DESCRIPTION
- Previous calculation of disk usage was for the entire volume containing the static directory. It will only be calculated for the static directory with this update.
- Superusers stopped receiving the project ownership role after a recent update. This should only be dropped when all projects are requested (e.g., for dashhboard display), otherwise, it is included once again. This fixes the issues with superusers not being able to make data products publish from the homepage.