### PR TITLE
fix issue with unnecessary requests for user projects and duplicate data products

### DIFF
--- a/backend/app/crud/crud_data_product.py
+++ b/backend/app/crud/crud_data_product.py
@@ -113,7 +113,9 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
             .where(and_(DataProduct.flight_id == flight_id, DataProduct.is_active))
         )
         with db as session:
-            data_products = session.execute(data_products_query).scalars().all()
+            data_products = (
+                session.execute(data_products_query).scalars().unique().all()
+            )
             updated_data_products = []
             for data_product in data_products:
                 # if not a point cloud, find user style settings for data product

--- a/frontend/src/components/pages/projects/flights/MoveFlightModal.tsx
+++ b/frontend/src/components/pages/projects/flights/MoveFlightModal.tsx
@@ -51,8 +51,8 @@ export default function MoveFlightModal({
         return [];
       }
     }
-    getProjects();
-  }, []);
+    if (open) getProjects();
+  }, [open]);
 
   async function moveProject() {
     try {
@@ -78,7 +78,10 @@ export default function MoveFlightModal({
         } else if (typeof (err.response.status === 422)) {
           setStatus({ type: 'error', msg: err.response.data.detail[0].msg });
         } else {
-          setStatus({ type: 'error', msg: 'Unable to move flight at this time' });
+          setStatus({
+            type: 'error',
+            msg: 'Unable to move flight at this time',
+          });
         }
       } else {
         setStatus({ type: 'error', msg: 'Unable to move flight at this time' });


### PR DESCRIPTION
1. Previously, the "Move Flight" modal triggered a request for user projects every time a project detail page loaded. Since the modal is present in each flight card, this resulted in multiple redundant requests, especially impacting users with many projects. Now, the request is made only when the modal is opened, not when the button renders. This should significantly improve the performance of project detail pages with many flights.
2. The CRUD method for fetching multiple data products was returning duplicate entries when products were associated with multiple jobs (e.g., zonal statistics + EXG resulted in two copies). A test has been added to detect duplicates, and the method has been updated to return only unique records.