### PR TITLE
handle missing crs error when getting data product bbox

### DIFF
--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';
-import { bbox } from '@turf/bbox';
+// import { bbox } from '@turf/bbox';
 
 import ColorBarControl from '../ColorBarControl';
 import CompareMapControl from './CompareMapControl';
@@ -66,12 +66,11 @@ export default function CompareMap() {
     latitude: 40.428655143949925,
     zoom: 8,
   });
-  const [mode, setMode] = useState<Mode>('split-screen');
-
   const [activeMap, setActiveMap] = useState<'left' | 'right'>('left');
-
   const [mapComparisonState, setMapComparisonState] =
     useState<MapComparisonState>(defaultMapComparisonState);
+  const [mode, setMode] = useState<Mode>('split-screen');
+  const [activeProjectBBox, setActiveProjectBBox] = useState<BBox | null>(null);
 
   const { activeProject, flights, mapboxAccessToken } = useMapContext();
 
@@ -205,7 +204,12 @@ export default function CompareMap() {
         reuseMaps={true}
       >
         {/* Display project boundary when project activated */}
-        {activeProject && <ProjectBoundary setViewState={setViewState} />}
+        {activeProject && (
+          <ProjectBoundary
+            setActiveProjectBBox={setActiveProjectBBox}
+            setViewState={setViewState}
+          />
+        )}
 
         <CompareMapControl
           flights={flights}
@@ -219,8 +223,7 @@ export default function CompareMap() {
           symbologyState[selectedLeftDataProduct.id]?.isLoaded && (
             <ProjectRasterTiles
               boundingBox={
-                selectedLeftDataProduct.bbox ||
-                (bbox(activeProject.field) as BBox)
+                selectedLeftDataProduct.bbox || activeProjectBBox || undefined
               }
               dataProduct={selectedLeftDataProduct}
             />
@@ -268,8 +271,7 @@ export default function CompareMap() {
           symbologyState[selectedRightDataProduct.id]?.isLoaded && (
             <ProjectRasterTiles
               boundingBox={
-                selectedRightDataProduct.bbox ||
-                (bbox(activeProject.field) as BBox)
+                selectedRightDataProduct.bbox || activeProjectBBox || undefined
               }
               dataProduct={selectedRightDataProduct}
             />

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -1,11 +1,11 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './HomeMap.css';
-import { Feature } from 'geojson';
+import { Feature, Polygon } from 'geojson';
 import maplibregl from 'maplibre-gl';
 import { useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';
 import { useLocation } from 'react-router-dom';
-import { bbox } from '@turf/bbox';
+// import { bbox } from '@turf/bbox';
 
 import ColorBarControl from './ColorBarControl';
 import GeocoderControl from './GeocoderControl';
@@ -17,7 +17,7 @@ import ProjectPopup from './ProjectPopup';
 import ProjectRasterTiles from './ProjectRasterTiles';
 import ProjectVectorTiles from './ProjectVectorTiles';
 
-import { BBox } from './Maps';
+// import { BBox } from './Maps';
 import { useMapContext } from './MapContext';
 import { MapLayerProps } from './MapLayersContext';
 import {
@@ -31,6 +31,7 @@ import {
 } from './styles/basemapStyles';
 
 import { isSingleBand } from './utils';
+import { BBox } from './Maps';
 
 export type PopupInfoProps = {
   feature: Feature;
@@ -40,6 +41,7 @@ export type PopupInfoProps = {
 };
 
 export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
+  const [activeProjectBBox, setActiveProjectBBox] = useState<BBox | null>(null);
   const [isMapReady, setIsMapReady] = useState(false);
   const [popupInfo, setPopupInfo] = useState<
     PopupInfoProps | { [key: string]: any } | null
@@ -161,7 +163,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       ].symbology as SingleBandSymbology;
       if (activeDataProductSymbology && activeDataProductSymbology.background) {
         const boundingBox =
-          activeDataProduct.bbox || (bbox(activeProject.field) as BBox);
+          activeDataProduct.bbox || activeProjectBBox || undefined;
         return (
           <ProjectRasterTiles
             boundingBox={boundingBox}
@@ -223,9 +225,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       {activeProject && activeDataProduct && (
         <ProjectRasterTiles
           key={activeDataProduct.id}
-          boundingBox={
-            activeDataProduct.bbox || (bbox(activeProject.field) as BBox)
-          }
+          boundingBox={activeDataProduct.bbox || activeProjectBBox || undefined}
           dataProduct={activeDataProduct}
         />
       )}
@@ -246,7 +246,9 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       {activeProject && <ProjectVectorTiles />}
 
       {/* Display project boundary when project activated */}
-      {activeProject && <ProjectBoundary />}
+      {activeProject && (
+        <ProjectBoundary setActiveProjectBBox={setActiveProjectBBox} />
+      )}
 
       {/* Project map layer controls */}
       {activeProject && <LayerControl />}

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -1,6 +1,6 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './HomeMap.css';
-import { Feature, Polygon } from 'geojson';
+import { Feature } from 'geojson';
 import maplibregl from 'maplibre-gl';
 import { useEffect, useMemo, useState } from 'react';
 import Map, { NavigationControl, ScaleControl } from 'react-map-gl/maplibre';

--- a/frontend/src/components/maps/ProjectBoundary.tsx
+++ b/frontend/src/components/maps/ProjectBoundary.tsx
@@ -1,16 +1,23 @@
 import { AxiosResponse } from 'axios';
-import { FeatureCollection, Polygon } from 'geojson';
+import {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Polygon,
+} from 'geojson';
 import { useEffect, useState } from 'react';
 import { Layer, Source, useMap } from 'react-map-gl/maplibre';
+import bbox from '@turf/bbox';
 import center from '@turf/center';
 
 import { projectBoundaryLayer } from './layerProps';
+import { BBox } from './Maps';
 import { useMapContext } from './MapContext';
 
 import api from '../../api';
-import { calculateBoundsFromGeoJSON } from './utils';
 
 type ProjectBoundaryProps = {
+  setActiveProjectBBox?: React.Dispatch<React.SetStateAction<BBox | null>>;
   setViewState?: React.Dispatch<
     React.SetStateAction<{
       longitude: number;
@@ -21,6 +28,7 @@ type ProjectBoundaryProps = {
 };
 
 export default function ProjectBoundary({
+  setActiveProjectBBox,
   setViewState,
 }: ProjectBoundaryProps) {
   const [projectBoundary, setProjectBoundary] =
@@ -44,8 +52,10 @@ export default function ProjectBoundary({
         const geojsonData = await response.data;
         setProjectBoundary(geojsonData);
         // Calculate the bounds of the GeoJSON feature
-        const bounds: [number, number, number, number] =
-          calculateBoundsFromGeoJSON(geojsonData);
+        const bounds = bbox(geojsonData) as BBox;
+        if (setActiveProjectBBox) {
+          setActiveProjectBBox(bounds);
+        }
 
         if (!setViewState) {
           // Fit the map to the bounds

--- a/frontend/src/components/maps/ProjectBoundary.tsx
+++ b/frontend/src/components/maps/ProjectBoundary.tsx
@@ -1,10 +1,5 @@
 import { AxiosResponse } from 'axios';
-import {
-  Feature,
-  FeatureCollection,
-  GeoJsonProperties,
-  Polygon,
-} from 'geojson';
+import { FeatureCollection, Polygon } from 'geojson';
 import { useEffect, useState } from 'react';
 import { Layer, Source, useMap } from 'react-map-gl/maplibre';
 import bbox from '@turf/bbox';

--- a/frontend/src/components/maps/ProjectRasterTiles.tsx
+++ b/frontend/src/components/maps/ProjectRasterTiles.tsx
@@ -68,7 +68,7 @@ export default function ProjectRasterTiles({
       maxzoom={24}
       minzoom={0}
       tileSize={256}
-      bounds={boundingBox}
+      {...(boundingBox ? { bounds: boundingBox } : {})}
     >
       <Layer
         key={`${dataProduct.id}-layer`}


### PR DESCRIPTION
Rasterio was throwing an unhandled exception when running `transform_bounds` on a data product with missing CRS information. This update catches the exception and prevents a bounding box from being set on the data product. The frontend has been updated to include the `bounds` property in the `Source` component only when bounds is defined. As a fallback, if the data product lacks a bounding box, the bounding box of the active project's boundary will be used. If the project's boundary is also unavailable, the `bounds` property is omitted from `Source`.