### PR TITLE
cleanup datetime imports

### DIFF
--- a/backend/app/api/api_v1/endpoints/tusd.py
+++ b/backend/app/api/api_v1/endpoints/tusd.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -106,7 +106,7 @@ def handle_tusd_http_hooks(
         if existing_upload:
             # update record to indicate upload has finished
             upload_update_in = UploadUpdate(
-                is_uploading=False, last_updated_at=datetime.utcnow()
+                is_uploading=False, last_updated_at=datetime.now(timezone.utc)
             )
             crud.upload.update(db, db_obj=existing_upload, obj_in=upload_update_in)
         else:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -2,16 +2,15 @@ import base64
 import hmac
 import hashlib
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast, Dict, Optional, Tuple
-from urllib.parse import urlencode, quote_plus
 
 from fastapi import Request, status
 from fastapi.exceptions import HTTPException
 from fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
 from fastapi.security import OAuth2
 from fastapi.security.utils import get_authorization_scheme_param
-from jose import jws, jwt
+from jose import jwt
 from passlib.context import CryptContext
 from passlib.hash import sha256_crypt
 
@@ -30,7 +29,7 @@ ALGORITHM = "HS256"
 def create_access_token(subject: str | Any, expire: datetime | None = None) -> str:
     """Create JWT access token with expiration defined in settings."""
     if not expire:
-        expire = datetime.utcnow() + timedelta(
+        expire = datetime.now(timezone.utc) + timedelta(
             minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
         )
     to_encode = {"exp": expire, "sub": str(subject)}

--- a/backend/app/tests/api/api_v1/test_api_keys.py
+++ b/backend/app/tests/api/api_v1/test_api_keys.py
@@ -1,5 +1,4 @@
-import requests
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from fastapi import HTTPException, status
@@ -11,9 +10,7 @@ from app.api.deps import get_current_user
 from app.core.config import settings
 from app.schemas.user import UserUpdate
 from app.tests.utils.data_product import SampleDataProduct
-from app.tests.utils.project import create_project
 from app.tests.utils.project_member import create_project_member
-from app.tests.utils.flight import create_flight
 from app.tests.utils.user import create_user
 from app.utils.ProtectedStaticFiles import verify_api_key_static_file_access
 
@@ -143,7 +140,9 @@ def test_access_authorized_data_product_with_deactivated_api_key(
 
     # verify with deactivated api key
     assert not deactivated_api_key.is_active
-    assert deactivated_api_key.deactivated_at < datetime.utcnow()
+    assert deactivated_api_key.deactivated_at.replace(
+        tzinfo=timezone.utc
+    ) < datetime.now(timezone.utc)
     assert not verify_api_key_static_file_access(
         data_product=data_product.obj, api_key=current_user_api_key.api_key, db=db
     )

--- a/backend/app/tests/api/api_v1/test_data_products.py
+++ b/backend/app/tests/api/api_v1/test_data_products.py
@@ -1,12 +1,8 @@
-import json
-import os
-import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
 from geojson_pydantic import Feature, FeatureCollection
 from fastapi import status
-from fastapi.encoders import jsonable_encoder
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -556,7 +552,7 @@ def test_deactivate_data_product_with_owner_role(
         deactivated_data_product.get("deactivated_at"), "%Y-%m-%dT%H:%M:%S.%f"
     )
     assert isinstance(deactivated_at, datetime)
-    assert deactivated_at < datetime.utcnow()
+    assert deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc)
 
 
 def test_deactivate_data_product_with_manager_role(

--- a/backend/app/tests/api/api_v1/test_flights.py
+++ b/backend/app/tests/api/api_v1/test_flights.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from random import randint
 
 from fastapi import status
@@ -624,7 +624,7 @@ def test_deactivate_flight_with_project_owner_role(
     except Exception:
         raise
     assert isinstance(deactivated_at, datetime)
-    assert deactivated_at < datetime.utcnow()
+    assert deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc)
 
 
 def test_deactivate_flight_with_project_manager_role(

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
@@ -702,7 +702,7 @@ def test_deactivate_project_with_owner_role(
     except Exception:
         raise
     assert isinstance(deactivated_at, datetime)
-    assert deactivated_at < datetime.utcnow()
+    assert deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc)
 
 
 def test_deactivate_project_with_manager_role(

--- a/backend/app/tests/api/api_v1/test_raw_data.py
+++ b/backend/app/tests/api/api_v1/test_raw_data.py
@@ -1,6 +1,5 @@
 import os
-import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -9,7 +8,6 @@ from sqlalchemy.orm import Session
 from app import crud
 from app.api.deps import get_current_user
 from app.core.config import settings
-from app.schemas.file_permission import FilePermissionUpdate
 from app.tests.utils.project import create_project
 from app.tests.utils.project_member import create_project_member
 from app.tests.utils.flight import create_flight
@@ -234,7 +232,7 @@ def test_deactivate_raw_data_with_owner_role(
         deactivated_raw_data.get("deactivated_at"), "%Y-%m-%dT%H:%M:%S.%f"
     )
     assert isinstance(deactivated_at, datetime)
-    assert deactivated_at < datetime.utcnow()
+    assert deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc)
 
 
 def test_deactivate_raw_data_with_manager_role(

--- a/backend/app/tests/crud/test_crud_raw_data.py
+++ b/backend/app/tests/crud/test_crud_raw_data.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -61,4 +61,6 @@ def test_deactivate_raw_data(db: Session) -> None:
     assert raw_data3.id == raw_data.obj.id
     assert raw_data3.is_active is False
     assert isinstance(raw_data3.deactivated_at, datetime)
-    assert raw_data3.deactivated_at < datetime.utcnow()
+    assert raw_data3.deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(
+        timezone.utc
+    )

--- a/backend/app/tests/crud/test_data_product.py
+++ b/backend/app/tests/crud/test_data_product.py
@@ -1,11 +1,10 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
 from app import crud
 from app.core.config import settings
-from app.schemas.data_product import DataProductUpdate
 from app.schemas.file_permission import FilePermissionUpdate
 from app.tests.utils.flight import create_flight
 from app.tests.utils.data_product import SampleDataProduct, test_stac_props_dsm
@@ -149,4 +148,6 @@ def test_deactivate_data_product(db: Session) -> None:
     assert data_product3.id == data_product.obj.id
     assert data_product3.is_active is False
     assert isinstance(data_product3.deactivated_at, datetime)
-    assert data_product3.deactivated_at < datetime.utcnow()
+    assert data_product3.deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(
+        timezone.utc
+    )

--- a/backend/app/tests/crud/test_flight.py
+++ b/backend/app/tests/crud/test_flight.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 import geopandas as gpd
 from geojson_pydantic import FeatureCollection
@@ -12,7 +12,6 @@ from app.models.flight import PLATFORMS, SENSORS
 from app.models.vector_layer import VectorLayer
 from app.schemas.data_product import DataProductCreate
 from app.schemas.flight import FlightUpdate
-from app.schemas.vector_layer import VectorLayerCreate
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.flight import create_flight
 from app.tests.utils.job import create_job
@@ -190,7 +189,9 @@ def test_deactivate_flight(db: Session) -> None:
     assert flight3.id == flight.id
     assert flight3.is_active is False
     assert isinstance(flight3.deactivated_at, datetime)
-    assert flight3.deactivated_at < datetime.utcnow()
+    assert flight3.deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(
+        timezone.utc
+    )
 
 
 def test_deactivate_flight_deactivates_data_products(db: Session) -> None:

--- a/backend/app/tests/crud/test_project.py
+++ b/backend/app/tests/crud/test_project.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -6,7 +6,6 @@ from app import crud, schemas
 from app.schemas.project import ProjectUpdate
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.flight import create_flight
-from app.tests.utils.location import create_location
 from app.tests.utils.team import create_team
 from app.tests.utils.team_member import create_team_member
 from app.tests.utils.project import (
@@ -270,7 +269,9 @@ def test_deactivate_project(db: Session) -> None:
     assert project3.id == project.id
     assert project3.is_active is False
     assert isinstance(project3.deactivated_at, datetime)
-    assert project3.deactivated_at < datetime.utcnow()
+    assert project3.deactivated_at.replace(tzinfo=timezone.utc) < datetime.now(
+        timezone.utc
+    )
 
 
 def test_deactivate_project_deactivates_flights_and_data_products(db: Session) -> None:

--- a/backend/app/tests/crud/test_upload.py
+++ b/backend/app/tests/crud/test_upload.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
 from app import crud
-from app.schemas import UploadCreate, UploadUpdate
+from app.schemas import UploadUpdate
 from app.tests.utils.user import create_user
 
 EXAMPLE_UPLOAD_ID = "7c26cadbb9ab184c35678d180cfa8ad4"
@@ -18,7 +18,9 @@ def test_create_upload(db: Session) -> None:
     assert upload.upload_id == EXAMPLE_UPLOAD_ID
     assert upload.user_id == user.id
     assert upload.is_uploading is True
-    assert upload.last_updated_at < datetime.utcnow()
+    assert upload.last_updated_at.replace(tzinfo=timezone.utc) < datetime.now(
+        timezone.utc
+    )
 
 
 def test_update_upload(db: Session) -> None:
@@ -26,10 +28,10 @@ def test_update_upload(db: Session) -> None:
     upload = crud.upload.create_with_user(
         db, upload_id=EXAMPLE_UPLOAD_ID, user_id=user.id
     )
-    ts = datetime.utcnow()
+    ts = datetime.now(timezone.utc)
     upload_update_in = UploadUpdate(is_uploading=False, last_updated_at=ts)
     upload_updated = crud.upload.update(db, db_obj=upload, obj_in=upload_update_in)
     assert upload_updated
     assert upload_updated.upload_id == upload.upload_id
     assert upload_updated.is_uploading is False
-    assert upload_updated.last_updated_at == ts
+    assert upload_updated.last_updated_at.replace(tzinfo=timezone.utc) == ts

--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -39,19 +39,19 @@ dependencies:
   - black=24.10.0=py311h38be061_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=hef167b5_0
-  - boto3=1.35.49=pyhd8ed1ab_0
-  - botocore=1.35.49=pyge310_1234567_0
+  - boto3=1.35.51=pyhd8ed1ab_0
+  - botocore=1.35.51=pyge310_1234567_0
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=hb9d3cd8_2
   - brotli-bin=1.1.0=hb9d3cd8_2
   - brotli-python=1.1.0=py311hfdbb021_2
   - bzip2=1.0.8=h4bc722e_7
   - c-ares=1.34.2=heb4867d_0
-  - ca-certificates=2024.8.30=hbcca054_0
+  - ca-certificates=2024.12.14=hbcca054_0
   - cairo=1.18.0=hebfffa5_3
   - celery=5.4.0=pyhd8ed1ab_1
   - ceres-solver=2.2.0=ha77e7a2_4
-  - certifi=2024.8.30=pyhd8ed1ab_0
+  - certifi=2024.12.14=pyhd8ed1ab_0
   - cffi=1.17.1=py311hf29c0ef_0
   - cfitsio=4.4.1=ha728647_2
   - charset-normalizer=3.4.0=pyhd8ed1ab_0
@@ -75,8 +75,8 @@ dependencies:
   - email-validator=2.2.0=pyhd8ed1ab_0
   - email_validator=2.2.0=hd8ed1ab_0
   - entwine=2.2.0=hb071377_4
+  - et_xmlfile=2.0.0=pyhd8ed1ab_0
   - exceptiongroup=1.2.2=pyhd8ed1ab_0
-  - expat=2.6.3=h5888daf_0
   - faker=30.8.1=pyhd8ed1ab_0
   - fastapi=0.115.4=pyhd8ed1ab_0
   - fastapi-cli=0.0.5=pyhd8ed1ab_1
@@ -91,13 +91,13 @@ dependencies:
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=h77eed37_3
-  - fontconfig=2.14.2=h14ed4e7_0
+  - fontconfig=2.15.0=h7e30c49_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
   - fonttools=4.54.1=py311h2dc5d0c_1
   - freetype=2.12.1=h267a509_2
   - freexl=2.0.0=h743c826_0
-  - gdal=3.9.3=py311h5159542_0
+  - gdal=3.9.3=py311h5159542_2
   - geoalchemy2=0.15.2=pyhd8ed1ab_0
   - geojson-pydantic=1.1.2=pyh3cfb1c2_0
   - geopandas=1.0.1=pyhd8ed1ab_1
@@ -161,21 +161,21 @@ dependencies:
   - libffi=3.4.2=h7f98852_5
   - libgcc=14.2.0=h77fa898_1
   - libgcc-ng=14.2.0=h69a702a_1
-  - libgdal=3.9.3=ha770c72_0
-  - libgdal-arrow-parquet=3.9.3=h7a91b6f_0
-  - libgdal-core=3.9.3=hd5b9bfb_0
-  - libgdal-fits=3.9.3=h2db6552_0
-  - libgdal-grib=3.9.3=hc3b29a1_0
-  - libgdal-hdf4=3.9.3=hd5ecb85_0
-  - libgdal-hdf5=3.9.3=h6283f77_0
-  - libgdal-jp2openjpeg=3.9.3=h1b2c38e_0
-  - libgdal-kea=3.9.3=h1df15e4_0
-  - libgdal-netcdf=3.9.3=hf2d2f32_0
-  - libgdal-pdf=3.9.3=h600f43f_0
-  - libgdal-pg=3.9.3=h5e77dd0_0
-  - libgdal-postgisraster=3.9.3=h5e77dd0_0
-  - libgdal-tiledb=3.9.3=h4a3bace_0
-  - libgdal-xls=3.9.3=h03c987c_0
+  - libgdal=3.9.3=ha770c72_2
+  - libgdal-arrow-parquet=3.9.3=h7a91b6f_2
+  - libgdal-core=3.9.3=hd5b9bfb_2
+  - libgdal-fits=3.9.3=h2db6552_2
+  - libgdal-grib=3.9.3=hc3b29a1_2
+  - libgdal-hdf4=3.9.3=hd5ecb85_2
+  - libgdal-hdf5=3.9.3=h6283f77_2
+  - libgdal-jp2openjpeg=3.9.3=h1b2c38e_2
+  - libgdal-kea=3.9.3=h1df15e4_2
+  - libgdal-netcdf=3.9.3=hf2d2f32_2
+  - libgdal-pdf=3.9.3=h600f43f_2
+  - libgdal-pg=3.9.3=h5e77dd0_2
+  - libgdal-postgisraster=3.9.3=h5e77dd0_2
+  - libgdal-tiledb=3.9.3=h4a3bace_2
+  - libgdal-xls=3.9.3=h03c987c_2
   - libgfortran=14.2.0=h69a702a_1
   - libgfortran-ng=14.2.0=h69a702a_1
   - libgfortran5=14.2.0=hd5240d6_1
@@ -214,7 +214,7 @@ dependencies:
   - libre2-11=2024.07.02=hbbce691_1
   - librttopo=1.1.0=h97f6797_17
   - libspatialite=5.1.0=h1b4f908_11
-  - libsqlite=3.47.0=hadc24fc_0
+  - libsqlite=3.47.0=hadc24fc_1
   - libssh2=1.11.0=h0841786_0
   - libstdcxx=14.2.0=hc0a3c3a_1
   - libstdcxx-ng=14.2.0=h4852527_1
@@ -226,7 +226,7 @@ dependencies:
   - libwebp-base=1.4.0=hd590300_0
   - libxcb=1.17.0=h8a09558_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.12.7=he7c6b58_4
+  - libxml2=2.13.4=hb346dea_0
   - libxslt=1.1.39=h76b75d6_0
   - libzip=1.11.1=hf83b1b0_0
   - libzlib=1.3.1=hb9d3cd8_2
@@ -256,7 +256,8 @@ dependencies:
   - openjpeg=2.5.2=h488ebb8_0
   - openldap=2.6.8=hedd0468_0
   - openmpi=5.0.5=h9a79eee_101
-  - openssl=3.3.2=hb9d3cd8_0
+  - openpyxl=3.1.5=py311h50c5138_1
+  - openssl=3.4.0=h7b32b05_1
   - orc=2.0.2=h690cf93_1
   - packaging=24.1=pyhd8ed1ab_0
   - pandas=2.2.3=py311h7db5c69_1
@@ -266,7 +267,7 @@ dependencies:
   - pdal=2.8.1=hd8ed1ab_0
   - pika=1.3.1=pyhd8ed1ab_0
   - pillow=11.0.0=py311h49e9ac3_0
-  - pip=24.2=pyh8b19718_1
+  - pip=24.3.1=pyh8b19718_0
   - pixman=0.43.2=h59595ed_0
   - platformdirs=4.3.6=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
@@ -293,11 +294,11 @@ dependencies:
   - pyproj=3.7.0=py311h0f98d5a_0
   - pysocks=1.7.1=pyha2e5f31_6
   - pytest=8.3.3=pyhd8ed1ab_0
-  - pytest-cov=5.0.0=pyhd8ed1ab_0
+  - pytest-cov=6.0.0=pyhd8ed1ab_0
   - python=3.11.10=hc5c86c4_3_cpython
   - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-dotenv=1.0.1=pyhd8ed1ab_0
-  - python-jose=3.3.0=pyh6c4a22f_1
+  - python-jose=3.3.0=pyhff2d567_2
   - python-multipart=0.0.16=pyhff2d567_0
   - python-pdal=3.4.5=py311h870b839_12
   - python-tzdata=2024.2=pyhd8ed1ab_0
@@ -326,8 +327,8 @@ dependencies:
   - snuggs=1.4.7=pyhd8ed1ab_1
   - spdlog=1.14.1=hed91bc2_1
   - sqlalchemy=2.0.36=py311h9ecbd09_0
-  - sqlite=3.47.0=h9eae976_0
-  - starlette=0.41.0=pyhd8ed1ab_0
+  - sqlite=3.47.0=h9eae976_1
+  - starlette=0.41.2=pyhd8ed1ab_0
   - suitesparse=7.8.2=hb42a789_0
   - tbb=2021.13.0=h84d6215_0
   - threadpoolctl=3.5.0=pyhc1e730c_0
@@ -336,7 +337,7 @@ dependencies:
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.2=pyhd8ed1ab_0
   - tornado=6.4.1=py311h9ecbd09_1
-  - tqdm=4.66.5=pyhd8ed1ab_0
+  - tqdm=4.66.6=pyhd8ed1ab_0
   - typer=0.12.5=pyhd8ed1ab_0
   - typer-slim=0.12.5=pyhd8ed1ab_0
   - typer-slim-standard=0.12.5=hd8ed1ab_0
@@ -351,9 +352,9 @@ dependencies:
   - untwine=1.3.2=hefcc2fe_2
   - uriparser=0.9.8=hac33072_0
   - urllib3=2.2.3=pyhd8ed1ab_0
-  - uvicorn=0.32.0=py311h38be061_0
-  - uvicorn-standard=0.32.0=h38be061_0
-  - uvloop=0.21.0=py311h9ecbd09_0
+  - uvicorn=0.32.0=pyh31011fe_1
+  - uvicorn-standard=0.32.0=h31011fe_1
+  - uvloop=0.21.0=py311h9ecbd09_1
   - vine=5.1.0=pyhd8ed1ab_0
   - watchfiles=0.24.0=py311h9e33e62_1
   - wcwidth=0.2.13=pyhd8ed1ab_0


### PR DESCRIPTION
- Replaces deprecated `datetime.utcnow` with `datetime.now(timezone.utc)`
- Removes unused imports
- Minor update to backend Python packages