### PR TITLE
convert inf to nodata value for ndvi and exg and re-generate statistics

### DIFF
--- a/backend/app/utils/Toolbox.py
+++ b/backend/app/utils/Toolbox.py
@@ -73,6 +73,10 @@ class Toolbox:
                 logger.exception(f"{name.upper()} processing tool failed")
                 raise e
             # convert output raster from tool to COG
+            import shutil
+
+            logger.info(f" Copying {tmp_out_raster} to /tmp/test.tif")
+            shutil.copy(tmp_out_raster, "/tmp/test.tif")
             self.convert_result_to_cog(
                 tmp_out_raster, output_dir=str(out_raster.parent)
             )

--- a/backend/app/utils/toolbox/ndvi.py
+++ b/backend/app/utils/toolbox/ndvi.py
@@ -30,7 +30,11 @@ def run(in_raster: str, out_raster: str, params: dict) -> str:
         # update source raster profile to single band and float32
         profile = src.profile
         profile.update(
-            dtype=rasterio.float32, count=1, compress="deflate", BIGTIFF="YES"
+            dtype=rasterio.float32,
+            count=1,
+            compress="deflate",
+            BIGTIFF="YES",
+            nodata=-9999.0,
         )
 
         # use block windows to calculate exg and write to new file
@@ -62,6 +66,9 @@ def run(in_raster: str, out_raster: str, params: dict) -> str:
                 nir = img[nir_band_img_idx, :, :].astype(np.float32)
                 red = img[red_band_img_idx, :, :].astype(np.float32)
                 ndvi = (nir - red) / (nir + red)
+
+                # replace infinite values with NoData
+                ndvi[np.isinf(ndvi)] = profile["nodata"]
 
                 # write ndvi window to out raster
                 dst.write(ndvi, window=window, indexes=1)

--- a/backend/app/utils/toolbox/vari.py
+++ b/backend/app/utils/toolbox/vari.py
@@ -27,7 +27,11 @@ def run(in_raster: str, out_raster: str, params: dict) -> str:
         # update source raster profile to single band and float32
         profile = src.profile
         profile.update(
-            dtype=rasterio.float32, count=1, compress="deflate", BIGTIFF="YES"
+            dtype=rasterio.float32,
+            count=1,
+            compress="deflate",
+            BIGTIFF="YES",
+            nodata=-9999.0,
         )
 
         # use block windows to calculate vari and write to new file
@@ -64,6 +68,9 @@ def run(in_raster: str, out_raster: str, params: dict) -> str:
                 blue = img[blue_band_img_idx, :, :].astype(np.float32)
 
                 vari = (green - red) / (green + red - blue)
+
+                # replace infinite values with NoData
+                vari[np.isinf(vari)] = profile["nodata"]
 
                 # write vari window to out raster
                 dst.write(vari, window=window, indexes=1)

--- a/frontend/src/components/maps/LayerPane/DataProductCard.tsx
+++ b/frontend/src/components/maps/LayerPane/DataProductCard.tsx
@@ -7,7 +7,11 @@ import { DataProduct } from '../../pages/projects/Project';
 import { getDataProductName } from '../../pages/projects/flights/DataProducts/DataProductsTable';
 import { useRasterSymbologyContext } from '../RasterSymbologyContext';
 
-export default function DataProductCard({ dataProduct }: { dataProduct: DataProduct }) {
+export default function DataProductCard({
+  dataProduct,
+}: {
+  dataProduct: DataProduct;
+}) {
   const { activeDataProduct, activeDataProductDispatch } = useMapContext();
 
   const { dispatch } = useRasterSymbologyContext();
@@ -15,7 +19,9 @@ export default function DataProductCard({ dataProduct }: { dataProduct: DataProd
   return (
     <LayerCard
       hover={true}
-      active={activeDataProduct !== null && dataProduct.id === activeDataProduct.id}
+      active={
+        activeDataProduct !== null && dataProduct.id === activeDataProduct.id
+      }
     >
       <div className="text-slate-600 text-sm">
         <div
@@ -63,7 +69,9 @@ export default function DataProductCard({ dataProduct }: { dataProduct: DataProd
           ) : null}
           {dataProduct.data_type !== 'point_cloud' &&
             dataProduct.stac_properties.raster.length === 1 && (
-              <RasterStats stats={dataProduct.stac_properties.raster[0].stats} />
+              <RasterStats
+                stats={dataProduct.stac_properties.raster[0].stats}
+              />
             )}
         </div>
         {activeDataProduct &&

--- a/frontend/src/components/pages/projects/flights/DataProducts/ToolboxModal.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/ToolboxModal.tsx
@@ -41,6 +41,39 @@ const getNumOfBands = (dataProduct: DataProduct) => {
   return dataProduct.stac_properties.raster.length;
 };
 
+const getInitialValues = (dataProduct: DataProduct) => {
+  const eo = dataProduct.stac_properties?.eo ?? [];
+
+  const findBandIndex = (description: string, defaultIndex: number) => {
+    const idx = eo.findIndex(
+      (band) => band.description.toLowerCase() === description
+    );
+    return idx === -1 ? defaultIndex : idx;
+  };
+
+  const redBandIndex = findBandIndex('red', 0);
+  const greenBandIndex = findBandIndex('green', 1);
+  const blueBandIndex = findBandIndex('blue', 2);
+  const nirBandIndex = findBandIndex('nir', 3);
+
+  return {
+    chm: false,
+    exg: false,
+    exgRed: redBandIndex + 1,
+    exgGreen: greenBandIndex + 1,
+    exgBlue: blueBandIndex + 1,
+    ndvi: false,
+    ndviNIR: nirBandIndex + 1,
+    ndviRed: redBandIndex + 1,
+    vari: false,
+    variRed: redBandIndex + 1,
+    variGreen: greenBandIndex + 1,
+    variBlue: blueBandIndex + 1,
+    zonal: false,
+    zonal_layer_id: '',
+  } as ToolboxFields;
+};
+
 export default function ToolboxModal({
   dataProduct,
   tableView = false,
@@ -82,24 +115,7 @@ export default function ToolboxModal({
           <div className="flex flex-col gap-4">
             <DataProductBandForm dataProduct={dataProduct} />
             <Formik
-              initialValues={
-                {
-                  chm: false,
-                  exg: false,
-                  exgRed: 3,
-                  exgGreen: 2,
-                  exgBlue: 1,
-                  ndvi: false,
-                  ndviNIR: 4,
-                  ndviRed: 3,
-                  vari: false,
-                  variRed: 3,
-                  variGreen: 2,
-                  variBlue: 1,
-                  zonal: false,
-                  zonal_layer_id: '',
-                } as ToolboxFields
-              }
+              initialValues={getInitialValues(dataProduct)}
               onSubmit={async (values, actions) => {
                 setStatus(null);
                 if (projectId && flightId && dataProduct.id) {

--- a/frontend/src/components/pages/projects/flights/DataProducts/ToolboxTools.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/ToolboxTools.tsx
@@ -17,7 +17,7 @@ import api from '../../../../../api';
 
 const EXGBandSelection = ({ dataProduct }: { dataProduct: DataProduct }) => {
   const bandOptions = dataProduct.stac_properties.eo.map((band, idx) => ({
-    label: band.name,
+    label: `${band.name} (${band.description})`,
     value: idx + 1,
   }));
 
@@ -35,7 +35,7 @@ const EXGBandSelection = ({ dataProduct }: { dataProduct: DataProduct }) => {
 
 const NDVIBandSelection = ({ dataProduct }: { dataProduct: DataProduct }) => {
   const bandOptions = dataProduct.stac_properties.eo.map((band, idx) => ({
-    label: band.name,
+    label: `${band.name} (${band.description})`,
     value: idx + 1,
   }));
 
@@ -52,7 +52,7 @@ const NDVIBandSelection = ({ dataProduct }: { dataProduct: DataProduct }) => {
 
 const VARIBandSelection = ({ dataProduct }: { dataProduct: DataProduct }) => {
   const bandOptions = dataProduct.stac_properties.eo.map((band, idx) => ({
-    label: band.name,
+    label: `${band.name} (${band.description})`,
     value: idx + 1,
   }));
 


### PR DESCRIPTION
- Converts "inf" and "-inf" to -9999 and sets this value as the NoData value for NDVI and VARI rasters generated from the toolbox
- Store gdal info output from COG in database instead of gdal info output from raster pre-COG conversion
- Try to use band descriptions to set initial band values in ExG, NDVI, and VARI tools (e.g. match "Red" description with red band input) 