### PR TITLE
move project start date and end date validation to pydantic schema

### DIFF
--- a/backend/app/api/api_v1/endpoints/projects.py
+++ b/backend/app/api/api_v1/endpoints/projects.py
@@ -18,22 +18,6 @@ logger = logging.getLogger("__name__")
 router = APIRouter()
 
 
-def valid_end_date(start_date: Optional[date], end_date: Optional[date]) -> bool:
-    """Returns False if the end date is before the start date and returns True
-    if the end date is on and after the start date.
-
-    Args:
-        start_date (Optional[date]): Start date of project or None.
-        end_date (Optional[date]): End date of project or None.
-
-    Returns:
-        bool: True if valid end date and False if not.
-    """
-    if start_date and end_date and end_date <= start_date:
-        return False
-    return True
-
-
 @router.post("", response_model=schemas.Project, status_code=status.HTTP_201_CREATED)
 def create_project(
     project_in: schemas.ProjectCreate,
@@ -46,19 +30,6 @@ def create_project(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Demo accounts cannot create projects",
         )
-
-    if not valid_end_date(project_in.planting_date, project_in.harvest_date):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=[
-                {
-                    "loc": ["body", "harvest_date"],
-                    "msg": "End date must be after start date.",
-                    "type": "value_error",
-                }
-            ],
-        )
-
     try:
         project = crud.project.create_with_owner(
             db,
@@ -132,21 +103,31 @@ def update_project(
     db: Session = Depends(deps.get_db),
 ) -> Any:
     """Update project if current user is project owner or member."""
+    if project_in.planting_date and project.harvest_date:
+        if project.harvest_date < project_in.planting_date:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "loc": ["body", "harvest_date"],
+                        "msg": "End date must be after start date.",
+                        "type": "value_error",
+                    }
+                ],
+            )
 
-    if not valid_end_date(
-        project_in.planting_date or project.planting_date,
-        project_in.harvest_date or project.harvest_date,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=[
-                {
-                    "loc": ["body", "harvest_date"],
-                    "msg": "End date must be after start date.",
-                    "type": "value_error",
-                }
-            ],
-        )
+    if project_in.harvest_date and project.planting_date:
+        if project_in.harvest_date < project.planting_date:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "loc": ["body", "harvest_date"],
+                        "msg": "End date must be after start date.",
+                        "type": "value_error",
+                    }
+                ],
+            )
 
     project = crud.project.update_project(
         db,

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -2,7 +2,8 @@ from datetime import date, datetime
 from typing import Dict, Literal, Optional
 
 from geojson_pydantic import Feature, Polygon
-from pydantic import BaseModel, Field, UUID4
+from pydantic import BaseModel, Field, field_validator, ValidationInfo, UUID4
+
 from app.schemas.location import LocationCreate
 
 
@@ -15,6 +16,20 @@ class ProjectBase(BaseModel):
     # relationships
     location_id: Optional[UUID4] = None
     team_id: Optional[UUID4] = None
+
+    @field_validator("harvest_date")
+    @classmethod
+    def end_date_after_or_on_start_date(
+        cls, v: Optional[date], info: ValidationInfo
+    ) -> Optional[date]:
+        if (
+            "planting_date" in info.data
+            and v is not None
+            and info.data["planting_date"] is not None
+            and v < info.data["planting_date"]
+        ):
+            raise ValueError("harvest_date cannot be before planting_date")
+        return v
 
 
 # properties to save in DB on creation

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -203,7 +203,7 @@ def test_create_project_date_validation(
         }
     )
     response = client.post(API_URL, json=data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_201_CREATED
 
     # valid - harvest_date after planting date
     data = jsonable_encoder(
@@ -602,6 +602,14 @@ def test_update_project_date_validation(
         db, owner_id=current_user.id, planting_date=None, harvest_date=None
     )
     update_data = jsonable_encoder({"planting_date": date(2024, 6, 2)})
+    response = client.put(f"{API_URL}/{project.id}", json=update_data)
+    assert response.status_code == status.HTTP_200_OK
+
+    # valid - update harvest date to same date as planting date
+    project = create_project(
+        db, owner_id=current_user.id, planting_date=date(2024, 6, 1), harvest_date=None
+    )
+    update_data = jsonable_encoder({"harvest_date": date(2024, 6, 1)})
     response = client.put(f"{API_URL}/{project.id}", json=update_data)
     assert response.status_code == status.HTTP_200_OK
 

--- a/frontend/src/components/pages/projects/ProjectForm.tsx
+++ b/frontend/src/components/pages/projects/ProjectForm.tsx
@@ -67,11 +67,14 @@ export default function ProjectForm({
               ...(values.harvestDate && { harvest_date: values.harvestDate }),
             };
             const response = await axios.post('/api/v1/projects', data);
-            if (response) {
+            if (response && response.status === 201) {
               navigate('/projects');
               setModalOpen(false);
             } else {
-              // do something
+              setStatus({
+                type: 'error',
+                msg: 'Unexpected error occurred. Unable to create project.',
+              });
             }
           } catch (err) {
             if (isAxiosError(err) && err.response && err.response.data.detail) {
@@ -82,7 +85,7 @@ export default function ProjectForm({
             } else {
               setStatus({
                 type: 'error',
-                msg: 'Unexpected error occurred. Unable to save project.',
+                msg: 'Unexpected error occurred. Unable to create project.',
               });
             }
           }

--- a/frontend/src/components/pages/projects/validationSchema.tsx
+++ b/frontend/src/components/pages/projects/validationSchema.tsx
@@ -8,7 +8,10 @@ const baseProjectRules = Yup.object({
     .max(300, 'Must be 300 characters or less')
     .required('Must enter project description'),
   plantingDate: Yup.date(),
-  harvestDate: Yup.date().min(Yup.ref('plantingDate'), 'Must be after planting date'),
+  harvestDate: Yup.date().min(
+    Yup.ref('plantingDate'),
+    'Must be after start of project'
+  ),
   teamID: Yup.string(),
 });
 


### PR DESCRIPTION
- project creation form was failing when start date and end date were the same due to an issue with the date validation
- revised and moved data validation to project schema
- update endpoint required additional validation since the schema will only validate if both a start date and harvest date are included in the update body