### PR TITLE
add link button for data management page to homepage flight card

### DIFF
--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -22,8 +22,9 @@ interface LinkButton extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   url: string;
 }
 
-interface LinkOutlineButton extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+interface LinkOutlineButton extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
+  target?: string;
   size?: string;
   url: string;
 }
@@ -84,17 +85,20 @@ const getButtonSizeClassNames = (size: string) =>
 
 export function LinkOutlineButton({
   children,
+  target = '_self',
   url,
   size = 'normal',
+  ...props
 }: LinkOutlineButton) {
   return (
-    <Link to={url}>
+    <Link to={url} target={target}>
       <button
         className={classNames(
           getButtonSizeClassNames(size),
           'w-full border-2 border-accent3 text-accent3 rounded-md py-2 px-4 w-full hover:bg-accent3 hover:text-white ease-in-out duration-300'
         )}
         type="button"
+        {...props}
       >
         {children}
       </button>

--- a/frontend/src/components/maps/LayerPane.tsx
+++ b/frontend/src/components/maps/LayerPane.tsx
@@ -10,7 +10,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 
-import { Button } from '../Buttons';
+import { Button, LinkOutlineButton } from '../Buttons';
 import { getDataProductName } from '../pages/projects/flights/dataProducts/DataProductsTable';
 import HintText from '../HintText';
 import { useMapContext } from './MapContext';
@@ -509,6 +509,16 @@ export default function LayerPane({
                                 </div>
                               </LayerCard>
                             ))}
+                            <div className="my-2">
+                              <LinkOutlineButton
+                                size="sm"
+                                target="_blank"
+                                title="Open data management page for this flight in a new tab"
+                                url={`/projects/${flight.project_id}/flights/${flight.id}/data`}
+                              >
+                                Manage Data
+                              </LinkOutlineButton>
+                            </div>
                           </details>
                         ) : null}
                       </LayerCard>


### PR DESCRIPTION
- New link button shown below a flight's data products on the home page
- Opens the flight's data management page in a new tab
- Only visible when the flight's data products are expanded