### PR TITLE
validate data_type to enforce 16 char limit, cast empty string to none for dem_id

### DIFF
--- a/backend/app/schemas/data_product.py
+++ b/backend/app/schemas/data_product.py
@@ -1,14 +1,24 @@
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import AnyHttpUrl, BaseModel, Field, UUID4
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    Field,
+    field_validator,
+    UUID4,
+)
 
 from app.utils.ImageProcessor import STACProperties
+
+data_type_char_limit_rule = Field(
+    None, title="Name of data product's new data type", min_length=1, max_length=16
+)
 
 
 # shared properties
 class DataProductBase(BaseModel):
-    data_type: Optional[str] = None
+    data_type: Optional[str] = data_type_char_limit_rule
     filepath: Optional[str] = None
     original_filename: Optional[str] = None
     stac_properties: Optional[STACProperties] = None
@@ -30,7 +40,7 @@ class DataProductUpdate(DataProductBase):
 
 
 class DataProductUpdateDataType(BaseModel):
-    data_type: str = Field(title="Name of data product's new data type", max_length=16)
+    data_type: Optional[str] = data_type_char_limit_rule
 
 
 # properties shared by models stored in DB
@@ -98,3 +108,11 @@ class ProcessingRequest(BaseModel):
     variBlue: int
     zonal: bool
     zonal_layer_id: str
+
+    @field_validator("dem_id", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v: Optional[UUID4]) -> Optional[UUID4]:
+        """Return None if the string is empty, otherwise return the UUID4."""
+        if v == "":
+            return None
+        return v

--- a/frontend/src/components/pages/projects/flights/DataProducts/DataProductUploadModal.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/DataProductUploadModal.tsx
@@ -105,7 +105,9 @@ export default function DataProductUploadModal({
                 )}
 
                 {dtype !== 'other' ||
-                (dtype === 'other' && dtypeOther.length > 1) ? (
+                (dtype === 'other' &&
+                  dtypeOther.length > 1 &&
+                  dtypeOther.length <= 16) ? (
                   <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
                     <DataProductUpload
                       info={{
@@ -122,7 +124,9 @@ export default function DataProductUploadModal({
                   </div>
                 ) : dtypeOtherTouched ? (
                   <span className="px-4 pb-4 pt-5 sm:p-6 sm:pb-4 text-red-600">
-                    Data type must be at least 2 characters in length
+                    {dtypeOther.length <= 1
+                      ? 'Data type must be at least 2 characters in length'
+                      : 'Data type must not exceed 16 characters in length'}
                   </span>
                 ) : null}
 

--- a/frontend/src/components/pages/projects/flights/DataProducts/DataTypeRadioInput.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/DataTypeRadioInput.tsx
@@ -159,6 +159,7 @@ export default function DataTypeRadioInput({
               placeholder="Enter other data type (e.g., NDVI)"
               className="w-full rounded-md border-gray-200 px-4 py-2.5 pe-10 shadow sm:text-sm"
               value={dtypeOther}
+              maxLength={16}
               onChange={updateDtypeOther}
               onBlur={() => setDtypeOtherTouched(true)}
               disabled={disabled}


### PR DESCRIPTION
- Enforced a 16-character limit on the data_type field to match the database constraint. Validation has been updated in both the web application and backend.
- Fixed issue where an empty string "" for optional dem_id caused a validation error; empty strings are now converted to None.