### PR TITLE
fix issue with zoom event firing after individual project activated

### DIFF
--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -4,8 +4,9 @@ import LayerPane from './LayerPane';
 
 import { MapContextProvider } from './MapContext';
 import { MapLayerProvider } from './MapLayersContext';
-import { RasterSymbologyProvider } from './RasterSymbologyContext';
 import MapViewMode from './MapViewMode';
+import ProjectLoader from './ProjectLoader';
+import { RasterSymbologyProvider } from './RasterSymbologyContext';
 
 function classNames(...classes: [string, string]) {
   return classes.filter(Boolean).join(' ');
@@ -16,6 +17,7 @@ export default function MapLayout() {
 
   return (
     <MapContextProvider>
+      <ProjectLoader />
       <MapLayerProvider>
         <RasterSymbologyProvider>
           {/* sidebar */}

--- a/frontend/src/components/maps/Maps.d.ts
+++ b/frontend/src/components/maps/Maps.d.ts
@@ -1,3 +1,5 @@
+import { FeatureCollection, Point } from 'geojson';
+
 import { DataProduct, Flight } from '../pages/projects/Project';
 import { Project } from '../pages/projects/ProjectList';
 
@@ -16,12 +18,25 @@ export type FlightsAction = { type: string; payload: Flight[] };
 
 export type ProjectsAction = { type: string; payload: Project[] | null };
 
+export type ProjectGeojsonAction = {
+  type: string;
+  payload: FeatureCollection<Point> | null;
+};
+
+export type ProjectGeojsonLoadedAction = {
+  type: string;
+  payload: boolean;
+};
+
 export type ProjectsVisibleAction = { type: string; payload: string[] };
 
 export type GeoRasterIdAction = { type: string };
 
 export type MapboxAccessTokenAction = { type: string; payload: string };
 
-export type SymbologySettingsAction = { type: string; payload: SymbologySettings };
+export type SymbologySettingsAction = {
+  type: string;
+  payload: SymbologySettings;
+};
 
 export type TileScaleAction = { type: string; payload: number };

--- a/frontend/src/components/maps/ProjectLoader.tsx
+++ b/frontend/src/components/maps/ProjectLoader.tsx
@@ -1,0 +1,48 @@
+import axios, { AxiosResponse, isAxiosError } from 'axios';
+import { FeatureCollection, Point } from 'geojson';
+import { useEffect } from 'react';
+
+import { useMapContext } from './MapContext';
+
+export default function ProjectLoader() {
+  const { projectGeojsonDispatch, projectGeojsonLoadedDispatch } =
+    useMapContext();
+
+  const geojsonUrl = `${
+    import.meta.env.VITE_API_V1_STR
+  }/projects?include_all=${false}&format=geojson`;
+
+  useEffect(() => {
+    const fetchGeojson = async () => {
+      try {
+        const response: AxiosResponse<FeatureCollection<Point>> =
+          await axios.get(geojsonUrl);
+        projectGeojsonDispatch({ type: 'set', payload: response.data });
+        projectGeojsonLoadedDispatch({ type: 'set', payload: true });
+      } catch (error) {
+        // Clear any previously set data
+        projectGeojsonDispatch({ type: 'set', payload: null });
+        projectGeojsonLoadedDispatch({ type: 'set', payload: false });
+        if (isAxiosError(error)) {
+          // Axios-specific error handling
+          const status = error.response?.status || 500;
+          const message = error.response?.data?.message || error.message;
+
+          throw {
+            status,
+            message: `Failed to load project geojson: ${message}`,
+          };
+        } else {
+          // Generic error handling
+          throw {
+            status: 500,
+            message: 'An unexpected error occurred.',
+          };
+        }
+      }
+    };
+    fetchGeojson();
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/pages/admin/DashboardMap.tsx
+++ b/frontend/src/components/pages/admin/DashboardMap.tsx
@@ -79,7 +79,7 @@ export default function DashboardMap() {
       onClick={handleMapClick}
     >
       {/* Display marker cluster for all project centroids */}
-      <ProjectCluster includeAll={true} />
+      <ProjectCluster fetchFromAPI={true} includeAll={true} />
 
       {/* Display popup when unclustered project marker clicked on */}
       {popupInfo && (


### PR DESCRIPTION
Fixes an issue where the zoom to all project markers event triggered after activating a project. This caused the map to zoom in on the activated project boundary before zooming back out to the extent of all project markers. The following improvements are made:
- The GeoJSON object containing project markers is now fetched only once when the home page map loads, rather than every time the map or user navigates back from an active project.
- The GeoJSON object is stored in state and made accessible via the map context provider.
- The zoom to GeoJSON object extent event is no longer triggered after a project is activated.
