### PR TITLE
add case-insensitive sensor normalization

### DIFF
--- a/backend/app/api/api_v1/endpoints/flights.py
+++ b/backend/app/api/api_v1/endpoints/flights.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
 from app.api import deps
+from app.api.utils import normalize_sensor_value
 from app.core.config import settings
 from app.schemas.role import Role
 
@@ -39,6 +40,9 @@ def create_flight(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Pilot must be project member",
         )
+    # Normalize sensor value
+    flight_in.sensor = normalize_sensor_value(flight_in.sensor)
+
     flight = crud.flight.create_with_project(
         db, obj_in=flight_in, project_id=project_id
     )

--- a/backend/app/api/utils.py
+++ b/backend/app/api/utils.py
@@ -322,3 +322,20 @@ def get_signature_for_data_product(data_product_id: UUID4) -> Tuple[str, int]:
     signed_payload, expiration_timestamp = sign_map_tile_payload(payload_str)
 
     return signed_payload, expiration_timestamp
+
+
+def normalize_sensor_value(sensor: str) -> str:
+    """
+    Normalize sensor value to match the expected ENUM case.
+    Returns the normalized value if it matches a valid sensor type (case-insensitive),
+    otherwise returns the original value.
+    """
+    sensor_mapping = {
+        "rgb": "RGB",
+        "multispectral": "Multispectral",
+        "lidar": "LiDAR",
+        "thermal": "Thermal",
+        "hyperspectral": "Hyperspectral",
+        "other": "Other",
+    }
+    return sensor_mapping.get(sensor.lower(), sensor)


### PR DESCRIPTION
Add normalize_sensor_value function to handle mixed-case sensor values in flight creation. This allows the API to accept sensor values in any case (e.g., "rgb", "RGB", "Rgb") and normalize them to match the expected ENUM values in the database.