### PR TITLE
project wgs84 rasters to appropriate UTM zones

### DIFF
--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -407,6 +407,7 @@ def process_data_product_from_external_storage(
                 dtype=data_product.data_type,
                 project_id=project_id,
                 flight_id=flight_id,
+                project_to_utm=True,
             )
 
     # remove token from database

--- a/backend/app/tasks/upload_tasks.py
+++ b/backend/app/tasks/upload_tasks.py
@@ -34,6 +34,7 @@ def upload_geotiff(
     user_id: UUID,
     job_id: UUID,
     data_product_id: UUID,
+    project_to_utm: bool = False,
 ) -> None:
     """Celery task for processing an uploaded GeoTIFF.
 
@@ -43,6 +44,7 @@ def upload_geotiff(
         user_id (UUID): User ID for user that uploaded GeoTIFF.
         job_id (UUID): Job ID for job associated with upload process.
         data_product_id (UUID): Data product ID for uploaded GeoTIFF.
+        project_to_utm (bool): Whether to project the GeoTIFF to UTM.
     """
     in_raster = Path(geotiff_filepath)
 
@@ -79,7 +81,7 @@ def upload_geotiff(
 
     # create get STAC properties and convert to COG (if needed)
     try:
-        ip = ImageProcessor(str(in_raster))
+        ip = ImageProcessor(str(in_raster), project_to_utm=project_to_utm)
         out_raster = ip.run()
         default_symbology = ip.get_default_symbology()
     except Exception:

--- a/backend/app/utils/tusd/post_processing.py
+++ b/backend/app/utils/tusd/post_processing.py
@@ -53,6 +53,7 @@ def process_data_product_uploaded_to_tusd(
     dtype: str,
     project_id: UUID,
     flight_id: UUID,
+    project_to_utm: bool = False,
 ) -> dict:
     """Post-processing method for data product uploaded to tus file server. Creates job
     for converting GeoTIFF (.tif) to Cloud Optimized GeoTIFF or converting point cloud
@@ -130,6 +131,7 @@ def process_data_product_uploaded_to_tusd(
                 user_id,
                 job.id,
                 data_product.id,
+                project_to_utm,
             ),
         )
 


### PR DESCRIPTION
- This change only impacts rasters received through the data products `create_from_ext_storage` endpoint.
- If the received raster data is in the WGS84 (EPSG:4326) coordinate system, it will be projected to the appropriate UTM zone during the COG conversion process.
- If it is not WGS84 (EPSG:4326), it will be left in its current coordinate system.