### PR TITLE
projects api consolidation and caching improvements

### DIFF
--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -43,6 +43,7 @@ export default function HomeMap() {
   const [popupInfo, setPopupInfo] = useState<
     PopupInfoProps | { [key: string]: any } | null
   >(null);
+
   const {
     activeDataProduct,
     activeProject,
@@ -83,6 +84,12 @@ export default function HomeMap() {
       fetchMapLayers(activeProject.id);
     }
   }, [activeProject]);
+
+  useEffect(() => {
+    if (projects && projects.length === 0) {
+      setClusterLayersReady(true);
+    }
+  }, [projects]);
 
   const handleMapClick = (event) => {
     const map: maplibregl.Map = event.target;

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -2,6 +2,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import './HomeMap.css';
 import { AxiosResponse } from 'axios';
 import { Feature } from 'geojson';
+import maplibregl from 'maplibre-gl';
 import { useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';
 
@@ -38,11 +39,17 @@ export type PopupInfoProps = {
 };
 
 export default function HomeMap() {
+  const [clusterLayersReady, setClusterLayersReady] = useState(false);
   const [popupInfo, setPopupInfo] = useState<
     PopupInfoProps | { [key: string]: any } | null
   >(null);
-  const { activeDataProduct, activeProject, mapboxAccessToken } =
-    useMapContext();
+  const {
+    activeDataProduct,
+    activeProject,
+    mapboxAccessToken,
+    projects,
+    projectsVisibleDispatch,
+  } = useMapContext();
   const {
     state: { layers },
     dispatch,
@@ -122,6 +129,29 @@ export default function HomeMap() {
     }
   };
 
+  const handleMoveEnd = (event) => {
+    if (!projects?.length) return;
+
+    const mapInstance = event.target;
+    const mapBounds = mapInstance.getBounds();
+
+    // Filter projects to those whose marker is inside the current map bounds,
+    // then extract their IDs
+    const visibleProjectMarkers = projects
+      .filter((project) => {
+        const { x, y } = project.centroid;
+        const markerLocation = new maplibregl.LngLat(x, y);
+        return mapBounds.contains(markerLocation);
+      })
+      .map((project) => project.id);
+
+    // Update state with visible project marker IDs
+    projectsVisibleDispatch({
+      type: 'set',
+      payload: visibleProjectMarkers,
+    });
+  };
+
   const showBackgroundRaster = () => {
     if (
       activeDataProduct &&
@@ -156,19 +186,25 @@ export default function HomeMap() {
       initialViewState={{
         longitude: -86.9138040788386,
         latitude: 40.428655143949925,
-        zoom: 8,
       }}
       style={{
         width: '100%',
         height: '100%',
+        opacity: clusterLayersReady ? 1 : 0,
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
       reuseMaps={true}
       onClick={handleMapClick}
+      onMoveEnd={handleMoveEnd}
     >
       {/* Display marker cluster for project centroids when no project is active */}
-      {!activeProject && <ProjectCluster />}
+      {!activeProject && (
+        <ProjectCluster
+          clusterLayersReady={clusterLayersReady}
+          setClusterLayersReady={setClusterLayersReady}
+        />
+      )}
 
       {/* Display popup on click for project markers when no project is active */}
       {!activeProject && popupInfo && (

--- a/frontend/src/components/maps/LayerPane/LayerPane.tsx
+++ b/frontend/src/components/maps/LayerPane/LayerPane.tsx
@@ -23,19 +23,17 @@ import Sort, {
   sortProjects,
 } from '../../Sort';
 
-import { getLocalStorageProjects } from './utils';
+type LayerPaneProps = {
+  hidePane: boolean;
+  toggleHidePane: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
 export default function LayerPane({
   hidePane,
   toggleHidePane,
-}: {
-  hidePane: boolean;
-  toggleHidePane: React.Dispatch<React.SetStateAction<boolean>>;
-}) {
+}: LayerPaneProps) {
   const [currentPage, setCurrentPage] = useState(0);
-  const [mapProjects, setMapProjects] = useState<Project[] | null>(
-    getLocalStorageProjects()
-  );
+  const [mapProjects, setMapProjects] = useState<Project[]>([]);
   const [searchText, setSearchText] = useState('');
   const [sortSelection, setSortSelection] = useState<SortSelection>(
     getSortPreferenceFromLocalStorage('sortPreference')
@@ -127,7 +125,9 @@ export default function LayerPane({
    * @param newPage Index of new page.
    */
   function updateCurrentPage(newPage: number): void {
-    const total_pages = Math.ceil(mapProjects ? mapProjects.length : 0 / MAX_ITEMS);
+    const total_pages = Math.ceil(
+      mapProjects ? mapProjects.length : 0 / MAX_ITEMS
+    );
 
     if (newPage + 1 > total_pages) {
       setCurrentPage(total_pages - 1);
@@ -275,8 +275,14 @@ export default function LayerPane({
                       <LayerCard hover={true}>
                         <div
                           onClick={() => {
-                            activeDataProductDispatch({ type: 'clear', payload: null });
-                            activeProjectDispatch({ type: 'set', payload: project });
+                            activeDataProductDispatch({
+                              type: 'clear',
+                              payload: null,
+                            });
+                            activeProjectDispatch({
+                              type: 'set',
+                              payload: project,
+                            });
                           }}
                           title={project.title}
                         >
@@ -324,9 +330,9 @@ export default function LayerPane({
               ) : mapProjects && mapProjects.length === 0 ? (
                 <div>
                   <p className="mb-4">
-                    You do not have any projects to display on the map. Use the below
-                    button to navigate to the Projects page and create your first
-                    project.
+                    You do not have any projects to display on the map. Use the
+                    below button to navigate to the Projects page and create
+                    your first project.
                   </p>
                   <Link to="/projects">
                     <Button>My Projects</Button>

--- a/frontend/src/components/maps/LayerPane/utils.ts
+++ b/frontend/src/components/maps/LayerPane/utils.ts
@@ -1,5 +1,3 @@
-import { Project } from '../../pages/projects/ProjectList';
-
 /**
  * Takes a date in YYYY-mm-dd format and returns it in Day, Month Date, Year format.
  * For example: 2024-03-13 to Wednesday, Mar 13, 2024
@@ -16,22 +14,4 @@ function formatDate(datestring) {
   });
 }
 
-/**
- * Checks local storage for previously stored projects.
- * @returns Array of projects retrieved from local storage.
- */
-function getLocalStorageProjects(): Project[] | null {
-  if ('projects' in localStorage) {
-    const lsProjectsString = localStorage.getItem('projects');
-    if (lsProjectsString) {
-      const lsProjects: Project[] = JSON.parse(lsProjectsString);
-      if (lsProjects && lsProjects.length > 0) {
-        return lsProjects;
-      }
-    }
-  }
-
-  return null;
-}
-
-export { formatDate, getLocalStorageProjects };
+export { formatDate };

--- a/frontend/src/components/maps/Maps.d.ts
+++ b/frontend/src/components/maps/Maps.d.ts
@@ -18,15 +18,7 @@ export type FlightsAction = { type: string; payload: Flight[] };
 
 export type ProjectsAction = { type: string; payload: Project[] | null };
 
-export type ProjectGeojsonAction = {
-  type: string;
-  payload: FeatureCollection<Point> | null;
-};
-
-export type ProjectGeojsonLoadedAction = {
-  type: string;
-  payload: boolean;
-};
+export type ProjectsLoadedAction = { type: string; payload: boolean };
 
 export type ProjectsVisibleAction = { type: string; payload: string[] };
 

--- a/frontend/src/components/maps/ProjectCluster.tsx
+++ b/frontend/src/components/maps/ProjectCluster.tsx
@@ -41,7 +41,7 @@ export default function ProjectCluster({
   const { current: map } = useMap();
 
   const projectsFeatureCollection = useMemo(() => {
-    if (!projects) return null;
+    if (!projects || projects.length === 0) return null;
     const features: ProjectPointFeature[] = projects.map((project) => ({
       type: 'Feature',
       geometry: {
@@ -127,6 +127,7 @@ export default function ProjectCluster({
     map.fitBounds(bounds, {
       padding: 20,
       duration: duration,
+      maxZoom: 16,
     });
   }, [map, geojsonData, geojsonLoaded]);
 

--- a/frontend/src/components/maps/ProjectLoader.tsx
+++ b/frontend/src/components/maps/ProjectLoader.tsx
@@ -1,51 +1,57 @@
 import { AxiosResponse, isAxiosError } from 'axios';
-import { FeatureCollection, Point } from 'geojson';
 import { useEffect } from 'react';
 
 import { useMapContext } from './MapContext';
+import { Project } from '../pages/projects/ProjectList';
 
 import api from '../../api';
+import { areProjectsEqual, getLocalStorageProjects } from './utils';
 
 export default function ProjectLoader() {
-  const { projectGeojsonDispatch, projectGeojsonLoadedDispatch } =
+  const { projectsDispatch, projectsLoadedDispatch, projects } =
     useMapContext();
 
   useEffect(() => {
-    const fetchGeojson = async () => {
+    const fetchProjects = async () => {
       try {
-        const geojsonUrl = `/projects?include_all=${false}&format=geojson`;
-        const response: AxiosResponse<FeatureCollection<Point>> = await api.get(
-          geojsonUrl
-        );
-        // Only set if project features returned
-        if (response.data?.features.length > 0) {
-          projectGeojsonDispatch({ type: 'set', payload: response.data });
-          projectGeojsonLoadedDispatch({ type: 'set', payload: true });
+        const geojsonUrl = `/projects?include_all=${false}`;
+        const response: AxiosResponse<Project[]> = await api.get(geojsonUrl);
+
+        if (response.data.length > 0) {
+          // Only update projects if they are new or differ from the current state
+          if (!projects || !areProjectsEqual(projects, response.data)) {
+            projectsDispatch({ type: 'set', payload: response.data });
+          }
+          projectsLoadedDispatch({ type: 'set', payload: true });
+        } else {
+          projectsDispatch({ type: 'set', payload: null });
         }
       } catch (error) {
-        // Clear any previously set data
-        projectGeojsonDispatch({ type: 'set', payload: null });
-        projectGeojsonLoadedDispatch({ type: 'set', payload: false });
+        // Clear any previously set data and update loading state
+        projectsDispatch({ type: 'set', payload: null });
+        projectsLoadedDispatch({ type: 'set', payload: false });
         if (isAxiosError(error)) {
-          // Axios-specific error handling
           const status = error.response?.status || 500;
           const message = error.response?.data?.message || error.message;
-
-          throw {
-            status,
-            message: `Failed to load project geojson: ${message}`,
-          };
+          console.error(
+            `Failed to load project geojson: ${status} -- ${message}`
+          );
+          // Optionally, display an error message instead of rethrowing
         } else {
-          // Generic error handling
-          throw {
-            status: 500,
-            message: 'An unexpected error occurred.',
-          };
+          console.error('An unexpected error occurred.');
         }
       }
     };
-    fetchGeojson();
-  }, []);
+
+    // Check for cached projects in local storage
+    const localStorageProjects = getLocalStorageProjects();
+    if (localStorageProjects) {
+      projectsDispatch({ type: 'set', payload: localStorageProjects });
+      projectsLoadedDispatch({ type: 'set', payload: true });
+    }
+    // Always fetch latest projects from the backend
+    fetchProjects();
+  }, []); // Consider dependencies if projects can change elsewhere
 
   return null;
 }

--- a/frontend/src/components/maps/ProjectLoader.tsx
+++ b/frontend/src/components/maps/ProjectLoader.tsx
@@ -17,15 +17,11 @@ export default function ProjectLoader() {
         const geojsonUrl = `/projects?include_all=${false}`;
         const response: AxiosResponse<Project[]> = await api.get(geojsonUrl);
 
-        if (response.data.length > 0) {
-          // Only update projects if they are new or differ from the current state
-          if (!projects || !areProjectsEqual(projects, response.data)) {
-            projectsDispatch({ type: 'set', payload: response.data });
-          }
-          projectsLoadedDispatch({ type: 'set', payload: true });
-        } else {
-          projectsDispatch({ type: 'set', payload: null });
+        // Only update projects if they are new or differ from the current state
+        if (!projects || !areProjectsEqual(projects, response.data)) {
+          projectsDispatch({ type: 'set', payload: response.data });
         }
+        projectsLoadedDispatch({ type: 'set', payload: true });
       } catch (error) {
         // Clear any previously set data and update loading state
         projectsDispatch({ type: 'set', payload: null });

--- a/frontend/src/components/maps/utils.tsx
+++ b/frontend/src/components/maps/utils.tsx
@@ -4,9 +4,14 @@ import {
   DataProduct,
   Flight,
   MapLayer,
+  ProjectFeatureCollection,
   STACProperties,
 } from '../pages/projects/Project';
-import { SingleBandSymbology, MultibandSymbology } from './RasterSymbologyContext';
+import { Project } from '../pages/projects/ProjectList';
+import {
+  SingleBandSymbology,
+  MultibandSymbology,
+} from './RasterSymbologyContext';
 
 type Bounds = [number, number, number, number];
 
@@ -17,7 +22,7 @@ type Bounds = [number, number, number, number];
  * @returns Bounding box array.
  */
 function calculateBoundsFromGeoJSON(
-  geojsonData: FeatureCollection<Point | Polygon>
+  geojsonData: ProjectFeatureCollection | FeatureCollection<Point | Polygon>
 ): Bounds {
   const bounds: Bounds = geojsonData.features.reduce(
     (bounds, feature) => {
@@ -25,7 +30,9 @@ function calculateBoundsFromGeoJSON(
 
       if (feature.geometry.type === 'Polygon') {
         // Flatten the coordinates array into single array of coordinates
-        const coordinates = feature.geometry.coordinates.flat(Infinity) as number[];
+        const coordinates = feature.geometry.coordinates.flat(
+          Infinity
+        ) as number[];
 
         for (let i = 0; i < coordinates.length; i += 2) {
           const lng = coordinates[i];
@@ -125,11 +132,15 @@ function getHillshade(
   const filteredFlights = flights.filter(
     ({ id }) => id === activeDataProduct.flight_id
   );
-  if (filteredFlights.length > 0 && filteredFlights[0].data_products.length > 1) {
+  if (
+    filteredFlights.length > 0 &&
+    filteredFlights[0].data_products.length > 1
+  ) {
     const dataProducts = filteredFlights[0].data_products;
     const dataProductHillshade = dataProducts.filter(
       (dataProduct) =>
-        dataProduct.data_type.toLowerCase().split(' hs')[0] === dataProductName &&
+        dataProduct.data_type.toLowerCase().split(' hs')[0] ===
+          dataProductName &&
         dataProduct.data_type.toLowerCase().split(' hs').length > 1
     );
     return dataProductHillshade.length > 0 ? dataProductHillshade[0] : null;
@@ -144,7 +155,10 @@ function getHillshade(
  * @returns True if single band, otherwise False.
  */
 function isSingleBand(dataProduct: DataProduct): boolean {
-  return dataProduct.stac_properties && dataProduct.stac_properties.raster.length === 1;
+  return (
+    dataProduct.stac_properties &&
+    dataProduct.stac_properties.raster.length === 1
+  );
 }
 
 /**
@@ -247,14 +261,17 @@ const getMultibandMinMax = (
   stacProps: STACProperties,
   symbology: MultibandSymbology
 ): [[number, number], [number, number], [number, number]] => {
-  const defaultMinMax: [[number, number], [number, number], [number, number]] = [
-    [0, 255],
-    [0, 255],
-    [0, 255],
-  ];
+  const defaultMinMax: [[number, number], [number, number], [number, number]] =
+    [
+      [0, 255],
+      [0, 255],
+      [0, 255],
+    ];
 
   const validateBands = (key: 'min' | 'max' | 'userMin' | 'userMax') =>
-    ['red', 'green', 'blue'].every((band) => symbology[band]?.[key] !== undefined);
+    ['red', 'green', 'blue'].every(
+      (band) => symbology[band]?.[key] !== undefined
+    );
 
   const getStats = (index: number) => stacProps.raster?.[index - 1]?.stats;
 
@@ -290,7 +307,9 @@ const getMultibandMinMax = (
     case 'meanStdDev':
       // verify we have a band index for RGB
       if (
-        !['red', 'green', 'blue'].every((band) => symbology[band]?.idx !== undefined)
+        !['red', 'green', 'blue'].every(
+          (band) => symbology[band]?.idx !== undefined
+        )
       ) {
         console.warn(
           'Missing index for at least one band, falling back to default min/max.'
@@ -303,7 +322,9 @@ const getMultibandMinMax = (
 
         // verify we have a mean, std. dev. for each band and a meanStdDev mult factor
         if (
-          stats.some((s) => !s || s.mean === undefined || s.stddev === undefined) ||
+          stats.some(
+            (s) => !s || s.mean === undefined || s.stddev === undefined
+          ) ||
           symbology.meanStdDev === undefined
         ) {
           console.warn(
@@ -323,14 +344,81 @@ const getMultibandMinMax = (
   }
 };
 
+/**
+ * Checks local storage for previously stored projects.
+ * @returns Array of projects retrieved from local storage.
+ */
+function getLocalStorageProjects(): Project[] | null {
+  if ('projects' in localStorage) {
+    const lsProjectsString = localStorage.getItem('projects');
+    if (lsProjectsString) {
+      const lsProjects: Project[] = JSON.parse(lsProjectsString);
+      if (lsProjects && lsProjects.length > 0) {
+        return lsProjects;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Sort projects by unique UUID string.
+ * @param projects Array of projects with unique `id` strings.
+ * @returns Array of sorted projects.
+ */
+function sortProjects(projects: Project[]): Project[] {
+  return projects.slice().sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Compare projects currently stored in local storage with new projects returned
+ * from API request.
+ * @param oldProjects Array of projects currently in local storage.
+ * @param newProjects Array of projects returned from API request.
+ * @returns True if both arrays match, otherwise false.
+ */
+function areProjectsEqual(
+  oldProjects: Project[],
+  newProjects: Project[]
+): boolean {
+  const sortedOld = sortProjects(oldProjects);
+  const sortedNew = sortProjects(newProjects);
+  return JSON.stringify(sortedOld) === JSON.stringify(sortedNew);
+}
+
+/**
+ * Sets projects returned from API in local storage. If projects already exist
+ * in local storage, they will only be replaced if the projects returned from
+ * the API differ.
+ * @param projects Projects returned from API.
+ */
+function setLocalStorageProjects(projects: Project[]): void {
+  const projectsString = JSON.stringify(projects);
+  const storedProjects = getLocalStorageProjects();
+
+  if (storedProjects) {
+    // Compare stored data with the new projects
+    if (!areProjectsEqual(storedProjects, projects)) {
+      localStorage.setItem('projects', projectsString);
+    }
+  } else {
+    // If nothing is stored, set the projects
+    localStorage.setItem('projects', projectsString);
+  }
+}
+
 export {
+  areProjectsEqual,
   calculateBoundsFromGeoJSON,
   createDefaultSingleBandSymbology,
   createDefaultMultibandSymbology,
   getDefaultStyle,
   getHillshade,
+  getLocalStorageProjects,
   getSingleBandMinMax,
   getMultibandMinMax,
   isSingleBand,
   mapApiResponseToLayers,
+  setLocalStorageProjects,
 };

--- a/frontend/src/components/pages/projects/Project.d.ts
+++ b/frontend/src/components/pages/projects/Project.d.ts
@@ -38,8 +38,10 @@ type MapLayerProperties = {
   properties?: { [key: string]: any };
 };
 
-interface MapLayerFeature<G extends Geometry | null = Geometry, P = MapLayerProperties>
-  extends Feature<G, P> {}
+interface MapLayerFeature<
+  G extends Geometry | null = Geometry,
+  P = MapLayerProperties
+> extends Feature<G, P> {}
 
 export interface MapLayerFeatureCollection<
   G extends Geometry | null = Geometry,
@@ -214,3 +216,16 @@ export type IForester = {
   user: string;
   timeStamp: string;
 };
+
+// Properties for a project point feature
+export interface ProjectPointFeatureProperties {
+  id: string;
+  title: string;
+  description: string;
+}
+
+// Project point feature with custom properties
+export type ProjectPointFeature = Feature<Point, ProjectPointFeatureProperties>;
+
+// Feature collection of project point features with custom properties
+export type ProjectFeatureCollection = FeatureCollection<ProjectPointFeature>;


### PR DESCRIPTION
- combined separate project state variables into one
- homepage and workspace pages now initially use projects cached in localStorage before fetching fresh data from api
- on initial homepage load, the map should now be at the extent of the cluster markers when it becomes visible