### PR TITLE
add qualitative colormaps to color maps list

### DIFF
--- a/frontend/src/components/maps/cmaps.tsx
+++ b/frontend/src/components/maps/cmaps.tsx
@@ -87,4 +87,21 @@ export const cmaps: CMaps = [
       'gist_ncar',
     ],
   ],
+  [
+    'Qualitative colormaps',
+    [
+      'pastel1',
+      'pastel2',
+      'paired',
+      'accent',
+      'dark2',
+      'set1',
+      'set2',
+      'set3',
+      'tab10',
+      'tab20',
+      'tab20b',
+      'tab20c',
+    ],
+  ],
 ];


### PR DESCRIPTION
- add matplotlib qualitative colormaps as color ramp options - [Qualitative colormaps preview](https://matplotlib.org/stable/_images/sphx_glr_colormaps_006_2_00x.png)