### PR TITLE
reformat layer pane stats, remove dark mode classes

### DIFF
--- a/frontend/src/components/maps/LayerPane.tsx
+++ b/frontend/src/components/maps/LayerPane.tsx
@@ -85,7 +85,7 @@ function MapToolbar() {
           />
           <label
             htmlFor="scale-checkbox"
-            className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+            className="ms-2 text-sm font-medium text-gray-900"
             title="Increases tile resolution from 512x512 to 1024x1024"
           >
             Increase tile resolution
@@ -130,12 +130,29 @@ export function formatDate(datestring) {
 
 function RasterStats({ stats }: { stats: Band['stats'] }) {
   return (
-    <div className="grid grid-cols-4 gap-1.5">
-      <span>Mean: {stats.mean.toFixed(2)}</span>
-      <span>Min: {stats.minimum.toFixed(2)}</span>
-      <span>Max: {stats.maximum.toFixed(2)}</span>
-      <span>Std. Dev: {stats.stddev.toFixed(2)}</span>
-    </div>
+    <fieldset className="border border-solid border-slate-300 p-2">
+      <legend className="block text-sm text-gray-400 font-semibold pt-1 pb-1">
+        Stats
+      </legend>
+      <div className="flex flex-row flex-wrap justify-between gap-1.5">
+        <div className="flex flex-col">
+          <span className="font-semibold">Mean</span>
+          <span>{stats.mean.toFixed(2)}</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="font-semibold">Min</span>
+          <span>{stats.minimum.toFixed(2)}</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="font-semibold">Max</span>
+          <span>{stats.maximum.toFixed(2)}</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="font-semibold">Std. Dev</span>
+          <span>{stats.stddev.toFixed(2)}</span>
+        </div>
+      </div>
+    </fieldset>
   );
 }
 
@@ -370,13 +387,13 @@ export default function LayerPane({
                             <div className="grid grid-rows-2 text-slate-700 text-sm gap-1.5">
                               <div className="grid grid-cols-2 gap-4">
                                 <div>
-                                  <span className="text-sm text-slate-400 font-semibold">
+                                  <span className="text-sm text-gray-400 font-semibold">
                                     Platform:{' '}
                                   </span>
                                   {flight.platform.replace('_', ' ')}
                                 </div>
                                 <div>
-                                  <span className="text-sm text-slate-400 font-semibold">
+                                  <span className="text-sm text-gray-400 font-semibold">
                                     Sensor:
                                   </span>{' '}
                                   {flight.sensor}
@@ -384,7 +401,7 @@ export default function LayerPane({
                               </div>
                               <div className="grid grid-cols-2 gap-4">
                                 <div>
-                                  <span className="text-sm text-slate-400 font-semibold">
+                                  <span className="text-sm text-gray-400 font-semibold">
                                     Altitude (m):
                                   </span>{' '}
                                   {flight.altitude}
@@ -417,7 +434,7 @@ export default function LayerPane({
                               >
                                 <div className="text-slate-600 text-sm">
                                   <div
-                                    className="grid grid-flow-row auto-rows-max"
+                                    className="flex flex-col gap-1.5"
                                     onClick={() => {
                                       if (
                                         (dataProduct && !activeDataProduct) ||
@@ -445,12 +462,14 @@ export default function LayerPane({
                                       }
                                     }}
                                   >
-                                    <strong>
-                                      {getDataProductName(dataProduct.data_type)}
-                                    </strong>
+                                    <div>
+                                      <span className="font-bold">
+                                        {getDataProductName(dataProduct.data_type)}
+                                      </span>
+                                    </div>
                                     {dataProduct.data_type !== 'point_cloud' ? (
-                                      <fieldset className="border border-solid border-slate-300 p-3">
-                                        <legend className="block text-sm text-gray-400 font-bold pt-2 pb-1">
+                                      <fieldset className="border border-solid border-slate-300 p-2">
+                                        <legend className="block text-sm text-gray-400 font-semibold pt-1 pb-1">
                                           Band Info
                                         </legend>
                                         <div className="flex flex-row flex-wrap justify-start gap-1.5">
@@ -464,19 +483,15 @@ export default function LayerPane({
                                         </div>
                                       </fieldset>
                                     ) : null}
-                                    {dataProduct.data_type !== 'point_cloud' ? (
-                                      <div className="grid grid-flow-col auto-cols-max gap-1.5">
-                                        {dataProduct.stac_properties.raster.length ===
-                                        1 ? (
-                                          <RasterStats
-                                            stats={
-                                              dataProduct.stac_properties.raster[0]
-                                                .stats
-                                            }
-                                          />
-                                        ) : null}
-                                      </div>
-                                    ) : null}
+                                    {dataProduct.data_type !== 'point_cloud' &&
+                                      dataProduct.stac_properties.raster.length ===
+                                        1 && (
+                                        <RasterStats
+                                          stats={
+                                            dataProduct.stac_properties.raster[0].stats
+                                          }
+                                        />
+                                      )}
                                   </div>
                                   {activeDataProduct &&
                                   activeDataProduct.id === dataProduct.id &&

--- a/frontend/src/components/pages/admin/StatCard.tsx
+++ b/frontend/src/components/pages/admin/StatCard.tsx
@@ -20,9 +20,9 @@ export function StatStorageCard({
   return (
     <div className="flex flex-col rounded-lg bg-blue-50 px-4 py-8 text-center">
       <dt className="order-last text-lg font-medium text-gray-500">{title}</dt>
-      <div className="w-full h-4 mb-4 bg-gray-200 rounded-full dark:bg-gray-700">
+      <div className="w-full h-4 mb-4 bg-gray-200 rounded-full">
         <div
-          className="h-4 bg-blue-600 rounded-full dark:bg-blue-500"
+          className="h-4 bg-blue-600 rounded-full"
           style={{ width: `${Math.round((storage.used / storage.total) * 100)}%` }}
         ></div>
       </div>

--- a/frontend/src/components/pages/auth/RegistrationForm.tsx
+++ b/frontend/src/components/pages/auth/RegistrationForm.tsx
@@ -101,12 +101,12 @@ export default function RegistrationForm() {
             <input
               id="default-checkbox"
               type="checkbox"
-              className="w-4 h-4 text-slate-600 accent-slate-600 bg-gray-100 border-gray-300 rounded focus:ring-slate-500 dark:focus:ring-slate-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+              className="w-4 h-4 text-slate-600 accent-slate-600 bg-gray-100 border-gray-300 rounded focus:ring-slate-500 focus:ring-2"
               onChange={(e) => toggleShowPassword(e.target.checked)}
             />
             <label
               htmlFor="default-checkbox"
-              className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+              className="ms-2 text-sm font-medium text-gray-900"
             >
               Show password
             </label>

--- a/frontend/src/components/pages/projects/fieldCampaigns/FieldCampaignTable.tsx
+++ b/frontend/src/components/pages/projects/fieldCampaigns/FieldCampaignTable.tsx
@@ -43,7 +43,7 @@ function FieldTimepoints({
               <input
                 name={`treatment.${treatmentIdx}.measurement.${measurementIdx}.timepoint.${timepointIdx}`}
                 type="checkbox"
-                className="w-4 h-4 size-4 rounded text-accent2 bg-gray-100 border-gray-300 rounded focus:ring-slate-500 dark:focus:ring-slate-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                className="w-4 h-4 size-4 rounded text-accent2 bg-gray-100 border-gray-300 rounded focus:ring-slate-500 focus:ring-2"
                 onChange={(e) => {
                   if (e.target.checked) {
                     addSelectedTimepoint(

--- a/frontend/src/components/pages/projects/flights/dataProducts/ToolboxTools.tsx
+++ b/frontend/src/components/pages/projects/flights/dataProducts/ToolboxTools.tsx
@@ -99,7 +99,7 @@ const LidarTools = () => {
             <Field id="chm-checkbox" type="checkbox" name="chm" disabled />
             <label
               htmlFor="chm-checkbox"
-              className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+              className="ms-2 text-sm font-medium text-gray-900"
             >
               Canopy Height Model (CHM) <span className="italic">Coming soon</span>
             </label>

--- a/frontend/src/components/pages/teams/SearchUsers.tsx
+++ b/frontend/src/components/pages/teams/SearchUsers.tsx
@@ -167,7 +167,7 @@ function SearchUsersResults({
                           type="checkbox"
                           value={user.id}
                           checked={user.checked}
-                          className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                          className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2"
                           onChange={(e) => {
                             const updatedSearchResults = searchResults.map((user) => {
                               if (user.id === e.target.value)


### PR DESCRIPTION
- Makes DSM raster statistics more consistent with other similar elements in layer pane
- Contains them within fieldset and better handles overflow
- Removes dark mode tailwind classes