### PR TITLE
include preview image of feature in polygon popups

### DIFF
--- a/frontend/src/components/maps/FeaturePreviewImage.tsx
+++ b/frontend/src/components/maps/FeaturePreviewImage.tsx
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import { Feature } from 'geojson';
+import { useEffect, useState } from 'react';
+
+import { DataProduct } from '../pages/projects/Project';
+import {
+  MultibandSymbology,
+  SingleBandSymbology,
+} from './RasterSymbologyContext';
+
+import { getTitilerQueryParams } from './utils';
+
+type FeaturePreviewImageProps = {
+  dataProduct: DataProduct;
+  feature: Feature;
+  symbology: SingleBandSymbology | MultibandSymbology;
+};
+
+export default function FeaturePreviewImage({
+  dataProduct,
+  feature,
+  symbology,
+}: FeaturePreviewImageProps) {
+  const [imageUrl, setImageUrl] = useState(null);
+
+  // Build the titiler /cog/feature url
+  const cogUrl = dataProduct.filepath;
+  const resourcePath = `/cog/feature`;
+  const basePath = window.location.origin;
+  const queryParams = getTitilerQueryParams(cogUrl, dataProduct, symbology);
+  queryParams.append('max_size', '1024');
+  const url = `${basePath}${resourcePath}?${queryParams.toString()}`;
+
+  // Fetch image from titiler and update the imageUrl state
+  useEffect(() => {
+    let isMounted = true;
+    let blobUrl;
+
+    axios
+      .post(url, feature, { responseType: 'blob' })
+      .then((response) => {
+        blobUrl = URL.createObjectURL(response.data);
+        if (isMounted) {
+          setImageUrl(blobUrl);
+        }
+      })
+      .catch((err) => console.error(err));
+
+    // Cleanup function to revoke the blob url
+    return () => {
+      isMounted = false;
+      if (blobUrl) {
+        URL.revokeObjectURL(blobUrl);
+      }
+    };
+  }, [url, feature]);
+
+  return (
+    <div className="flex h-40 w-full justify-center">
+      <img
+        id="feature-preview-image"
+        className="object-contain h-40"
+        alt="Feature preview"
+        src={imageUrl || undefined}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -34,6 +34,7 @@ import { isSingleBand } from './utils';
 
 export type PopupInfoProps = {
   feature: Feature;
+  feature_type: string;
   latitude: number;
   longitude: number;
 };
@@ -92,6 +93,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
 
           setPopupInfo({
             feature: clickedFeature,
+            feature_type: 'point',
             latitude: coordinates[1],
             longitude: coordinates[0],
           });
@@ -109,9 +111,12 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
           if (features.length > 0) {
             const clickedFeature = features[0];
             const clickCoordinates = event.lngLat;
+            const clickedFeatureType =
+              clickedFeature.geometry.type.toLowerCase();
 
             setPopupInfo({
               feature: clickedFeature,
+              feature_type: clickedFeatureType,
               latitude: clickCoordinates.lat,
               longitude: clickCoordinates.lng,
             });

--- a/frontend/src/components/maps/ProjectRasterTiles.tsx
+++ b/frontend/src/components/maps/ProjectRasterTiles.tsx
@@ -8,7 +8,7 @@ import {
   useRasterSymbologyContext,
 } from './RasterSymbologyContext';
 
-import { getMultibandMinMax, getSingleBandMinMax, isSingleBand } from './utils';
+import { getTitilerQueryParams } from './utils';
 import { useMapContext } from './MapContext';
 
 function constructRasterTileUrl(
@@ -26,41 +26,11 @@ function constructRasterTileUrl(
   // parts of path for fetching tiles
   const resourcePath = `/cog/tiles/${tms}/{z}/{x}/{y}@2x`;
   const basePath = window.location.origin;
-
-  const queryParams = new URLSearchParams();
-  queryParams.append('url', cogUrl);
-
-  if (isSingleBand(dataProduct)) {
-    const symbology = symbologySettings as SingleBandSymbology;
-
-    queryParams.append('bidx', '1');
-    queryParams.append('colormap_name', symbology.colorRamp);
-    queryParams.append(
-      'rescale',
-      getSingleBandMinMax(dataProduct.stac_properties, symbology)
-        .flat()
-        .join(',')
-    );
-  } else {
-    const symbology = symbologySettings as MultibandSymbology;
-    queryParams.append('bidx', symbology.red.idx.toString());
-    queryParams.append('bidx', symbology.green.idx.toString());
-    queryParams.append('bidx', symbology.blue.idx.toString());
-    getMultibandMinMax(dataProduct.stac_properties, symbology).forEach(
-      (rescale) => {
-        queryParams.append('rescale', `${rescale}`);
-      }
-    );
-  }
-
-  // add data product id and add signature
-  queryParams.append('dataProductId', dataProduct.id);
-  queryParams.append(
-    'expires',
-    (dataProduct.signature?.expires || 0).toString()
+  const queryParams = getTitilerQueryParams(
+    cogUrl,
+    dataProduct,
+    symbologySettings
   );
-  queryParams.append('secure', dataProduct.signature?.secure || '');
-
   // add query params to base url
   const url = `${basePath}${resourcePath}?${queryParams.toString()}`;
 

--- a/frontend/src/components/maps/ZonalStatistics.tsx
+++ b/frontend/src/components/maps/ZonalStatistics.tsx
@@ -23,8 +23,12 @@ export const ZonalStatistics = ({
 }: {
   dataProduct: DataProduct | null;
   zonalFeature: ZonalFeature | null;
-}) =>
-  dataProduct && isSingleBand(dataProduct) && zonalFeature ? (
+}) => {
+  if (!dataProduct || !isSingleBand(dataProduct) || !zonalFeature) {
+    return null;
+  }
+
+  return (
     <div className="grid grid-flow-row auto-rows-max">
       <span className="text-base font-semibold">Zonal Statistics Result</span>
       <div className="overflow-x-auto rounded-lg border border-gray-200">
@@ -34,14 +38,18 @@ export const ZonalStatistics = ({
             { label: 'Min', value: zonalFeature.properties.min.toFixed(2) },
             { label: 'Max', value: zonalFeature.properties.max.toFixed(2) },
             { label: 'Mean', value: zonalFeature.properties.mean.toFixed(2) },
-            { label: 'Median', value: zonalFeature.properties.median.toFixed(2) },
+            {
+              label: 'Median',
+              value: zonalFeature.properties.median.toFixed(2),
+            },
             { label: 'StDev', value: zonalFeature.properties.std.toFixed(2) },
             { label: 'Count', value: zonalFeature.properties.count.toString() },
           ]}
         />
       </div>
     </div>
-  ) : null;
+  );
+};
 
 export const ZonalStatisticsLoading = ({
   dataProduct,
@@ -63,7 +71,9 @@ export const DownloadZonalStatistic = ({
   zonalFeature: ZonalFeature;
 }) => (
   <div>
-    <span className="text-base font-semibold">Download Zonal Statistic Result</span>
+    <span className="text-base font-semibold">
+      Download Zonal Statistic Result
+    </span>
     <div>
       <button
         type="button"

--- a/frontend/src/components/pages/admin/DashboardMap.tsx
+++ b/frontend/src/components/pages/admin/DashboardMap.tsx
@@ -40,12 +40,14 @@ export default function DashboardMap() {
 
       if (features.length > 0) {
         const clickedFeature = features[0];
+        const clickedFeatureType = clickedFeature.geometry.type.toLowerCase();
 
         if (clickedFeature.geometry.type === 'Point') {
           const coordinates = clickedFeature.geometry.coordinates;
 
           setPopupInfo({
             feature: clickedFeature,
+            feature_type: clickedFeatureType,
             latitude: coordinates[1],
             longitude: coordinates[0],
           });

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -98,6 +98,11 @@ sub vcl_recv {
         set req.url = regsuball(req.url, "[&?](expires|secure)=[^&]*", "");
     }
 
+    # Do not attempt to cache POST requests
+    if (req.method == "POST") {
+        return (pass);
+    }
+
     # Unset authorization related headers
     unset req.http.secure;
     unset req.http.expires;
@@ -125,8 +130,8 @@ sub vcl_recv {
         return (purge);
     }
 
-    # Limit HTTP methods to GET and HEAD
-    if (req.method != "GET" && req.method != "HEAD") {
+    # Limit HTTP methods to GET, HEAD, and POST
+    if (req.method != "GET" && req.method != "HEAD" && req.method != "POST") {
         return (synth(405, "Method Not Allowed"));
     }
 
@@ -149,7 +154,7 @@ sub vcl_recv {
 
 sub vcl_synth {
     if (resp.status == 405) {
-        set resp.http.Allow = "GET, HEAD";
+        set resp.http.Allow = "GET, HEAD, POST";
         set resp.body = "Method not allowed";
         return (deliver);
     }


### PR DESCRIPTION
- Image of data product clipped to clicked on polygon feature displayed at top of feature popup window. Works for both single band and multiband rasters.

- Removed unnecessary call to zonal statistics endpoint when multiband raster is active and a polygon feature is clicked.