### PR TITLE
add bbox as attribute to raster data product objects, use bounding box to reduce tiles requested

### DIFF
--- a/backend/app/crud/crud_flight.py
+++ b/backend/app/crud/crud_flight.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import joinedload, Session
 from app import crud
 from app.crud.base import CRUDBase
 from app.crud.crud_data_product import (
+    set_bbox_attr,
     set_public_attr,
     set_signature_attr,
     set_url_attr,
@@ -130,6 +131,7 @@ class CRUDFlight(CRUDBase[Flight, FlightCreate, FlightUpdate]):
                         ):
                             # do not include geotiffs without stac props
                             available_data_products.append(data_product)
+                            set_bbox_attr(data_product)
                             set_public_attr(
                                 data_product, data_product.file_permission.is_public
                             )

--- a/backend/app/schemas/data_product.py
+++ b/backend/app/schemas/data_product.py
@@ -55,6 +55,7 @@ class DataProductSignature(BaseModel):
 
 
 class DataProduct(DataProductInDBBase):
+    bbox: Optional[List[float]] = None
     public: bool = False
     signature: Optional[DataProductSignature] = None
     status: Optional[str] = None

--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';
+import { bbox } from '@turf/bbox';
 
 import CompareMapControl from './CompareMapControl';
 import CompareModeControl from './CompareModeControl';
@@ -9,6 +10,7 @@ import ProjectRasterTiles from '../ProjectRasterTiles';
 import { DataProduct } from '../../pages/projects/Project';
 import { useRasterSymbologyContext } from '../RasterSymbologyContext';
 
+import { BBox } from '../Maps';
 import {
   getMapboxSatelliteBasemapStyle,
   usgsImageryTopoBasemapStyle,
@@ -67,9 +69,8 @@ export default function CompareMap() {
 
   const [activeMap, setActiveMap] = useState<'left' | 'right'>('left');
 
-  const [mapComparisonState, setMapComparisonState] = useState<MapComparisonState>(
-    defaultMapComparisonState
-  );
+  const [mapComparisonState, setMapComparisonState] =
+    useState<MapComparisonState>(defaultMapComparisonState);
 
   const { activeProject, flights, mapboxAccessToken } = useMapContext();
 
@@ -215,7 +216,13 @@ export default function CompareMap() {
         {activeProject &&
           selectedLeftDataProduct &&
           symbologyState[selectedLeftDataProduct.id]?.isLoaded && (
-            <ProjectRasterTiles dataProduct={selectedLeftDataProduct} />
+            <ProjectRasterTiles
+              boundingBox={
+                selectedLeftDataProduct.bbox ||
+                (bbox(activeProject.field) as BBox)
+              }
+              dataProduct={selectedLeftDataProduct}
+            />
           )}
 
         {/* Toggle compare mode */}
@@ -248,7 +255,13 @@ export default function CompareMap() {
         {activeProject &&
           selectedRightDataProduct &&
           symbologyState[selectedRightDataProduct.id]?.isLoaded && (
-            <ProjectRasterTiles dataProduct={selectedRightDataProduct} />
+            <ProjectRasterTiles
+              boundingBox={
+                selectedRightDataProduct.bbox ||
+                (bbox(activeProject.field) as BBox)
+              }
+              dataProduct={selectedRightDataProduct}
+            />
           )}
 
         {/* General controls */}

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -6,6 +6,7 @@ import maplibregl from 'maplibre-gl';
 import { useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';
 import { useLocation } from 'react-router-dom';
+import { bbox } from '@turf/bbox';
 
 import ColorBarControl from './ColorBarControl';
 import GeocoderControl from './GeocoderControl';
@@ -18,6 +19,7 @@ import ProjectRasterTiles from './ProjectRasterTiles';
 import ProjectVectorTiles from './ProjectVectorTiles';
 import { MapLayer } from '../pages/projects/Project';
 
+import { BBox } from './Maps';
 import { useMapContext } from './MapContext';
 import { useMapLayerContext } from './MapLayersContext';
 import {
@@ -171,6 +173,7 @@ export default function HomeMap() {
 
   const showBackgroundRaster = () => {
     if (
+      activeProject &&
       activeDataProduct &&
       isSingleBand(activeDataProduct) &&
       symbologyContext.state[activeDataProduct.id]
@@ -179,8 +182,11 @@ export default function HomeMap() {
         activeDataProduct.id
       ].symbology as SingleBandSymbology;
       if (activeDataProductSymbology && activeDataProductSymbology.background) {
+        const boundingBox =
+          activeDataProduct.bbox || (bbox(activeProject.field) as BBox);
         return (
           <ProjectRasterTiles
+            boundingBox={boundingBox}
             dataProduct={activeDataProductSymbology.background}
           />
         );
@@ -240,6 +246,9 @@ export default function HomeMap() {
       {activeProject && activeDataProduct && (
         <ProjectRasterTiles
           key={activeDataProduct.id}
+          boundingBox={
+            activeDataProduct.bbox || (bbox(activeProject.field) as BBox)
+          }
           dataProduct={activeDataProduct}
         />
       )}

--- a/frontend/src/components/maps/Maps.d.ts
+++ b/frontend/src/components/maps/Maps.d.ts
@@ -14,6 +14,8 @@ export type ActiveMapToolAction = { type: string; payload: MapTool };
 
 export type ActiveProjectAction = { type: string; payload: Project | null };
 
+export type BBox = [number, number, number, number];
+
 export type FlightsAction = { type: string; payload: Flight[] };
 
 export type ProjectsAction = { type: string; payload: Project[] | null };

--- a/frontend/src/components/maps/ProjectRasterTiles.tsx
+++ b/frontend/src/components/maps/ProjectRasterTiles.tsx
@@ -68,8 +68,10 @@ function constructRasterTileUrl(
 }
 
 export default function ProjectRasterTiles({
+  boundingBox = undefined,
   dataProduct,
 }: {
+  boundingBox?: [number, number, number, number];
   dataProduct: DataProduct;
 }) {
   const { current: map } = useMap();
@@ -96,6 +98,7 @@ export default function ProjectRasterTiles({
       maxzoom={24}
       minzoom={0}
       tileSize={256}
+      bounds={boundingBox}
     >
       <Layer
         key={`${dataProduct.id}-layer`}

--- a/frontend/src/components/maps/ShareMap.tsx
+++ b/frontend/src/components/maps/ShareMap.tsx
@@ -121,7 +121,11 @@ export default function ShareMap() {
       }
     }
     if (dataProduct) {
-      getBounds(dataProduct.id);
+      if (dataProduct.bbox) {
+        setBounds(dataProduct.bbox);
+      } else {
+        getBounds(dataProduct.id);
+      }
     }
   }, [dataProduct]);
 
@@ -164,7 +168,10 @@ export default function ShareMap() {
     >
       {/* Display raster tiles */}
       {dataProduct && state[dataProduct.id]?.symbology && (
-        <ProjectRasterTiles dataProduct={dataProduct} />
+        <ProjectRasterTiles
+          boundingBox={dataProduct.bbox}
+          dataProduct={dataProduct}
+        />
       )}
 
       {/* Display color bar when single band data product */}

--- a/frontend/src/components/pages/projects/Project.d.ts
+++ b/frontend/src/components/pages/projects/Project.d.ts
@@ -141,6 +141,7 @@ export interface DataProduct {
   filepath: string;
   url: string;
   flight_id: string;
+  bbox?: [number, number, number, number];
   public: boolean;
   signature?: {
     secure: string;


### PR DESCRIPTION
Data products returned by the backend API now include a WGS84 bounding box computed using rasterio. On the frontend, the Maplibre Sources leverage this bounding box via their bounds attribute to restrict tile requests to the relevant area, which minimizes 404 errors from out-of-bounds tile requests.