### PR TITLE
revise "harvest date" and "planting date" project labels

### DIFF
--- a/frontend/src/components/pages/projects/ProjectDetailEditForm.tsx
+++ b/frontend/src/components/pages/projects/ProjectDetailEditForm.tsx
@@ -98,7 +98,7 @@ export default function ProjectDetailEditForm({
           </div>
           <Table>
             <TableHead
-              columns={['Planting Date', 'Harvest Date', 'Team', 'Location']}
+              columns={['Start of project', 'End of project', 'Team', 'Location']}
             />
             <TableBody
               rows={[

--- a/frontend/src/components/pages/projects/ProjectForm.tsx
+++ b/frontend/src/components/pages/projects/ProjectForm.tsx
@@ -109,13 +109,13 @@ export default function ProjectForm({
                 <div className="grid grid-cols-2 gap-4">
                   <TextField
                     type="date"
-                    label="Planting date"
+                    label="Start of project"
                     name="plantingDate"
                     required={false}
                   />
                   <TextField
                     type="date"
-                    label="Harvest date"
+                    label="End of project"
                     name="harvestDate"
                     required={false}
                   />


### PR DESCRIPTION
- Replace "Harvest date" label with "End of project"
- Replace "Planting date" label with "Start of project"
- Internal db columns and other references remain plantingDate and harvestDate