### PR TITLE
add build orthomosaic option blending mode

### DIFF
--- a/backend/app/schemas/raw_data.py
+++ b/backend/app/schemas/raw_data.py
@@ -75,6 +75,7 @@ class RawDataMetadata(BaseModel):
 class MetashapeQueryParams(BaseModel):
     alignQuality: Literal["low", "medium", "high"]
     backend: Literal["metashape"]
+    blendingMode: Literal["average", "disabled", "min", "max", "mosaic"]
     buildDepthQuality: Literal["low", "medium", "high"]
     camera: Literal["single", "multi"]
     disclaimer: bool

--- a/frontend/src/components/pages/projects/flights/RawData/RawData.types.ts
+++ b/frontend/src/components/pages/projects/flights/RawData/RawData.types.ts
@@ -1,9 +1,11 @@
+type BlendingModeType = 'average' | 'disabled' | 'min' | 'max' | 'mosaic';
 type CameraType = 'single' | 'multi';
 type QualityType = 'low' | 'medium' | 'high';
 
 export interface MetashapeSettings {
-  backend: 'metashape';
   alignQuality: QualityType;
+  backend: 'metashape';
+  blendingMode: BlendingModeType;
   buildDepthQuality: QualityType;
   camera: CameraType;
   disclaimer: boolean;

--- a/frontend/src/components/pages/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/MetashapeForm.tsx
+++ b/frontend/src/components/pages/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/MetashapeForm.tsx
@@ -41,7 +41,7 @@ export default function MetashapeForm({
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="flex gap-8">
             {/* Camera Options */}
-            <fieldset className="border border-solid border-slate-300 p-3">
+            <fieldset className="border border-solid border-slate-300 p-3 min-w-max">
               <legend className="block text-gray-600 font-bold pt-2 pb-1">
                 Camera Options
               </legend>
@@ -123,47 +123,95 @@ export default function MetashapeForm({
                 />
               </div>
             </fieldset>
-            {/* Build Point Cloud */}
-            <fieldset className="border border-solid border-slate-300 p-3">
-              <legend className="block text-gray-600 font-bold pt-2 pb-1">
-                Build Point Cloud
-              </legend>
-              {/* Quality */}
-              <div className="flex flex-col gap-1.5">
-                <span className="text-sm font-medium">Quality</span>
-                <div>
-                  <RadioInput
-                    fieldName="buildDepthQuality"
-                    inputId="buildDepthQualityLow"
-                    label="Low"
-                    value="low"
-                  />
+            {/* Point Cloud and Orthomosaic Column */}
+            <div className="space-y-4">
+              {/* Build Point Cloud */}
+              <fieldset className="border border-solid border-slate-300 p-3">
+                <legend className="block text-gray-600 font-bold pt-2 pb-1">
+                  Build Point Cloud
+                </legend>
+                {/* Quality */}
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-sm font-medium">Quality</span>
+                  <div className="flex gap-4">
+                    <RadioInput
+                      fieldName="buildDepthQuality"
+                      inputId="buildDepthQualityLow"
+                      label="Low"
+                      value="low"
+                    />
+                    <RadioInput
+                      fieldName="buildDepthQuality"
+                      inputId="buildDepthQualityMedium"
+                      label="Medium"
+                      value="medium"
+                    />
+                    <RadioInput
+                      fieldName="buildDepthQuality"
+                      inputId="buildDepthQualityHigh"
+                      label="High"
+                      value="high"
+                    />
+                  </div>
+                  {errors &&
+                    errors.buildDepthQuality &&
+                    typeof errors.buildDepthQuality.message === 'string' && (
+                      <p className="text-sm text-red-500">
+                        {errors.buildDepthQuality.message}
+                      </p>
+                    )}
                 </div>
-                <div>
-                  <RadioInput
-                    fieldName="buildDepthQuality"
-                    inputId="buildDepthQualityMedium"
-                    label="Medium"
-                    value="medium"
-                  />
+              </fieldset>
+              {/* Build Orthomosaic */}
+              <fieldset className="border border-solid border-slate-300 p-3">
+                <legend className="block text-gray-600 font-bold pt-2 pb-1">
+                  Build Orthomosaic
+                </legend>
+                {/* Blending Mode */}
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-sm font-medium">Blending Mode</span>
+                  <div className="flex gap-4 flex-wrap">
+                    <RadioInput
+                      fieldName="blendingMode"
+                      inputId="blendingModeAverage"
+                      label="Average"
+                      value="average"
+                    />
+                    <RadioInput
+                      fieldName="blendingMode"
+                      inputId="blendingModeDisabled"
+                      label="Disabled"
+                      value="disabled"
+                    />
+                    <RadioInput
+                      fieldName="blendingMode"
+                      inputId="blendingModeMin"
+                      label="Min"
+                      value="min"
+                    />
+                    <RadioInput
+                      fieldName="blendingMode"
+                      inputId="blendingModeMax"
+                      label="Max"
+                      value="max"
+                    />
+                    <RadioInput
+                      fieldName="blendingMode"
+                      inputId="blendingModeMosaic"
+                      label="Mosaic"
+                      value="mosaic"
+                    />
+                  </div>
+                  {errors &&
+                    errors.blendingMode &&
+                    typeof errors.blendingMode.message === 'string' && (
+                      <p className="text-sm text-red-500">
+                        {errors.blendingMode.message}
+                      </p>
+                    )}
                 </div>
-                <div>
-                  <RadioInput
-                    fieldName="buildDepthQuality"
-                    inputId="buildDepthQualityHigh"
-                    label="High"
-                    value="high"
-                  />
-                </div>
-                {errors &&
-                  errors.buildDepthQuality &&
-                  typeof errors.buildDepthQuality.message === 'string' && (
-                    <p className="text-sm text-red-500">
-                      {errors.buildDepthQuality.message}
-                    </p>
-                  )}
-              </div>
-            </fieldset>
+              </fieldset>
+            </div>
           </div>
           <div className="mt-4">
             <CheckboxInput fieldName="disclaimer" label="Check to proceed" />

--- a/frontend/src/components/pages/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/defaultValues.ts
+++ b/frontend/src/components/pages/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/defaultValues.ts
@@ -1,8 +1,9 @@
 import { MetashapeSettings } from '../../RawData.types';
 
 const defaultValues: MetashapeSettings = {
-  backend: 'metashape',
   alignQuality: 'medium',
+  backend: 'metashape',
+  blendingMode: 'mosaic',
   buildDepthQuality: 'medium',
   camera: 'single',
   disclaimer: false,

--- a/frontend/src/components/pages/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/validationSchema.ts
+++ b/frontend/src/components/pages/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/validationSchema.ts
@@ -12,6 +12,13 @@ const schema = yup.object({
     .string()
     .oneOf(['metashape'], 'Backend must be "metashape"')
     .required('Backend is required'),
+  blendingMode: yup
+    .string()
+    .oneOf(
+      ['average', 'disabled', 'min', 'max', 'mosaic'],
+      'Blending mode must be "average", "disabled", "min", "max", or "mosaic"'
+    )
+    .required('Blending mode is required'),
   buildDepthQuality: yup
     .string()
     .oneOf(


### PR DESCRIPTION
## Summary

This update introduces an option to configure the **Blending Mode** when generating orthomosaics from raw image data using Metashape (requires a configured Metashape backend). The Blending Mode determines how overlapping image areas are combined during orthomosaic generation.

By default, the mode is set to `mosaic`. Users can now choose from the following additional options:

- `average`
- `min`
- `max`
- `disabled`

This allows for greater flexibility and control over the appearance and quality of the final orthomosaic.
