### PR TITLE
reduce size of projects response, add admin context to router

### DIFF
--- a/backend/app/api/api_v1/endpoints/projects.py
+++ b/backend/app/api/api_v1/endpoints/projects.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, List
 from uuid import UUID
 
 from geojson_pydantic import Feature
@@ -68,27 +68,30 @@ def read_project(
     return project
 
 
-@router.get("", response_model=list[schemas.Project])
+@router.get("", response_model=List[schemas.project.Projects])
 def read_projects(
-    request: Request,
     edit_only: bool = False,
-    skip: int = 0,
-    limit: int = 100,
     has_raster: bool = False,
     include_all: bool = False,
     current_user: models.User = Depends(deps.get_current_approved_user),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     """Retrieve list of projects current user belongs to."""
-    projects = crud.project.get_user_project_list(
+    projects = crud.project.get_user_projects(
         db,
         user=current_user,
-        edit_only=edit_only,
-        skip=skip,
-        limit=limit,
         has_raster=has_raster,
         include_all=include_all,
     )
+    return projects
+
+
+@router.get("/landing/", response_model=List[schemas.project.Projects])
+def read_projects2(
+    current_user: models.User = Depends(deps.get_current_approved_user),
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    projects = crud.project.get_user_projects(db, user_id=current_user.id)
     return projects
 
 

--- a/backend/app/tests/crud/test_project.py
+++ b/backend/app/tests/crud/test_project.py
@@ -123,7 +123,7 @@ def test_get_projects_by_owner(db: Session) -> None:
     create_project(db, owner_id=user.id)
     create_project(db, owner_id=user.id)
     create_project(db, owner_id=user.id)
-    projects = crud.project.get_user_project_list(db, user=user)
+    projects = crud.project.get_user_projects(db, user=user)
     assert projects
     assert isinstance(projects, list)
     assert len(projects) == 3
@@ -139,30 +139,12 @@ def test_get_projects_by_project_member(db: Session) -> None:
     create_project_member(db, member_id=user.id, project_id=project1.id)
     create_project_member(db, member_id=user.id, project_id=project2.id)
     create_project_member(db, member_id=user.id, project_id=project3.id)
-    projects = crud.project.get_user_project_list(db, user=user)
+    projects = crud.project.get_user_projects(db, user=user)
     assert projects
     assert isinstance(projects, list)
     assert len(projects) == 3
     for project in projects:
         assert project.id in [project1.id, project2.id, project3.id]
-
-
-def test_get_projects_with_edit_permission(db: Session) -> None:
-    user = create_user(db)
-    project1 = create_project(db)
-    project2 = create_project(db)
-    project3 = create_project(db)
-    # cannot edit as viewer
-    create_project_member(db, role="viewer", member_id=user.id, project_id=project1.id)
-    # can edit as manager and owner
-    create_project_member(db, role="manager", member_id=user.id, project_id=project2.id)
-    create_project_member(db, role="owner", member_id=user.id, project_id=project3.id)
-    projects = crud.project.get_user_project_list(db, user=user, edit_only=True)
-    assert projects
-    assert isinstance(projects, list)
-    assert len(projects) == 2
-    for project in projects:
-        assert project.id in [project2.id, project3.id]
 
 
 def test_get_projects_with_data_products_by_type(db: Session) -> None:
@@ -196,7 +178,7 @@ def test_get_projects_with_data_products_by_type(db: Session) -> None:
                 flight_id=flight.id,
             )
     # get list of projects with raster data products
-    projects_with_rasters = crud.project.get_user_project_list(
+    projects_with_rasters = crud.project.get_user_projects(
         db, user=user, has_raster=True
     )
     assert projects_with_rasters
@@ -210,7 +192,7 @@ def test_get_all_projects(db: Session) -> None:
     project1 = create_project(db, owner_id=user.id)
     project2 = create_project(db, owner_id=user.id)
     project3 = create_project(db)
-    projects = crud.project.get_user_project_list(db, user=user, include_all=True)
+    projects = crud.project.get_user_projects(db, user=user, include_all=True)
     assert len(projects) == 3
     for project in projects:
         assert project.id in [project1.id, project2.id, project3.id]
@@ -318,7 +300,7 @@ def test_get_projects_ignores_deactivated_projects(db: Session) -> None:
     project2 = create_project(db, owner_id=user.id)
     project3 = create_project(db, owner_id=user.id)
     crud.project.deactivate(db, project_id=project3.id)
-    projects = crud.project.get_user_project_list(db, user=user)
+    projects = crud.project.get_user_projects(db, user=user)
     assert projects
     assert isinstance(projects, list)
     assert len(projects) == 2

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -102,4 +102,15 @@ export function RequireAuth({ children }: { children: React.ReactNode }) {
   return children;
 }
 
+export function RequireAdmin({ children }: { children: React.ReactNode }) {
+  const { user } = useContext(AuthContext);
+  const location = useLocation();
+
+  if (!user || (user && !user.is_superuser)) {
+    return <Navigate to="/auth/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+}
+
 export default AuthContext;

--- a/frontend/src/components/maps/Map.tsx
+++ b/frontend/src/components/maps/Map.tsx
@@ -50,7 +50,7 @@ export default function Map({ layerPaneHidden }: { layerPaneHidden: boolean }) {
         worldCopyJump={true}
       >
         {!activeProject && <ProjectMarkers projects={projects ? projects : []} />}
-        {activeProject && <ProjectBoundary project={activeProject} />}
+        {activeProject && <ProjectBoundary projectId={activeProject.id} />}
         {activeProject && <ProjectLayersControl project={activeProject} />}
 
         {activeProject &&

--- a/frontend/src/components/maps/ProjectBoundary.tsx
+++ b/frontend/src/components/maps/ProjectBoundary.tsx
@@ -1,21 +1,43 @@
-import { useEffect, useRef } from 'react';
+import axios, { AxiosResponse } from 'axios';
+import { useEffect, useRef, useState } from 'react';
 import { GeoJSON } from 'react-leaflet/GeoJSON';
 import { useMap } from 'react-leaflet';
 import { Project } from '../pages/projects/ProjectList';
 
-export default function ProjectBoundary({ project }: { project: Project }) {
+export default function ProjectBoundary({ projectId }: { projectId: string }) {
+  const [project, setProject] = useState<Project | null>(null);
+
   const map = useMap();
   const boundaryRef = useRef<L.GeoJSON>(null);
+
+  useEffect(() => {
+    async function fetchProject() {
+      try {
+        const response: AxiosResponse<Project> = await axios.get(
+          `${import.meta.env.VITE_API_V1_STR}/projects/${projectId}`
+        );
+        if (response) {
+          setProject(response.data);
+        } else {
+          return null;
+        }
+      } catch {
+        console.error('Unable to fetch project');
+        return null;
+      }
+    }
+    fetchProject();
+  }, [projectId]);
 
   useEffect(() => {
     if (boundaryRef.current) map.fitBounds(boundaryRef.current.getBounds());
   }, [boundaryRef.current]);
 
-  return (
+  return project ? (
     <GeoJSON
       ref={boundaryRef}
       style={{ fillOpacity: 0, color: '#ffffff', weight: 2 }}
       data={project.field}
     />
-  );
+  ) : null;
 }

--- a/frontend/src/components/maps/ProjectMarkers.tsx
+++ b/frontend/src/components/maps/ProjectMarkers.tsx
@@ -27,10 +27,7 @@ export default function ProjectMarkers({ projects }: ProjectMarkersProps) {
       if (projects.length > 0) {
         // add each project that is contained within current map to visible projects
         projects.forEach((project) => {
-          const projCoordinates = L.latLng([
-            project.field.properties.center_y,
-            project.field.properties.center_x,
-          ]);
+          const projCoordinates = L.latLng([project.centroid.y, project.centroid.x]);
           if (context.map.getBounds().contains(projCoordinates)) {
             visibleProjects.push(project.id);
           }
@@ -43,10 +40,7 @@ export default function ProjectMarkers({ projects }: ProjectMarkersProps) {
   useEffect(() => {
     if (projects.length > 0) {
       const projectMarkers = projects.map((project) => {
-        const marker = L.marker([
-          project.field.properties.center_y,
-          project.field.properties.center_x,
-        ]);
+        const marker = L.marker([project.centroid.y, project.centroid.x]);
         marker.on('click', () => {
           activeDataProductDispatch({ type: 'clear', payload: null });
           activeProjectDispatch({ type: 'set', payload: project });
@@ -70,11 +64,8 @@ export default function ProjectMarkers({ projects }: ProjectMarkersProps) {
         <MarkerClusterGroup>
           {projects.map((project) => (
             <Marker
-              key={project.field.properties.id}
-              position={[
-                project.field.properties.center_y,
-                project.field.properties.center_x,
-              ]}
+              key={project.id}
+              position={[project.centroid.y, project.centroid.x]}
               eventHandlers={{
                 click: () => {
                   activeDataProductDispatch({ type: 'clear', payload: null });

--- a/frontend/src/components/maps/ShareControls.tsx
+++ b/frontend/src/components/maps/ShareControls.tsx
@@ -80,7 +80,7 @@ export default function ShareControls({
             className="peer hidden [&:checked_+_label_svg]:block"
             checked={!accessOption}
             onChange={onChange}
-            disabled={!project.is_owner}
+            disabled={project.role !== 'owner'}
           />
           <label
             htmlFor="accessRestricted"
@@ -108,7 +108,7 @@ export default function ShareControls({
             </p>
           </label>
         </div>
-        {project.is_owner ? (
+        {project.role === 'owner' ? (
           <div className="mt-2">
             <input
               type="radio"
@@ -118,7 +118,7 @@ export default function ShareControls({
               className="peer hidden [&:checked_+_label_svg]:block"
               checked={accessOption}
               onChange={onChange}
-              disabled={!project.is_owner}
+              disabled={project.role !== 'owner'}
             />
             <label
               htmlFor="accessUnrestricted"

--- a/frontend/src/components/pages/projects/ProjectList.tsx
+++ b/frontend/src/components/pages/projects/ProjectList.tsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { useLoaderData, Link } from 'react-router-dom';
 
@@ -26,19 +26,26 @@ type FieldGeoJSONFeature = Omit<GeoJSON.Feature, 'properties'> & {
 
 export interface Project {
   id: string;
-  title: string;
+  centroid: {
+    x: number;
+    y: number;
+  };
   description: string;
   field: FieldGeoJSONFeature;
   flight_count: number;
+  is_owner: boolean;
+  location_id: string;
   most_recent_flight: string;
   owner_id: string;
-  is_owner: boolean;
+  role: string;
   team_id: string;
-  location_id: string;
+  title: string;
 }
 
 export async function loader() {
-  const response = await axios.get('/api/v1/projects');
+  const response: AxiosResponse<Project[]> = await axios.get(
+    `${import.meta.env.VITE_API_V1_STR}/projects`
+  );
   if (response) {
     return response.data;
   } else {

--- a/frontend/src/components/pages/teams/TeamCreate.tsx
+++ b/frontend/src/components/pages/teams/TeamCreate.tsx
@@ -17,10 +17,10 @@ import validationSchema from './validationSchema';
 
 export async function loader() {
   const response: AxiosResponse<Project[]> = await axios.get(
-    '/api/v1/projects?edit_only=True'
+    `${import.meta.env.VITE_API_V1_STR}/projects`
   );
   if (response) {
-    return response.data;
+    return response.data.filter(({ role }) => role === 'owner' || role === 'manager');
   } else {
     return [];
   }
@@ -31,6 +31,7 @@ export default function TeamCreate() {
   const projects = useLoaderData() as Project[];
   const navigate = useNavigate();
   const revalidator = useRevalidator();
+
   const [teamMembers, setTeamMembers] = useState<UserSearch[]>([]);
   const [searchResults, setSearchResults] = useState<UserSearch[]>([]);
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -48,7 +48,7 @@ import TeamDetail, {
 } from './components/pages/teams/TeamDetail';
 
 import { RootPublic, RootProtected } from './components/layout/Root';
-import { RequireAuth } from './AuthContext';
+import { RequireAdmin, RequireAuth } from './AuthContext';
 import ProjectLayout from './components/pages/projects/ProjectLayout';
 
 export const router = createBrowserRouter([
@@ -107,27 +107,6 @@ export const router = createBrowserRouter([
         element: <MapLayout />,
       },
       {
-        path: '/admin/dashboard',
-        element: <Dashboard />,
-        children: [
-          {
-            path: '/admin/dashboard',
-            element: <DashboardSiteStatistics />,
-            loader: dashboardSiteStatisticsLoader,
-          },
-          {
-            path: '/admin/dashboard/map',
-            element: <DashboardMap />,
-            loader: dashboardMapLoader,
-          },
-          {
-            path: '/admin/dashboard/users',
-            element: <DashboardUsers />,
-            loader: dashboardUsersLoader,
-          },
-        ],
-      },
-      {
         path: '/auth/profile',
         element: <Profile />,
       },
@@ -184,6 +163,38 @@ export const router = createBrowserRouter([
             path: '/projects',
             element: <ProjectList />,
             loader: projectListLoader,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    // admin pages
+    element: (
+      <RequireAdmin>
+        <RootProtected />
+      </RequireAdmin>
+    ),
+    errorElement: <ErrorPage />,
+    children: [
+      {
+        path: '/admin/dashboard',
+        element: <Dashboard />,
+        children: [
+          {
+            path: '/admin/dashboard',
+            element: <DashboardSiteStatistics />,
+            loader: dashboardSiteStatisticsLoader,
+          },
+          {
+            path: '/admin/dashboard/map',
+            element: <DashboardMap />,
+            loader: dashboardMapLoader,
+          },
+          {
+            path: '/admin/dashboard/users',
+            element: <DashboardUsers />,
+            loader: dashboardUsersLoader,
           },
         ],
       },


### PR DESCRIPTION
- Reduces amount of information returned by /projects endpoint
- Project boundary now fetched from server when a project is activated
- Revised Auth Context and routes to redirect non-superuser to login page if attempting to access dashboard
- Overall simplified the /projects crud