### PR TITLE
add opacity slider for cogs on homepage, automatically add hillshade

### DIFF
--- a/frontend/src/components/InputFields.tsx
+++ b/frontend/src/components/InputFields.tsx
@@ -13,6 +13,7 @@ import { getIcon } from './utils';
 const styles = {
   textField:
     'focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none border border-gray-400 rounded py-1 px-4 block w-full appearance-none',
+  rangeField: 'w-full m-0 accent-accent2',
   selectField:
     'focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none border border-gray-400 rounded py-1 px-4 block w-full',
   disabled:
@@ -38,6 +39,13 @@ interface NumberField extends InputField {
   max?: number;
   min?: number;
   step?: number;
+}
+
+interface RangeField extends InputField {
+  max?: number;
+  min?: number;
+  step?: number;
+  list?: string;
 }
 
 interface TextField extends InputField {
@@ -107,6 +115,44 @@ export function NumberField({
   );
 }
 
+export function RangeField({
+  altLabel = false,
+  disabled = false,
+  label,
+  max = undefined,
+  min = undefined,
+  name,
+  required = true,
+  showError = true,
+  step = 1,
+  list,
+  onChange = undefined,
+}: RangeField) {
+  const { handleChange } = useFormikContext();
+
+  return (
+    <InputField
+      altLabel={altLabel}
+      label={label}
+      name={name}
+      required={required}
+      showError={showError}
+    >
+      <Field
+        className={disabled ? styles.disabled : styles.rangeField}
+        id={name}
+        name={name}
+        type="range"
+        disabled={disabled}
+        min={min}
+        max={max}
+        step={step}
+        list={list}
+        onChange={onChange ? onChange : handleChange}
+      />
+    </InputField>
+  );
+}
 export function TextField({
   altLabel = false,
   disabled = false,

--- a/frontend/src/components/maps/DataProductTileLayer.tsx
+++ b/frontend/src/components/maps/DataProductTileLayer.tsx
@@ -101,6 +101,13 @@ export function getDataProductTileLayer(
         zIndex={500}
         maxNativeZoom={24}
         maxZoom={26}
+        opacity={
+          symbology && symbology.opacity
+            ? symbology.opacity / 100
+            : savedStyle.opacity
+            ? savedStyle.opacity
+            : 1
+        }
       />
     );
   } else {
@@ -170,6 +177,13 @@ export function getDataProductTileLayer(
         zIndex={500}
         maxNativeZoom={24}
         maxZoom={26}
+        opacity={
+          symbology && symbology.opacity
+            ? symbology.opacity / 100
+            : savedStyle.opacity
+            ? savedStyle.opacity
+            : 1
+        }
       />
     );
   }
@@ -193,5 +207,33 @@ export default function DataProductTileLayer({
     symbology ? symbology : symbologySettings,
     tileLayerRef,
     tileScale
+  );
+}
+
+export function HillshadeTileLayer({
+  dataProduct,
+}: {
+  dataProduct: DataProduct | null;
+}) {
+  if (!dataProduct) return null;
+
+  if (!isSingleBand(dataProduct)) {
+    return null;
+  }
+
+  const max = dataProduct.stac_properties.raster[0].stats.maximum;
+  const min = dataProduct.stac_properties.raster[0].stats.minimum;
+
+  return (
+    <TileLayer
+      url={getTileURL(dataProduct.url.replace(window.origin, ''), undefined, [
+        min,
+        max,
+      ])}
+      zIndex={100}
+      maxNativeZoom={24}
+      maxZoom={26}
+      opacity={1}
+    />
   );
 }

--- a/frontend/src/components/maps/Map.tsx
+++ b/frontend/src/components/maps/Map.tsx
@@ -7,7 +7,7 @@ import { ZoomControl } from 'react-leaflet/ZoomControl';
 
 import ColorBarControl from './ColorBarControl';
 import CompareTool, { CompareToolAlert, getFlightsWithGTIFF } from './CompareTool';
-import DataProductTileLayer from './DataProductTileLayer';
+import DataProductTileLayer, { HillshadeTileLayer } from './DataProductTileLayer';
 import MapLayersControl from './MapLayersControl';
 import ProjectBoundary from './ProjectBoundary';
 import ProjectLayersControl from './ProjectLayersControl';
@@ -19,7 +19,7 @@ import icon from './icons/marker-icon.png';
 import shadow from './icons/marker-shadow.png';
 import PotreeViewer from './PotreeViewer';
 
-import { isSingleBand } from './utils';
+import { getHillshade, isSingleBand } from './utils';
 
 export default function Map({ layerPaneHidden }: { layerPaneHidden: boolean }) {
   const { activeDataProduct, activeMapTool, activeProject, flights, projects } =
@@ -53,6 +53,14 @@ export default function Map({ layerPaneHidden }: { layerPaneHidden: boolean }) {
         {!activeProject && <ProjectMarkers projects={projects ? projects : []} />}
         {activeProject && <ProjectBoundary projectId={activeProject.id} />}
         {activeProject && <ProjectLayersControl project={activeProject} />}
+
+        {activeProject &&
+        flights &&
+        activeDataProduct &&
+        activeDataProduct.data_type !== 'point_cloud' &&
+        activeMapTool === 'map' ? (
+          <HillshadeTileLayer dataProduct={getHillshade(activeDataProduct, flights)} />
+        ) : null}
 
         {activeProject &&
         flights &&

--- a/frontend/src/components/maps/MapContext.tsx
+++ b/frontend/src/components/maps/MapContext.tsx
@@ -31,6 +31,7 @@ const defaultSymbologySettings = {
   mode: 'minMax',
   userMin: 0,
   userMax: 255,
+  opacity: 100,
 };
 
 function activeDataProductReducer(
@@ -162,7 +163,10 @@ function symbologySettingsReducer(
 ) {
   switch (action.type) {
     case 'update': {
-      return action.payload;
+      return {
+        ...action.payload,
+        opacity: action.payload.opacity ? action.payload.opacity : 100,
+      };
     }
     default:
       return state;

--- a/frontend/src/components/maps/Maps.d.ts
+++ b/frontend/src/components/maps/Maps.d.ts
@@ -9,6 +9,7 @@ export interface DSMSymbologySettings {
   mode: string;
   userMin: number;
   userMax: number;
+  opacity: number;
 }
 
 export interface OrthoSymbologySettings {
@@ -35,6 +36,7 @@ export interface OrthoSymbologySettings {
     userMin: number;
     userMax: number;
   };
+  opacity: number;
 }
 
 export type MapTool = 'map' | 'compare' | 'timeline';

--- a/frontend/src/components/maps/SymbologyControls.tsx
+++ b/frontend/src/components/maps/SymbologyControls.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { cmaps } from './cmaps';
 import { Button } from '../Buttons';
 import { DataProduct } from '../pages/projects/Project';
-import { NumberField, SelectField } from '../InputFields';
+import { NumberField, RangeField, SelectField } from '../InputFields';
 import { useMapContext } from './MapContext';
 import {
   DSMSymbologySettings,
@@ -48,6 +48,33 @@ const saveSymbology = async (
     console.error(err);
   }
 };
+
+function OpacitySlider({
+  onChange,
+}: {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <div>
+      <RangeField
+        name="opacity"
+        label="Opacity"
+        min={0}
+        max={100}
+        step={1}
+        list="opacity-markers"
+        onChange={onChange}
+      />
+      <datalist className="flex justify-between w-full" id="opacity-markers">
+        <option className="w-8 p-0 text-left" value="0" label="0%"></option>
+        <option className="w-8 p-0 text-center" value="25" label="25%"></option>
+        <option className="w-8 p-0 text-center" value="50" label="50%"></option>
+        <option className="w-8 p-0 text-center" value="75" label="75%"></option>
+        <option className="w-8 p-0 text-right" value="100" label="100%"></option>
+      </datalist>
+    </div>
+  );
+}
 
 function ShareDataProduct({
   dataProduct,
@@ -111,6 +138,13 @@ function DSMSymbologyControls() {
                   onChange={(e) => {
                     setFieldValue('colorRamp', e.target.value);
                     setFieldTouched('colorRamp', true);
+                    submitForm();
+                  }}
+                />
+                <OpacitySlider
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    setFieldValue('opacity', e.target.value);
+                    setFieldTouched('opacity', true);
                     submitForm();
                   }}
                 />
@@ -263,7 +297,7 @@ function OrthoSymbologyControls() {
           });
         }}
       >
-        {({ values }) => (
+        {({ values, setFieldTouched, setFieldValue, submitForm }) => (
           <Form>
             <fieldset className="border border-solid border-slate-300 p-3">
               <legend className="block text-sm text-gray-400 font-bold pt-2 pb-1">
@@ -396,6 +430,13 @@ function OrthoSymbologyControls() {
                   </div>
                 </div>
               </div>
+              <OpacitySlider
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setFieldValue('opacity', e.target.value);
+                  setFieldTouched('opacity', true);
+                  submitForm();
+                }}
+              />
               <div className="w-full flex justify-end mt-4">
                 <Button type="submit" size="xs">
                   Apply Changes

--- a/frontend/src/components/maps/utils.tsx
+++ b/frontend/src/components/maps/utils.tsx
@@ -1,4 +1,4 @@
-import { DataProduct } from '../pages/projects/Project';
+import { DataProduct, Flight } from '../pages/projects/Project';
 import { SymbologySettings } from './Maps';
 
 function getDefaultStyle(dataProduct: DataProduct): SymbologySettings {
@@ -12,6 +12,7 @@ function getDefaultStyle(dataProduct: DataProduct): SymbologySettings {
       mode: 'minMax',
       userMin: stats.minimum,
       userMax: stats.maximum,
+      opacity: 100,
     };
   } else {
     const raster = dataProduct.stac_properties.raster;
@@ -39,7 +40,29 @@ function getDefaultStyle(dataProduct: DataProduct): SymbologySettings {
         userMin: raster[2].stats.minimum,
         userMax: raster[2].stats.maximum,
       },
+      opacity: 100,
     };
+  }
+}
+
+function getHillshade(
+  activeDataProduct: DataProduct,
+  flights: Flight[]
+): DataProduct | null {
+  const dataProductName = activeDataProduct.data_type.toLowerCase();
+  const filteredFlights = flights.filter(
+    ({ id }) => id === activeDataProduct.flight_id
+  );
+  if (filteredFlights.length > 0 && filteredFlights[0].data_products.length > 1) {
+    const dataProducts = filteredFlights[0].data_products;
+    const dataProductHillshade = dataProducts.filter(
+      (dataProduct) =>
+        dataProduct.data_type.toLowerCase().split(' hs')[0] === dataProductName &&
+        dataProduct.data_type.toLowerCase().split(' hs').length > 1
+    );
+    return dataProductHillshade.length > 0 ? dataProductHillshade[0] : null;
+  } else {
+    return null;
   }
 }
 
@@ -52,4 +75,4 @@ function isSingleBand(dataProduct: DataProduct): boolean {
   return dataProduct.stac_properties && dataProduct.stac_properties.raster.length === 1;
 }
 
-export { getDefaultStyle, isSingleBand };
+export { getDefaultStyle, getHillshade, isSingleBand };

--- a/frontend/src/components/pages/projects/Project.d.ts
+++ b/frontend/src/components/pages/projects/Project.d.ts
@@ -1,6 +1,7 @@
 import { Feature, FeatureCollection, Geometry } from 'geojson';
 
 import { FieldCampaignInitialValues } from './fieldCampaigns/FieldCampaign';
+import { SymbologySettings } from '../../maps/Maps';
 
 // geojson object representing project field boundary
 export type FieldGeoJSONFeature = Omit<Feature, 'properties'> & {


### PR DESCRIPTION
- opacity slider available for all geotiffs on homepage
- opacity automatically updates when slider changes (no need to "apply symbology"
- opacity setting can be saved
- when a data product is activated, a data product in the same flight that has the same data type name plus " HS" will be added beneath the active data product
  - for example, if a flight has a "DTM" data product and a "DTM HS" data product, when "DTM" is selected the "DTM HS" will also be displayed as a layer below "DTM"
  - adjust the opacity of "DTM" to make the "DTM HS" hillshade layer visible