### PR TITLE
add varnish container for caching map tiles

### DIFF
--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -149,6 +149,11 @@ async def get_map_tiles_for_data_product(
         upload_dir=upload_dir,
         user_id=current_user.id,
     )
+    if not data_product:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unable to find data product",
+        )
     async with httpx.AsyncClient() as client:
         response = await client.get(
             f"http://varnish/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@{scale}x"

--- a/default.vcl
+++ b/default.vcl
@@ -4,11 +4,11 @@ import std;
 
 backend default {
     .host = "titiler";
-    .port = "8000";
+    .port = "8888";
     .max_connections = 100;
     .probe = {
         .request =
-            "HEAD / HTTP/1.1"
+            "GET / HTTP/1.1"
             "Host: titiler"
             "Connection: close"
             "User-Agent: Varnish Health Probe";

--- a/default.vcl
+++ b/default.vcl
@@ -1,0 +1,109 @@
+vcl 4.1;
+
+import std;
+
+backend default {
+    .host = "titiler";
+    .port = "8000";
+    .max_connections = 100;
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: titiler"
+            "Connection: close"
+            "User-Agent: Varnish Health Probe";
+        .interval  = 10s;
+        .timeout   = 5s;
+        .window    = 5;
+        .threshold = 3;
+    }
+    .connect_timeout        = 5s;
+    .first_byte_timeout     = 90s;
+    .between_bytes_timeout  = 2s;
+}
+
+# only allow purge from local server
+acl purge {
+    "localhost";
+    "127.0.0.1";
+    "::1";
+}
+
+sub vcl_recv {
+    # strip off port numbers from object hash
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+
+    # strip off trailing /?
+    set req.url = regsub(req.url, "\?$", "");
+
+    # allow purging from local server
+    if (req.method == "PURGE") {
+        if (!client.ip ~ purge) {
+            return (synth(405, client.ip + " is not allowed to send PURGE requests."));
+        }
+        return (purge);
+    }
+
+    # limit HTTP methods to GET and HEAD requests
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (synth(405, "Method Not Allowed"));
+    }
+
+    # only cache GET and HEAD requests
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+    }
+
+    # indicate if https or http used in request with X-Forwarded-Proto header
+    if (!req.http.X-Forwarded-Proto) {
+        if(std.port(server.ip) == 443 || std.port(server.ip) == 8443) {
+            set req.http.X-Forwarded-Proto = "https";
+        } else {
+            set req.http.X-Forwarded-Proto = "http";
+        }
+    }
+
+    # strip off cookie and auth headers before caching new request
+    if (req.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|ogg|ogm|opus|otf|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
+        # store access token temporarily before unsetting it
+        if (req.http.Cookie ~ "access_token") {
+            set req.http.x-temp-access-token = regsub(req.http.Cookie, ".*access_token=([^;]+);?.*", "\1");
+        }
+        unset req.http.Cookie;
+        # Only keep the following if VCL handling is complete
+        return(hash);
+    }
+
+    # asynchronously revalidate object while serving stale object if not past 10 seconds
+    if (std.healthy(req.backend_hint)) {
+        set req.grace = 10s;
+    }
+}
+
+sub vcl_synth {
+    if (resp.status == 405) {
+        set resp.http.Allow = "GET, HEAD";
+        set resp.body = "Method not allowed";
+        return (deliver);
+    }
+}
+
+sub vcl_hash {
+    hash_data(req.http.X-Forwarded-Proto);
+}
+
+sub vcl_backend_response {
+    if (bereq.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|ogg|ogm|opus|otf|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
+        unset beresp.http.Set-Cookie;
+        set beresp.ttl = 1d;
+    }
+
+    set beresp.grace = 6h;
+}
+
+sub vcl_backend_fetch {
+    # Add temp access token to request before forwarding to backend
+    if (bereq.http.x-temp-access-token) {
+        set bereq.http.Cookie = "access_token=" + bereq.http.x-temp-access-token + "; " + bereq.http.Cookie;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -211,12 +211,24 @@ services:
     security_opt:
       - no-new-privileges=true
 
+  varnish:
+    image: varnish:latest
+    volumes:
+      - ./default.vcl:/etc/varnish/default.vcl:ro
+    ports:
+      - "8888:80"
+    tmpfs:
+      - /var/lib/varnish/varnishd:exec
+    environment:
+      - VARNISH_SIZE=2G
+    command: "-p default_keep=300"
+    depends_on:
+      - titiler
+
   titiler:
     image: ghcr.io/developmentseed/titiler:latest
     volumes:
       - user-data:/static
-    ports:
-      - ":8888"
     environment:
       # uvicorn/gunicorn settings
       - PORT=8888

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,15 +138,27 @@ services:
     depends_on:
       - frontend
 
+  varnish:
+    image: varnish:latest
+    volumes:
+      - ./default.vcl:/etc/varnish/default.vcl:ro
+    ports:
+      - "8888:80"
+    tmpfs:
+      - /var/lib/varnish/varnishd:exec
+    environment:
+      - VARNISH_SIZE=2G
+    command: "-p default_keep=300"
+    depends_on:
+      - titiler
+
   titiler:
     image: ghcr.io/developmentseed/titiler:latest
     volumes:
       - user-data:/static
-    ports:
-      - ":8888"
     environment:
       # uvicorn/gunicorn settings
-      - PORT=8888
+      - PORT=8000
       - WORKERS_PER_CORE=0.5
       - WEB_CONCURRENCY=2
       - ACCESS_LOG=/var/log/titiler-access.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       - user-data:/static
     environment:
       # uvicorn/gunicorn settings
-      - PORT=8000
+      - PORT=8888
       - WORKERS_PER_CORE=0.5
       - WEB_CONCURRENCY=2
       - ACCESS_LOG=/var/log/titiler-access.log

--- a/frontend/src/components/maps/CompareTool.tsx
+++ b/frontend/src/components/maps/CompareTool.tsx
@@ -6,8 +6,10 @@ import 'leaflet-side-by-side';
 import CompareToolSelector from './CompareToolSelector';
 import { getDataProductTileLayer } from './DataProductTileLayer';
 import { Flight } from '../pages/projects/Project';
+import { useMapContext } from './MapContext';
 
 import { isSingleBand } from './utils';
+import { Project } from '../pages/projects/ProjectList';
 
 interface SideBySideControl extends L.Control {
   _leftLayer: L.TileLayer;
@@ -33,13 +35,14 @@ export const getFlightsWithGTIFF = (flights: Flight[]): Flight[] => {
 const getLayerFromProps = (
   flights: Flight[],
   flightID: string,
-  dataProductID: string
+  dataProductID: string,
+  project: Project
 ) => {
   const dataProduct = flights
     .filter(({ id }) => id === flightID)[0]
     .data_products.filter(({ id }) => id === dataProductID)[0];
 
-  const tileLayer = getDataProductTileLayer(dataProduct);
+  const tileLayer = getDataProductTileLayer(project, dataProduct);
   return L.tileLayer(tileLayer.props.url, {
     className: 'compare-tl',
     maxZoom: tileLayer.props.maxZoom,
@@ -93,6 +96,7 @@ export default function CompareTool({
   flights: Flight[];
   layerPaneHidden: boolean;
 }) {
+  const { activeProject } = useMapContext();
   const map = useMap();
   const [dividerPosition, setDividerPosition] = useState<{
     divider: number;
@@ -126,12 +130,12 @@ export default function CompareTool({
     }
 
     // must have two data products to compare
-    if (!dataProduct1 || !dataProduct2) return;
+    if (!dataProduct1 || !dataProduct2 || !activeProject) return;
 
     // create tile layers for left/right data products
     // TODO: needs improvement
-    const layer1 = getLayerFromProps(flights, flight1, dataProduct1);
-    const layer2 = getLayerFromProps(flights, flight2, dataProduct2);
+    const layer1 = getLayerFromProps(flights, flight1, dataProduct1, activeProject);
+    const layer2 = getLayerFromProps(flights, flight2, dataProduct2, activeProject);
 
     // add layers to map if not already present on it
     if (!map.hasLayer(layer1)) layer1.addTo(map);

--- a/nginx/templates/dev/default.conf.template
+++ b/nginx/templates/dev/default.conf.template
@@ -6,12 +6,16 @@ upstream backend {
     server  backend:5000;
 }
 
-upstream titiler {
-    server titiler:8888;
-}
-
 upstream tusd {
     server tusd:8080;
+}
+
+upstream titiler {
+    server titiler:8000;
+}
+
+upstream varnish {
+    server varnish:8888;
 }
 
 server {
@@ -129,11 +133,5 @@ server {
         proxy_set_header Host $host;
 
         proxy_pass http://backend;
-    }
-
-    location /cog {
-        proxy_set_header Host $host;
-
-        proxy_pass http://titiler/cog;
     }
 }

--- a/nginx/templates/dev/default.conf.template
+++ b/nginx/templates/dev/default.conf.template
@@ -10,14 +10,6 @@ upstream tusd {
     server tusd:8080;
 }
 
-upstream titiler {
-    server titiler:8000;
-}
-
-upstream varnish {
-    server varnish:8888;
-}
-
 server {
     listen 80;
     server_name localhost;

--- a/nginx/templates/prod/default.conf.template
+++ b/nginx/templates/prod/default.conf.template
@@ -6,10 +6,6 @@ upstream backend {
     server  backend:5000;
 }
 
-upstream titiler {
-    server titiler:8888;
-}
-
 upstream tusd {
     server tusd:8080;
 }
@@ -109,11 +105,5 @@ server {
         proxy_set_header Host $host;
 
         proxy_pass http://backend;
-    }
-
-    location /cog {
-        proxy_set_header Host $host;
-
-        proxy_pass http://titiler/cog;
     }
 }


### PR DESCRIPTION
- move request for map tiles from frontend to backend
- use varnish container as reverse proxy in front of titiler container
  - pass through first time requests for a map tile to titiler for tile generation
  - respond with cached tiles for repeated requests
  - respond with same cached tiles when multiple users request tiles from same data product (permission checked in /maptile endpoint before requesting tile from varnish/titiler)
 