### PR TITLE
add bigtiff flag to output profile for exg and ndvi data products

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
 from app.api import deps, mail
+from app.api.utils import str_to_bool
 from app.core import security
 from app.core.config import settings
 
@@ -27,30 +28,6 @@ from app.core.config import settings
 router = APIRouter()
 
 logger = logging.getLogger("__name__")
-
-
-def str_to_bool(value: str | bool) -> bool:
-    """Converts a boolean str into a boolean object.
-
-    Args:
-        value (str | bool): String value to convert to bool or bool value.
-
-    Raises:
-        ValueError: Raised if string value does not match a boolean value.
-
-    Returns:
-        bool: Returns True if string value matched one of the values in the "True" set.
-    """
-    # If already a bool object, return it
-    if isinstance(value, bool):
-        return value
-
-    if value.lower() in {"1", "true"}:
-        return True
-    elif value.lower() in {"0", "false"}:
-        return False
-    else:
-        raise ValueError(f"Invalid boolean string: {value}")
 
 
 @router.post("/access-token")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Optional
 from uuid import UUID
 
@@ -15,7 +16,7 @@ from app.core import security
 from app.core.config import settings
 from app.core.mail import fm
 from app.db.session import SessionLocal
-from app.api.utils import is_valid_api_key
+from app.api.utils import is_valid_api_key, str_to_bool
 
 logger = logging.getLogger("__name__")
 
@@ -81,7 +82,9 @@ def send_email(
     message = MessageSchema(
         subject=subject, recipients=recipients, body=body, subtype=MessageType.html
     )
-    if settings.MAIL_ENABLED:
+    if settings.MAIL_ENABLED and not str_to_bool(
+        os.environ.get("RUNNING_TESTS", False)
+    ):
         background_tasks.add_task(fm.send_message, message)
 
 

--- a/backend/app/api/utils.py
+++ b/backend/app/api/utils.py
@@ -133,3 +133,27 @@ def get_data_product_dir(project_id: str, flight_id: str, data_product_id: str) 
         os.makedirs(data_product_dir)
 
     return data_product_dir
+
+
+def str_to_bool(value: str | bool) -> bool:
+    """Converts a boolean str into a boolean object.
+
+    Args:
+        value (str | bool): String value to convert to bool or bool value.
+
+    Raises:
+        ValueError: Raised if string value does not match a boolean value.
+
+    Returns:
+        bool: Returns True if string value matched one of the values in the "True" set.
+    """
+    # If already a bool object, return it
+    if isinstance(value, bool):
+        return value
+
+    if value.lower() in {"1", "true"}:
+        return True
+    elif value.lower() in {"0", "false"}:
+        return False
+    else:
+        raise ValueError(f"Invalid boolean string: {value}")

--- a/backend/app/utils/toolbox/exg.py
+++ b/backend/app/utils/toolbox/exg.py
@@ -29,7 +29,9 @@ def run(in_raster: str, out_raster: str, params: dict) -> str:
 
         # update source raster profile to single band and float32
         profile = src.profile
-        profile.update(dtype=rasterio.float32, count=1, compress="deflate")
+        profile.update(
+            dtype=rasterio.float32, count=1, compress="deflate", BIGTIFF="YES"
+        )
 
         # use block windows to calculate exg and write to new file
         with rasterio.open(out_raster, "w", **profile) as dst:

--- a/backend/app/utils/toolbox/ndvi.py
+++ b/backend/app/utils/toolbox/ndvi.py
@@ -29,7 +29,9 @@ def run(in_raster: str, out_raster: str, params: dict) -> str:
 
         # update source raster profile to single band and float32
         profile = src.profile
-        profile.update(dtype=rasterio.float32, count=1, compress="deflate")
+        profile.update(
+            dtype=rasterio.float32, count=1, compress="deflate", BIGTIFF="YES"
+        )
 
         # use block windows to calculate exg and write to new file
         with rasterio.open(out_raster, "w", **profile) as dst:


### PR DESCRIPTION
- exg and ndvi tools were failing when output raster exceeding 4GB
- added BIGTIFF=YES to profile for output rasters to allow size to go beyond 4GB

misc:
- sending emails suppressed while testing