### PR TITLE
update map ready state when navigating from data product card

### DIFF
--- a/frontend/src/components/maps/ProjectCluster.tsx
+++ b/frontend/src/components/maps/ProjectCluster.tsx
@@ -20,17 +20,17 @@ import api from '../../api';
 import { calculateBoundsFromGeoJSON } from './utils';
 
 type ProjectClusterProps = {
-  clusterLayersReady?: boolean;
+  isMapReady?: boolean;
   fetchFromAPI?: boolean;
   includeAll?: boolean;
-  setClusterLayersReady?: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsMapReady?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function ProjectCluster({
-  clusterLayersReady,
+  isMapReady,
   fetchFromAPI = false,
   includeAll = false,
-  setClusterLayersReady,
+  setIsMapReady,
 }: ProjectClusterProps) {
   const { projects, projectsLoaded } = useMapContext();
 
@@ -112,13 +112,12 @@ export default function ProjectCluster({
     const bounds = calculateBoundsFromGeoJSON(geojsonData);
 
     // Determine animation duration based on whether it's the first load
-    const duration =
-      clusterLayersReady === undefined || clusterLayersReady ? 1000 : 1;
+    const duration = isMapReady === undefined || isMapReady ? 1000 : 1;
 
     // Set cluster layers as ready after first fitBounds event finishes
     const onMoveEnd = () => {
-      if (setClusterLayersReady) {
-        setClusterLayersReady(true);
+      if (setIsMapReady) {
+        setIsMapReady(true);
       }
     };
     map.once('moveend', onMoveEnd);

--- a/frontend/src/components/pages/projects/flights/DataProducts/DataProductCard.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/DataProductCard.tsx
@@ -48,7 +48,8 @@ export default function DataProductCard({
           <div className="grid grid-flow-row auto-rows-max gap-2">
             {/* preview image */}
             <div className="relative flex items-center justify-center bg-accent3/20">
-              {dataProduct.status === 'SUCCESS' && isGeoTIFF(dataProduct.data_type) ? (
+              {dataProduct.status === 'SUCCESS' &&
+              isGeoTIFF(dataProduct.data_type) ? (
                 <div className="flex items-center justify-center w-full h-48">
                   <img
                     className="object-scale-down h-full"
@@ -77,7 +78,10 @@ export default function DataProductCard({
                       src={dataProduct.url.replace('copc.laz', 'png')}
                       alt="Preview of data product"
                       onError={() => {
-                        setInvalidPreviews([...invalidPreviews, dataProduct.id]);
+                        setInvalidPreviews([
+                          ...invalidPreviews,
+                          dataProduct.id,
+                        ]);
                       }}
                     />
                   ) : (
@@ -146,7 +150,11 @@ export default function DataProductCard({
                 className="flex items-center gap-2 text-sky-600 cursor-pointer"
                 onClick={() => {
                   navigate('/home', {
-                    state: { project: project, dataProduct: dataProduct },
+                    state: {
+                      project: project,
+                      dataProduct: dataProduct,
+                      navContext: 'dataProductCard',
+                    },
                   });
                 }}
               >
@@ -163,7 +171,8 @@ export default function DataProductCard({
             </div>
           </div>
         </Card>
-        {dataProduct.status === 'INPROGRESS' || dataProduct.status === 'WAITING' ? (
+        {dataProduct.status === 'INPROGRESS' ||
+        dataProduct.status === 'WAITING' ? (
           <div className="w-full absolute bottom-0">
             <ProgressBar />
           </div>


### PR DESCRIPTION
This commit updates the navigation context handling so that when the home map is reached from a data product card, the map ready state is immediately set to `true`. This ensures the map behaves appropriately for users coming from a data product card.