### PR TITLE
revision for flight moving endpoint

### DIFF
--- a/backend/app/api/api_v1/endpoints/flights.py
+++ b/backend/app/api/api_v1/endpoints/flights.py
@@ -93,14 +93,14 @@ def update_flight(
 
 
 @router.put(
-    "/{flight_id}/modify_project/{destination_project_id}",
+    "/{flight_id}/move_to_project/{destination_project_id}",
     response_model=schemas.Flight,
 )
 def update_flight_project(
     flight_id: UUID,
     destination_project_id: UUID,
     current_user: models.User = Depends(deps.get_current_approved_user),
-    flight: models.Flight = Depends(deps.can_read_write_flight),
+    flight: models.Flight = Depends(deps.can_read_write_delete_flight),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     # check if user has permission to read/write to destination project

--- a/backend/app/api/api_v1/endpoints/flights.py
+++ b/backend/app/api/api_v1/endpoints/flights.py
@@ -108,12 +108,10 @@ def update_flight_project(
         db, project_id=destination_project_id, member_id=current_user.id
     )
     # raise exception if not project member or member without owner/manager role
-    if not project_membership or (
-        project_membership.role != "owner" and project_membership.role != "manager"
-    ):
+    if not project_membership or project_membership.role != "owner":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Must be an owner or manager of destination project",
+            detail="Must be an owner of destination project",
         )
 
     # lock flight record if no active jobs, raise exception if active jobs

--- a/backend/app/tests/api/api_v1/test_flights.py
+++ b/backend/app/tests/api/api_v1/test_flights.py
@@ -496,7 +496,7 @@ def test_update_flight_project_with_manager_role_for_both_projects(
         db, project=src_project, flight=flight, skip_job=True
     )
     # create destination project add current user as manager (read/write)
-    dst_project = create_project(db, owner_id=current_user.id)
+    dst_project = create_project(db)
     project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
     crud.project_member.create_with_project(
         db,
@@ -586,26 +586,13 @@ def test_update_flight_project_with_read_only_set_on_flight(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
     # create source project with a flight and add current user as manager (read/write)
-    src_project = create_project(db)
-    flight = create_flight(db, altitude=50, project_id=src_project.id)
     current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
-    crud.project_member.create_with_project(
-        db,
-        obj_in=project_member_in,
-        project_id=src_project.id,
-    )
+    src_project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, altitude=50, project_id=src_project.id)
     # add data product to flight
     data_product = SampleDataProduct(db, project=src_project, flight=flight)
     # create destination project add current user as manager (read/write)
-    dst_project = create_project(db)
-    current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
-    crud.project_member.create_with_project(
-        db,
-        obj_in=project_member_in,
-        project_id=dst_project.id,
-    )
+    dst_project = create_project(db, owner_id=current_user.id)
     # set flight to "read_only"
     with db as session:
         statement = update(Flight).values(read_only=True).where(Flight.id == flight.id)

--- a/backend/app/tests/api/api_v1/test_flights.py
+++ b/backend/app/tests/api/api_v1/test_flights.py
@@ -439,35 +439,22 @@ def test_update_flight_with_non_project_member(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_update_flight_project_with_read_write_access_to_both_projects(
+def test_update_flight_project_with_ownership_role_for_both_projects(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
-    # create source project with a flight and add current user as manager (read/write)
-    src_project = create_project(db)
-    flight = create_flight(db, altitude=50, project_id=src_project.id)
+    # create source project with a flight and add current user as owner (read/write/del)
     current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
-    crud.project_member.create_with_project(
-        db,
-        obj_in=project_member_in,
-        project_id=src_project.id,
-    )
+    src_project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, altitude=50, project_id=src_project.id)
     # add data product to flight
     data_product = SampleDataProduct(
         db, project=src_project, flight=flight, skip_job=True
     )
-    # create destination project add current user as manager (read/write)
-    dst_project = create_project(db)
-    current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
-    crud.project_member.create_with_project(
-        db,
-        obj_in=project_member_in,
-        project_id=dst_project.id,
-    )
+    # create destination project add current user as owner (read/write/del)
+    dst_project = create_project(db, owner_id=current_user.id)
     # request to move flight from source project to destination project
     response = client.put(
-        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/modify_project/{dst_project.id}",
+        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/move_to_project/{dst_project.id}",
     )
     assert response.status_code == status.HTTP_200_OK
     response_data = response.json()
@@ -491,23 +478,26 @@ def test_update_flight_project_with_read_write_access_to_both_projects(
     assert updated_data_product.filepath == new_static_location
 
 
-def test_update_flight_project_with_read_write_access_to_src_project_and_read_only_access_to_dst_project(
+def test_update_flight_project_with_manager_role_for_both_projects(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
     # create source project with a flight and add current user as manager (read/write)
+    current_user = get_current_user(db, normal_user_access_token)
     src_project = create_project(db)
     flight = create_flight(db, altitude=50, project_id=src_project.id)
-    current_user = get_current_user(db, normal_user_access_token)
     project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
     crud.project_member.create_with_project(
         db,
         obj_in=project_member_in,
         project_id=src_project.id,
     )
-    # create destination project add current user as viewer (read only)
-    dst_project = create_project(db)
-    current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="viewer")
+    # add data product to flight
+    data_product = SampleDataProduct(
+        db, project=src_project, flight=flight, skip_job=True
+    )
+    # create destination project add current user as manager (read/write)
+    dst_project = create_project(db, owner_id=current_user.id)
+    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
     crud.project_member.create_with_project(
         db,
         obj_in=project_member_in,
@@ -515,19 +505,63 @@ def test_update_flight_project_with_read_write_access_to_src_project_and_read_on
     )
     # request to move flight from source project to destination project
     response = client.put(
-        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/modify_project/{dst_project.id}",
+        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/move_to_project/{dst_project.id}",
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_update_flight_project_with_read_only_access_to_src_project_and_read_write_access_to_dst_project(
+def test_update_flight_project_with_owner_role_for_src_project_and_manager_role_for_dst_project(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
-    # create source project with a flight and add current user as viewer (read only)
+    # create source project with a flight and add current user as owner (read/write/del)
+    current_user = get_current_user(db, normal_user_access_token)
+    src_project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, altitude=50, project_id=src_project.id)
+    # create destination project add current user as manager (read/write)
+    dst_project = create_project(db)
+    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
+    crud.project_member.create_with_project(
+        db,
+        obj_in=project_member_in,
+        project_id=dst_project.id,
+    )
+    # request to move flight from source project to destination project
+    response = client.put(
+        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/move_to_project/{dst_project.id}",
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_update_flight_project_with_manager_role_for_src_project_and_owner_role_for_dst_project(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    # create source project with a flight and add current user as manager (read/write)
+    current_user = get_current_user(db, normal_user_access_token)
     src_project = create_project(db)
     flight = create_flight(db, altitude=50, project_id=src_project.id)
+    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
+    crud.project_member.create_with_project(
+        db,
+        obj_in=project_member_in,
+        project_id=src_project.id,
+    )
+    # create destination project add current user as owner (read/write/del)
+    dst_project = create_project(db, owner_id=current_user.id)
+    # request to move flight from source project to destination project
+    response = client.put(
+        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/move_to_project/{dst_project.id}",
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_update_flight_project_with_manager_role_for_both_src_and_dst_projects(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    # create source project with a flight and add current user as manager (read/write)
     current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="viewer")
+    src_project = create_project(db)
+    flight = create_flight(db, altitude=50, project_id=src_project.id)
+    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
     crud.project_member.create_with_project(
         db,
         obj_in=project_member_in,
@@ -535,7 +569,6 @@ def test_update_flight_project_with_read_only_access_to_src_project_and_read_wri
     )
     # create destination project add current user as manager (read/write)
     dst_project = create_project(db)
-    current_user = get_current_user(db, normal_user_access_token)
     project_member_in = ProjectMemberCreate(member_id=current_user.id, role="manager")
     crud.project_member.create_with_project(
         db,
@@ -544,36 +577,7 @@ def test_update_flight_project_with_read_only_access_to_src_project_and_read_wri
     )
     # request to move flight from source project to destination project
     response = client.put(
-        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/modify_project/{dst_project.id}",
-    )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-def test_update_flight_project_with_read_only_access_to_src_and_dst_projects(
-    client: TestClient, db: Session, normal_user_access_token: str
-) -> None:
-    # create source project with a flight and add current user as viewer (read only)
-    src_project = create_project(db)
-    flight = create_flight(db, altitude=50, project_id=src_project.id)
-    current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="viewer")
-    crud.project_member.create_with_project(
-        db,
-        obj_in=project_member_in,
-        project_id=src_project.id,
-    )
-    # create destination project add current user as viewer (read only)
-    dst_project = create_project(db)
-    current_user = get_current_user(db, normal_user_access_token)
-    project_member_in = ProjectMemberCreate(member_id=current_user.id, role="viewer")
-    crud.project_member.create_with_project(
-        db,
-        obj_in=project_member_in,
-        project_id=dst_project.id,
-    )
-    # request to move flight from source project to destination project
-    response = client.put(
-        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/modify_project/{dst_project.id}",
+        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/move_to_project/{dst_project.id}",
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -609,7 +613,7 @@ def test_update_flight_project_with_read_only_set_on_flight(
         session.commit()
     # request to move flight from source project to destination project
     response = client.put(
-        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/modify_project/{dst_project.id}",
+        f"{settings.API_V1_STR}/projects/{src_project.id}/flights/{flight.id}/move_to_project/{dst_project.id}",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 

--- a/frontend/src/components/pages/projects/ProjectFlights.tsx
+++ b/frontend/src/components/pages/projects/ProjectFlights.tsx
@@ -13,6 +13,7 @@ import TableCardRadioInput from '../../TableCardRadioInput';
 import { useProjectContext } from './ProjectContext';
 
 import { getUnique, sorter } from '../../utils';
+import MoveFlightModal from './flights/MoveFlightModal';
 
 function getFlightsDisplayModeFromLS(): 'table' | 'carousel' {
   const flightsDisplayMode = localStorage.getItem('flightsDisplayMode');
@@ -153,6 +154,18 @@ export default function ProjectFlights() {
                               label: 'Edit',
                               url: `/projects/${project.id}/flights/${flight.id}/edit`,
                             };
+                            const moveAction = {
+                              key: `action-move-${flight.id}`,
+                              type: 'component',
+                              component: (
+                                <MoveFlightModal
+                                  flightId={flight.id}
+                                  srcProjectId={flight.project_id}
+                                  tableView={true}
+                                />
+                              ),
+                              label: 'Move',
+                            };
                             const deleteAction = {
                               key: `action-delete-${flight.id}`,
                               type: 'component',
@@ -161,9 +174,11 @@ export default function ProjectFlights() {
                               ),
                               label: 'Delete',
                             };
-                            if (projectRole === 'owner')
-                              return [editAction, deleteAction];
-                            return [editAction];
+                            if (projectRole === 'owner') {
+                              return [editAction, moveAction, deleteAction];
+                            } else {
+                              return [editAction];
+                            }
                           })
                     }
                   />

--- a/frontend/src/components/pages/projects/flights/FlightCarousel/FlightCard.tsx
+++ b/frontend/src/components/pages/projects/flights/FlightCarousel/FlightCard.tsx
@@ -9,6 +9,7 @@ import { Flight } from '../../Project';
 import { isGeoTIFF } from '../DataProducts/DataProductsTable';
 import { useProjectContext } from '../../ProjectContext';
 import FlightDeleteModal from '../FlightDeleteModal';
+import MoveFlightModal from '../MoveFlightModal';
 
 export default function FlightCard({ flight }: { flight: Flight }) {
   const [invalidPreviews, setInvalidPreviews] = useState<string[]>([]);
@@ -62,9 +63,15 @@ export default function FlightCard({ flight }: { flight: Flight }) {
               <span className="block text-lg">Sensor: {flight.sensor}</span>
               <HintText>On: {flight.acquisition_date}</HintText>
             </div>
-            {projectRole === 'owner' ? (
-              <FlightDeleteModal flight={flight} iconOnly={true} />
-            ) : null}
+            {projectRole === 'owner' && (
+              <div className="flex gap-4">
+                <MoveFlightModal
+                  flightId={flight.id}
+                  srcProjectId={flight.project_id}
+                />
+                <FlightDeleteModal flight={flight} iconOnly={true} />
+              </div>
+            )}
           </div>
           {/* action buttons */}
           <div className="flex items-center justify-between gap-2">

--- a/frontend/src/components/pages/projects/flights/MoveFlightModal.tsx
+++ b/frontend/src/components/pages/projects/flights/MoveFlightModal.tsx
@@ -1,0 +1,146 @@
+import axios, { AxiosResponse, isAxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+import Select from 'react-select';
+import { useRevalidator } from 'react-router-dom';
+import { FolderIcon } from '@heroicons/react/24/outline';
+
+import { AlertBar, Status } from '../../../Alert';
+import { Flight, Project } from '../Project';
+import Modal from '../../../Modal';
+import { Button } from '../../../Buttons';
+
+type ProjectOption = {
+  label: string;
+  value: string;
+};
+
+export default function MoveFlightModal({
+  flightId,
+  srcProjectId,
+  tableView,
+}: {
+  flightId: string;
+  srcProjectId: string;
+  tableView?: boolean;
+}) {
+  const [dstProjectId, setDstProjectId] = useState('');
+  const [projectOptions, setProjectOptions] = useState<ProjectOption[]>([]);
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<Status | null>(null);
+
+  const revalidator = useRevalidator();
+
+  useEffect(() => {
+    setStatus(null);
+  }, [open]);
+
+  useEffect(() => {
+    async function getProjects() {
+      const response: AxiosResponse<Project[]> = await axios.get(
+        `${import.meta.env.VITE_API_V1_STR}/projects`
+      );
+      if (response) {
+        const ownedProjects = response.data
+          .filter(({ id, role }) => role === 'owner' && id !== srcProjectId)
+          .map((project) => ({ label: project.title, value: project.id }));
+        setDstProjectId(ownedProjects.length > 0 ? ownedProjects[0].value : '');
+        setProjectOptions(ownedProjects);
+      } else {
+        return [];
+      }
+    }
+    getProjects();
+  }, []);
+
+  async function moveProject() {
+    try {
+      const response: AxiosResponse<Flight> = await axios.put(
+        `${
+          import.meta.env.VITE_API_V1_STR
+        }/projects/${srcProjectId}/flights/${flightId}/move_to_project/${dstProjectId}`
+      );
+      if (response.status === 200) {
+        revalidator.revalidate();
+        setOpen(false);
+      } else {
+        setStatus({ type: 'error', msg: 'Unable to move flight at this time' });
+      }
+    } catch (err) {
+      if (isAxiosError(err) && err.response && err.response.data.detail) {
+        if (typeof err.response.data.detail === 'string') {
+          setStatus({ type: 'error', msg: err.response.data.detail });
+        } else if (typeof (err.response.status === 422)) {
+          setStatus({ type: 'error', msg: err.response.data.detail[0].msg });
+        } else {
+          setStatus({ type: 'error', msg: 'Unable to move flight at this time' });
+        }
+      } else {
+        setStatus({ type: 'error', msg: 'Unable to move flight at this time' });
+      }
+    }
+  }
+
+  return (
+    <div>
+      {tableView ? (
+        <div
+          className="flex items-center text-sky-600 text-sm cursor-pointer"
+          onClick={() => setOpen(true)}
+        >
+          <div className="relative rounded-full accent3 p-1 focus:outline-none">
+            <FolderIcon className="w-4 h-4" />
+          </div>
+          <span>Move</span>
+        </div>
+      ) : (
+        <button onClick={() => setOpen(true)}>
+          <FolderIcon className="h-5 w-5" />
+        </button>
+      )}
+      <Modal open={open} setOpen={setOpen}>
+        <div className="m-4 h-64 flex flex-col justify-between">
+          <div>
+            <span className="text-gray-600 font-semibold">
+              Select the project you are moving the flight to:
+            </span>
+            <Select
+              styles={{
+                input: (base) => ({
+                  ...base,
+                  'input:focus': {
+                    boxShadow: 'none',
+                  },
+                }),
+              }}
+              theme={(theme) => ({
+                ...theme,
+                colors: {
+                  ...theme.colors,
+                  primary: '#3d5a80',
+                  primary25: '#e2e8f0',
+                },
+              })}
+              isSearchable
+              defaultValue={projectOptions[0]}
+              maxMenuHeight={120}
+              options={projectOptions}
+              onChange={(dstProject) => {
+                if (dstProject && dstProject.value) {
+                  setDstProjectId(dstProject.value);
+                }
+              }}
+            />
+          </div>
+          <Button
+            type="button"
+            disabled={dstProjectId.length === 0}
+            onClick={() => moveProject()}
+          >
+            Update
+          </Button>
+          {status && <AlertBar alertType={status.type}>{status.msg}</AlertBar>}
+        </div>
+      </Modal>
+    </div>
+  );
+}


### PR DESCRIPTION
- Revises name of endpoint for moving a flight from project A to project B
- User must be owner of both project A and project B to move the flight
- Tests revised for new access rules
- Add move button to flight cards and flight table records