### PR TITLE
simplify geometry for map layer preview maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# VS Code
+.vscode/
+
 !backend/potree/

--- a/backend/app/utils/MapMaker.py
+++ b/backend/app/utils/MapMaker.py
@@ -1,6 +1,10 @@
 import os
+from typing import List
 
+import geopandas as gpd
+import numpy as np
 from geojson_pydantic import Feature
+from shapely.geometry import MultiLineString, MultiPolygon, MultiPoint
 from staticmap import CircleMarker, Line, Polygon, StaticMap
 
 from app.core.config import settings
@@ -37,48 +41,39 @@ class MapMaker:
             headers=headers,
         )
 
+        # Standardize geometry type for features
+        simplified_features_gdf: gpd.GeoDataFrame = simplify_geometry(
+            gpd.GeoDataFrame.from_features(self.features, crs="EPSG:4326")
+        )
+
+        # Get list of Features from Geopandas DataFrame
+        simplified_features: List[Feature] = [
+            Feature(**feature)
+            for feature in simplified_features_gdf.to_geo_dict()["features"]
+        ]
+
         # Iterate over each feature and add to map
-        for feature in self.features:
-            geom_type = feature.geometry.type.lower()
-            if geom_type == "point" or geom_type == "multipoint":
-                self.map.add_marker(create_point(feature.geometry.coordinates))
-            elif geom_type == "linestring" or geom_type == "multilinestring":
-                if (
-                    len(feature.geometry.coordinates) == 1
-                    and len(feature.geometry.coordinates[0]) > 1
-                ):
-                    self.map.add_line(create_line(feature.geometry.coordinates[0]))
-                else:
+        for feature in simplified_features:
+            if feature and hasattr(feature, "geometry") and feature.geometry:
+                geom_type = feature.geometry.type.lower()
+                if geom_type == "point" or geom_type == "multipoint":
+                    self.map.add_marker(create_point(feature.geometry.coordinates))
+                elif geom_type == "linestring" or geom_type == "multilinestring":
                     self.map.add_line(create_line(feature.geometry.coordinates))
-            elif geom_type == "polygon" or geom_type == "multipolygon":
-                if (
-                    len(feature.geometry.coordinates) == 1
-                    and len(feature.geometry.coordinates[0]) == 1
-                ):
-                    self.map.add_polygon(
-                        create_polygon(feature.geometry.coordinates[0][0])
-                    )
-                elif (
-                    len(feature.geometry.coordinates) >= 1
-                    and len(feature.geometry.coordinates[0]) > 1
-                ):
+                elif geom_type == "polygon" or geom_type == "multipolygon":
                     self.map.add_polygon(
                         create_polygon(feature.geometry.coordinates[0])
                     )
                 else:
-                    self.map.add_polygon(create_polygon(feature.geometry.coordinates))
-            else:
-                raise ValueError(f"Unknown geometry type: {geom_type}")
+                    raise ValueError(f"Unknown geometry type: {geom_type}")
 
     def save(self, outname: str = "preview_map.png") -> None:
-        zoom_level = 16
-
-        image = self.map.render(zoom_level)
+        image = self.map.render()
         image.save(os.path.join(self.outpath, outname))
         self.preview_img = os.path.join(self.outpath, outname)
 
 
-def create_polygon(coords: list[list[float, float]]) -> Polygon:
+def create_polygon(coords: List[List[float]]) -> Polygon:
     fill_color = "#fcd34d66"  # 40% opacity
     outline_color = "#fcd34d"
     simplify = False
@@ -90,12 +85,74 @@ def create_polygon(coords: list[list[float, float]]) -> Polygon:
     )
 
 
-def create_point(coord: list[float, float]) -> CircleMarker:
+def create_point(coord: List[float]) -> CircleMarker:
     color = "#fcd34d"
     return CircleMarker(coord=coord, color=color, width=4)
 
 
-def create_line(coords: list[list[float, float]]) -> Line:
+def create_line(coords: List[List[float]]) -> Line:
     color = "#fcd34d"
     simplify = False
     return Line(coords=coords, color=color, width=2, simplify=simplify)
+
+
+def standardize_geometry(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Converts all geometries in a GeoDataFrame to their Multi- counterparts.
+
+    Args:
+      gdf (gpd.GeoDataFrame): GeoDataFrame with any geometry types.
+
+    Returns:
+      gpd.GeoDataFrame: GeoDataFrame with all geometries as MultiPoint,
+      MultiLineString, or MultiPolygon.
+    """
+    gdf.geometry = gpd.GeoSeries(
+        [
+            (
+                MultiPoint([geom])
+                if geom.geom_type == "Point"
+                else (
+                    MultiLineString([geom])
+                    if geom.geom_type == "LineString"
+                    else MultiPolygon([geom]) if geom.geom_type == "Polygon" else geom
+                )
+            )
+            for geom in gdf.geometry
+        ]
+    )
+    return gdf
+
+
+def simplify_geometry(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Converts Multi geometries in a GeoDataFrame to their single-part counterparts. If
+    Multi geometry, line with longest length returned or polygon with largest area
+    returned. First point is returned in event of multipoint.
+
+    Args:
+      gdf (gpd.GeoDataFrame): A GeoDataFrame with any geometry types.
+
+    Returns:
+      gpd.GeoDataFrame: GeoDataFrame with MultiPoint, MultiLineString, or MultiPolygon
+      geometries simplified to Point, LineString, or Polygon where possible.
+    """
+    gdf.geometry = gpd.GeoSeries(
+        [
+            (
+                geom[0]
+                if geom.geom_type == "MultiPoint" and len(geom.geoms) > 0
+                else (
+                    max(geom.geoms, key=lambda x: x.length)
+                    if geom.geom_type == "MultiLineString"
+                    else (
+                        max(geom.geoms, key=lambda x: x.area)
+                        if geom.geom_type == "MultiPolygon"
+                        else geom
+                    )
+                )
+            )
+            for geom in gdf.geometry
+        ]
+    )
+    return gdf

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -3,5 +3,11 @@ plugins = pydantic.mypy, sqlalchemy.ext.mypy.plugin
 disallow_untyped_defs = True
 [mypy-celery.*]
 ignore_missing_imports = True
+[mypy-geopandas.*]
+ignore_missing_imports = True
 [mypy-rasterio.*]
+ignore_missing_imports = True
+[mypy-shapely.*]
+ignore_missing_imports = True
+[mypy-staticmap.*]
 ignore_missing_imports = True

--- a/frontend/src/components/pages/projects/mapLayers/MapLayerFileInput.tsx
+++ b/frontend/src/components/pages/projects/mapLayers/MapLayerFileInput.tsx
@@ -224,7 +224,7 @@ export default function MapLayerFileInput({
           {uploadFile && <span className="text-gray-600">{uploadFile.name}</span>}
           <label
             htmlFor="uploadMapLayer"
-            className="px-4 py-2 text-white font-semibold rounded-md bg-blue-500/90 hover:bg-blue-500"
+            className="px-4 py-2 text-white font-semibold rounded-md bg-blue-500/90 hover:bg-blue-500 cursor-pointer"
           >
             Browse
           </label>


### PR DESCRIPTION
Update addresses issue with the vector data preview image generation function not being able to handle a mix of similar geometry types (e.g., LineString and MultiLineString, Polygon and MultiPolygon, etc.):
- when creating the preview image for a map layer
  - only use first point if multipoint feature
  - only use line with largest length if multilinestring feature
  - only use polygon with largest area if multipolygon feature
- drop static zoom level and allow staticmap library to pick an optimal zoom level

Misc
- "Browse" button in map layer upload input now has `cursor-pointer` class name
- Ignore .vscode directory in root folder