### PR TITLE
fix missing cluster markers by switching to OpenMapTiles compatible fonts and add missing config.json

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 # Generate a runtime configuration file with the environment variable
-echo "{\"mapboxAccessToken\": \"${VITE_MAPBOX_ACCESS_TOKEN}\"}" > /usr/share/nginx/html/config.json
+CONFIG_CONTENT="{\"mapboxAccessToken\": \"${VITE_MAPBOX_ACCESS_TOKEN}\"}"
+
+# Write to public folder (for development yarn server)
+echo "$CONFIG_CONTENT" > /app/public/config.json
+
+# Write to nginx html folder (for production) if it exists
+if [ -d "/usr/share/nginx/html" ]; then
+    echo "$CONFIG_CONTENT" > /usr/share/nginx/html/config.json
+fi
 
 exec "$@"

--- a/frontend/frontend.dockerfile
+++ b/frontend/frontend.dockerfile
@@ -8,4 +8,12 @@ RUN yarn install
 
 COPY . .
 
+# Create the config file in the public directory where yarn dev server can serve it
+RUN touch /app/public/config.json
+
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 CMD ["yarn", "run", "dev", "--host", "0.0.0.0", "--port", "8080"]

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,0 +1,1 @@
+{"mapboxAccessToken": ""}

--- a/frontend/src/components/maps/layerProps.tsx
+++ b/frontend/src/components/maps/layerProps.tsx
@@ -49,7 +49,7 @@ export const clusterCountLayer: LayerProps = {
   filter: ['has', 'point_count'],
   layout: {
     'text-field': '{point_count_abbreviated}',
-    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+    'text-font': ['Open Sans Semibold'],
     'text-size': ['step', ['get', 'point_count'], 12, 25, 16, 50, 22],
   },
   paint: {

--- a/frontend/src/components/pages/projects/iForester/layerProps.tsx
+++ b/frontend/src/components/pages/projects/iForester/layerProps.tsx
@@ -47,7 +47,7 @@ export const clusterCountLayer: LayerProps = {
   filter: ['has', 'point_count'],
   layout: {
     'text-field': '{point_count_abbreviated}',
-    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+    'text-font': ['Open Sans Semibold'],
     'text-size': ['step', ['get', 'point_count'], 12, 25, 16, 50, 22],
   },
   paint: {


### PR DESCRIPTION
## Problem
Cluster count labels were not displaying on maps due to two issues:
1. **Font 404 errors**: The application was requesting font combinations (`DIN Offc Pro Medium,Arial Unicode MS Bold`) that are not available on the OpenMapTiles font service at `https://fonts.openmaptiles.org/`
2. **Missing config.json**: Development frontend server was missing the required `config.json` file

## Solution
### Font Stack Fix
- Changed `text-font` configuration in cluster layers from unavailable fonts to `['Open Sans Semibold']`
- `Open Sans Semibold` is officially supported by the OpenMapTiles font service
- Updated both main map cluster layers and iForester project cluster layers

### Development Configuration Fix  
- Added missing `frontend/public/config.json` file required by the development server