### PR TITLE
add colorbar for single-band rasters in compare maps, disable reuseMaps on homepage map

### DIFF
--- a/frontend/src/components/maps/ColorBarControl.tsx
+++ b/frontend/src/components/maps/ColorBarControl.tsx
@@ -12,11 +12,13 @@ import {
 import api from '../../api';
 
 export default function ColorBarControl({
-  projectId,
   dataProduct,
+  position = 'left',
+  projectId,
 }: {
-  projectId?: string;
   dataProduct: DataProduct;
+  position?: 'left' | 'right';
+  projectId?: string;
 }) {
   const [isRefreshing, toggleIsRefreshing] = useState(false);
   const [url, setURL] = useState('');
@@ -86,7 +88,12 @@ export default function ColorBarControl({
 
   if (url) {
     return (
-      <div className="absolute left-0 bottom-8 bg-white/75 rounded-md shadow-md px-3 py-6 m-2.5 leading-3 text-slate-600 outline-none">
+      <div
+        className={clsx(
+          'absolute bottom-8 bg-white/75 rounded-md shadow-md px-3 py-6 m-2.5 leading-3 text-slate-600 outline-none',
+          { 'start-0': position === 'left', 'end-0': position === 'right' }
+        )}
+      >
         <img src={url} className="h-80" />
         <button
           type="button"

--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';
 import { bbox } from '@turf/bbox';
 
+import ColorBarControl from '../ColorBarControl';
 import CompareMapControl from './CompareMapControl';
 import CompareModeControl from './CompareModeControl';
 import ProjectBoundary from '../ProjectBoundary';
@@ -225,6 +226,16 @@ export default function CompareMap() {
             />
           )}
 
+        {/* Display color bar when project active and single band data product active */}
+        {activeProject &&
+          selectedLeftDataProduct &&
+          isSingleBand(selectedLeftDataProduct) && (
+            <ColorBarControl
+              dataProduct={selectedLeftDataProduct}
+              projectId={activeProject.id}
+            />
+          )}
+
         {/* Toggle compare mode */}
         <CompareModeControl mode={mode} onModeChange={setMode} />
 
@@ -261,6 +272,17 @@ export default function CompareMap() {
                 (bbox(activeProject.field) as BBox)
               }
               dataProduct={selectedRightDataProduct}
+            />
+          )}
+
+        {/* Display color bar when project active and single band data product active */}
+        {activeProject &&
+          selectedRightDataProduct &&
+          isSingleBand(selectedRightDataProduct) && (
+            <ColorBarControl
+              dataProduct={selectedRightDataProduct}
+              position="right"
+              projectId={activeProject.id}
             />
           )}
 

--- a/frontend/src/components/maps/CompareMap/CompareModeControl.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareModeControl.tsx
@@ -14,7 +14,7 @@ export default function CompareModeControl(props: {
   );
 
   return (
-    <div className="absolute bottom-12 left-2.5 font-semibold text-gray-600 border-2 border-gray-300 rounded-md">
+    <div className="absolute bottom-2 left-32 font-semibold text-gray-600 border-2 border-gray-300 rounded-md">
       <select className="rounded-md" value={props.mode} onChange={onModeChange}>
         <option value="side-by-side">Side by side</option>
         <option value="split-screen">Split screen</option>

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -190,7 +190,6 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
-      reuseMaps={true}
       onClick={handleMapClick}
       onMoveEnd={handleMoveEnd}
     >


### PR DESCRIPTION
- Added color bar for single-band rasters on left and right side maps when in "compare" mode.
- Added optional "position" property to color bar to allow for positioning on right side of map.
- Removed reuseMaps property from home page map to prevent reuse of view state and padding applied to compare maps.