### PR TITLE
add option to set uvicorn "limit_max_requests" setting

### DIFF
--- a/backend/backend-start.sh
+++ b/backend/backend-start.sh
@@ -13,5 +13,5 @@ alembic upgrade head
 if [[ "$DEV_MODE" = true ]]; then
     uvicorn app.main:app --host 0.0.0.0 --port 5000  --reload
 else
-    uvicorn app.main:app --proxy-headers --workers ${UVICORN_WORKERS} --host 0.0.0.0 --port 5000
+    uvicorn app.main:app --proxy-headers --workers ${UVICORN_WORKERS} --host 0.0.0.0 --port 5000 --limit-max-requests ${LIMIT_MAX_REQUESTS}
 fi

--- a/backend/backend.dockerfile
+++ b/backend/backend.dockerfile
@@ -4,6 +4,7 @@ FROM python:3.11-slim as python-base
 # build args
 ARG INSTALL_DEV=false
 ARG NUM_OF_WORKERS=1
+ARG LIMIT_MAX_REQUESTS=10000
 
 # do not buffer log messages and do not write byte code .pyc
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -18,6 +19,9 @@ ENV CONDA_ENV_PATH=/opt/conda/envs/d2s
 
 # set number of workers for uvicorn process
 ENV UVICORN_WORKERS=$NUM_OF_WORKERS
+
+# limit max requests per process
+ENV LIMIT_MAX_REQUESTS=$LIMIT_MAX_REQUESTS
 
 # set path for celery beats schedule
 ENV CELERY_BEAT_SCHEDULE=/var/run/celery/celerybeat-schedule

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       dockerfile: backend.dockerfile
       args:
         NUM_OF_WORKERS: 1
+        LIMIT_MAX_REQUESTS: 10000
     image: d2s-api:latest
     platform: linux/x86_64
     volumes:


### PR DESCRIPTION
Defaults uvicorn "limit_max_requests" setting to 10000. Can be changed with build arg in docker-compose or environment variable.