### PR TITLE
better handle wait for site statistics

### DIFF
--- a/frontend/src/components/pages/admin/DashboardSiteStatistics.tsx
+++ b/frontend/src/components/pages/admin/DashboardSiteStatistics.tsx
@@ -1,23 +1,43 @@
 import axios, { AxiosResponse } from 'axios';
-import { useLoaderData } from 'react-router-dom';
+import { Suspense } from 'react';
+import { Await, defer, useLoaderData } from 'react-router-dom';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 
 import StatCards from './StatCards';
 
 import { SiteStatistics } from './DashboardTypes';
+import StatCardsSkeleton from './StatCardsSkeleton';
 
 export async function loader() {
-  const response: AxiosResponse<SiteStatistics> = await axios.get(
+  const response: Promise<AxiosResponse<SiteStatistics>> = axios.get(
     `${import.meta.env.VITE_API_V1_STR}/admin/site_statistics`
   );
   if (response) {
-    return response.data;
+    return defer({ stats: response });
   } else {
     return [];
   }
 }
 
-export default function DashboardSiteStatistics() {
-  const stats = useLoaderData() as SiteStatistics;
+function ErrorElement() {
+  return (
+    <div className="h-full w-full flex flex-col items-center justify-center">
+      <ExclamationTriangleIcon className="h-10 w-10 text-red-600" />
+      <span className="text-2xl font-semibold text-primary">
+        Error occurred. Unable to load statistics.
+      </span>
+    </div>
+  );
+}
 
-  return <StatCards stats={stats} />;
+export default function DashboardSiteStatistics() {
+  const data = useLoaderData() as { stats: Promise<SiteStatistics> };
+
+  return (
+    <Suspense fallback={<StatCardsSkeleton />}>
+      <Await resolve={data.stats} errorElement={<ErrorElement />}>
+        {(stats) => <StatCards stats={stats.data} />}
+      </Await>
+    </Suspense>
+  );
 }

--- a/frontend/src/components/pages/admin/StatCardsSkeleton.tsx
+++ b/frontend/src/components/pages/admin/StatCardsSkeleton.tsx
@@ -1,0 +1,63 @@
+function StatCardSkeleton() {
+  return (
+    <div className="min-h-[140px] flex flex-col items-center rounded-lg bg-blue-50 px-4 py-8 text-center shadow-md animate-pulse">
+      <div className="h-12 w-1/4 text-center bg-gray-300 rounded mb-2"></div>
+
+      <div className="h-6 w-1/2 bg-gray-300 rounded mb-2"></div>
+    </div>
+  );
+}
+
+function StatStorageCardSkeleton() {
+  return (
+    <div className="min-h-[140px] flex flex-col items-center rounded-lg bg-blue-50 px-4 py-8 text-center shadow-md animate-pulse">
+      <div className="h-4 w-full bg-gray-300 rounded-full mb-4"></div>
+      <div className="h-6 w-1/2 bg-gray-300 rounded mb-2"></div>
+      <div className="h-4 w-full bg-gray-300 rounded mb-2"></div>
+    </div>
+  );
+}
+
+export default function StatCardsSkeleton() {
+  return (
+    <section className="w-full bg-white">
+      <div className="mx-auto max-w-screen-xl px-4 py-12 sm:px-6 md:py-16 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+            Site Statistics
+          </h2>
+
+          <p className="mt-4 text-gray-500 sm:text-xl">
+            Summary of overall activity on this Data to Science application instance.
+          </p>
+        </div>
+
+        {/* general summary of users, projects, flights, and data products */}
+        <div className="mt-8 sm:mt-12">
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+          </dl>
+        </div>
+
+        {/* data product by data type counts */}
+        <div className="mt-8 sm:mt-12">
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+          </dl>
+        </div>
+
+        <div className="mt-8 sm:mt-12">
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+            <StatStorageCardSkeleton />
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
This update prevents react-router-dom loader from blocking the main dashboard page from loading while it waits for a response from the site statistics endpoint. A skeleton UI will now be displayed while the page waits for the request to finish.