### PR TITLE
convert numpy nans to string "nan" before storing in db

### DIFF
--- a/backend/app/utils/STACProperties.py
+++ b/backend/app/utils/STACProperties.py
@@ -1,5 +1,6 @@
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import NotRequired, TypedDict, Union
 
+import numpy as np
 from pydantic import BaseModel, TypeAdapter
 
 
@@ -24,11 +25,20 @@ class Stats(TypedDict):
     stddev: float
 
 
-class STACRasterProperties(TypedDict):
+class STACRasterPropertiesBase(TypedDict):
     data_type: str
     stats: Stats
-    nodata: NotRequired[int | float | None]
-    unit: NotRequired[str | None]
+    nodata: NotRequired[Union[int, float, str, None]]
+    unit: NotRequired[Union[str, None]]
+
+
+class STACRasterProperties(STACRasterPropertiesBase):
+    @staticmethod
+    def validate_nodata(properties: "STACRasterProperties") -> "STACRasterProperties":
+        # convert numpy nan to string before storing in database
+        if "nodata" in properties and np.isnan(properties["nodata"]):
+            properties["nodata"] = "nan"
+        return properties
 
 
 class STACEOProperties(TypedDict):


### PR DESCRIPTION
- celery task for processing uploaded raster data failed when the stac properties nodata value was set to np.nan
- np.nan passed current stac validation because it is considered a float type, but it is an invalid type for postgres
- expanded stac validation to allow strings for nodata and added static method to convert np.nan to string 'nan' when it appears