### PR TITLE
require SECRET_KEY and TILE_SIGNING_SECRET_KEY configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ EXTERNAL_STORAGE=
 # directory should be owned by same user as tusd container (defaults to 1000:1000)
 TUSD_STORAGE=
 # Secret key used for signing pg_tileserv and titiler requests
-TILE_SIGNING_SECRET_KEY=
+TILE_SIGNING_SECRET_KEY=CHANGEME-tile-signing-key-32-chars-min

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ These aspects make D2S a powerful tool for researchers looking to manage, share,
 
 3. Open `backend.env` in a text editor. Below is a list of the environment variables that can be set inside `backend.env`. You may use the default values or change them as needed.
 
-   If you do not assign a value to `SECRET_KEY`, a key will automatically be generated for you. Note to developers: A new key will be generated each time a change is made to the backend code. This will invalidate any JWT tokens signed with the previous key. To prevent this behavior, set a secret key in `backend.env`.
+   You must provide a value for `SECRET_KEY` in your `backend.env` file. Use a cryptographically secure random string of at least 32 characters.
 
    **Environment variables**
 

--- a/backend.example.env
+++ b/backend.example.env
@@ -27,7 +27,7 @@ RABBITMQ_HOST=
 RABBITMQ_USERNAME=
 RABBITMQ_PASSWORD=
 
-SECRET_KEY=
+SECRET_KEY=CHANGEME-your-super-secret-key-32-chars-min
 
 # Setting this value to 0 will remove the "Secure" attribute from the HttpOnly cookie,
 # allowing it to be sent over non-HTTPS connections. Only make this change if you fully

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,14 +12,19 @@ class Settings(BaseSettings):
     ENV: str = "dev"
     API_V1_STR: str = "/api/v1"
 
-    SECRET_KEY: str = generate_secret_key()
+    SECRET_KEY: str = ""
     # Secret key used for signing pg_tileserv and titiler requests
-    TILE_SIGNING_SECRET_KEY: str = generate_secret_key()
+    TILE_SIGNING_SECRET_KEY: str = ""
 
-    @field_validator("SECRET_KEY", mode="before")
-    def generate_secret_key(cls, v: str | None) -> str:
-        if not v:
-            return secrets.token_urlsafe(32)
+    @field_validator("SECRET_KEY", "TILE_SIGNING_SECRET_KEY", mode="before")
+    def validate_secret_keys(cls, v: str | None, info: ValidationInfo) -> str:
+        field_name = info.field_name
+        if not v or v.strip() == "":
+            raise ValueError(
+                f"{field_name} environment variable must be set and cannot be empty"
+            )
+        if len(v) < 32:
+            raise ValueError(f"{field_name} must be at least 32 characters long")
         return v
 
     # 60 minutes * 24 hours * 8 days = 8 days


### PR DESCRIPTION
## Problem
The current auto-generation of `SECRET_KEY` and `TILE_SIGNING_SECRET_KEY` causes user confusion and authentication failures:

- Keys regenerate on every application restart/code change
- JWT tokens become invalid unexpectedly  
- Users receive 403 errors without understanding why
- Tile service authentication breaks intermittently

## Solution
Make both secret keys **required configuration** with proper validation:

- ✅ **Fail fast on startup** if keys are missing or too short
- ✅ **Enforce 32+ character minimum** for security best practices  
- ✅ **Clear error messages** guide users to fix configuration
- ✅ **Updated documentation** clarifies requirements
- ✅ **Better example values** show proper format

## Changes
- Modified `backend/app/core/config.py` to validate both secret keys
- Updated `backend.example.env` with clear placeholder values
- Updated README to emphasize SECRET_KEY requirement
- Removed auto-generation logic to prevent confusion

## Breaking Change ⚠️
**Existing deployments** must add both keys to their `backend.env`:
```bash
SECRET_KEY=your-secure-random-key-32-chars-minimum
TILE_SIGNING_SECRET_KEY=your-tile-signing-key-32-chars-minimum
```

## Impact
- **One-time setup**: Users must provide proper secret keys
- **Better security**: No more weak auto-generated keys
- **Predictable behavior**: Keys remain stable across restarts
- **Clear errors**: Immediate feedback when configuration is wrong

Users will need to log out/in once after the update to refresh JWT tokens, but passwords remain unaffected.