### PR TITLE
update docker-compose to provide TILE_SIGNING_SECRET_KEY to all backend services

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -47,7 +47,10 @@ services:
     restart: always
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB"]
+        [
+          "CMD-SHELL",
+          "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -86,11 +89,12 @@ services:
     depends_on:
       - redis
       - db
+    environment:
+      - CELERY_WORKERS=4
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
-    environment:
-      - CELERY_WORKERS=4
 
   celery_beat:
     image: d2s-api:dev
@@ -104,6 +108,8 @@ services:
     depends_on:
       - redis
       - db
+    environment:
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
@@ -120,12 +126,14 @@ services:
     depends_on:
       - redis
       - db
+    environment:
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
 
   proxy:
-    build: 
+    build:
       context: ./nginx
       dockerfile: nginx.dockerfile
       args:

--- a/docker-compose.prod.example.yml
+++ b/docker-compose.prod.example.yml
@@ -78,7 +78,10 @@ services:
       - /var/run/postgresql
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB"]
+        [
+          "CMD-SHELL",
+          "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -146,11 +149,12 @@ services:
         window: 120s
     security_opt:
       - no-new-privileges=true
+    environment:
+      - CELERY_WORKERS=4
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
-    environment:
-      - CELERY_WORKERS=4
 
   celery_beat:
     image: d2s-api:latest
@@ -180,12 +184,14 @@ services:
         window: 120s
     security_opt:
       - no-new-privileges=true
+    environment:
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
 
   proxy:
-    build: 
+    build:
       context: ./nginx
       dockerfile: nginx.dockerfile
       args:
@@ -288,7 +294,15 @@ services:
       - CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif,.TIF,.tiff
       - CPL_VSIL_CURL_CACHE_SIZE=200000000
     healthcheck:
-      test: ["CMD", "curl", "-s", "-o", "/dev/null", "http://localhost:8888/healthz"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-s",
+          "-o",
+          "/dev/null",
+          "http://localhost:8888/healthz",
+        ]
       interval: 1m30s
       timeout: 30s
       retries: 5
@@ -296,10 +310,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
+          cpus: "2"
           memory: 4G
         reservations:
-          cpus: '1'
+          cpus: "1"
           memory: 2G
       restart_policy:
         condition: on-failure

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,7 +78,10 @@ services:
       - /var/run/postgresql
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB"]
+        [
+          "CMD-SHELL",
+          "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -146,11 +149,12 @@ services:
         window: 120s
     security_opt:
       - no-new-privileges=true
+    environment:
+      - CELERY_WORKERS=4
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
-    environment:
-      - CELERY_WORKERS=4
 
   celery_beat:
     image: d2s-api:latest
@@ -180,12 +184,14 @@ services:
         window: 120s
     security_opt:
       - no-new-privileges=true
+    environment:
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
 
   proxy:
-    build: 
+    build:
       context: ./nginx
       dockerfile: nginx.dockerfile
       args:
@@ -288,7 +294,15 @@ services:
       - CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif,.TIF,.tiff
       - CPL_VSIL_CURL_CACHE_SIZE=200000000
     healthcheck:
-      test: ["CMD", "curl", "-s", "-o", "/dev/null", "http://localhost:8888/healthz"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-s",
+          "-o",
+          "/dev/null",
+          "http://localhost:8888/healthz",
+        ]
       interval: 1m30s
       timeout: 30s
       retries: 5
@@ -296,10 +310,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
+          cpus: "2"
           memory: 4G
         reservations:
-          cpus: '1'
+          cpus: "1"
           memory: 2G
       restart_policy:
         condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,10 @@ services:
     restart: always
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB"]
+        [
+          "CMD-SHELL",
+          "pg_isready --username=$$POSTGRES_USER --dbname=$$POSTGRES_DB",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -91,6 +94,7 @@ services:
       - db.env
     environment:
       - CELERY_WORKERS=4
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
 
   celery_beat:
     image: d2s-api:dev
@@ -107,6 +111,8 @@ services:
     env_file:
       - backend.env
       - db.env
+    environment:
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
 
   flower:
     image: d2s-api:dev
@@ -120,12 +126,14 @@ services:
     depends_on:
       - redis
       - db
+    environment:
+      - TILE_SIGNING_SECRET_KEY=${TILE_SIGNING_SECRET_KEY}
     env_file:
       - backend.env
       - db.env
 
   proxy:
-    build: 
+    build:
       context: ./nginx
       dockerfile: nginx.dockerfile
       args:


### PR DESCRIPTION
## Problem
After implementing required secret key validation in #209, backend services (celery_worker, celery_beat, flower) fail to start because they don't have access to the `TILE_SIGNING_SECRET_KEY` environment variable that is now required by the configuration validation.

These services use the same backend image and configuration validation, but previously didn't need the tile signing key since they don't directly handle tile requests.

## Solution
Update docker-compose configurations to provide `TILE_SIGNING_SECRET_KEY` to all backend-based services:

- ✅ **Add environment variable** to celery_worker, celery_beat, and flower containers
- ✅ **Reference from main .env** to maintain single source of truth
- ✅ **Avoid configuration duplication** across environment files
- ✅ **Update both dev and prod** docker-compose examples

## Changes
- Updated `docker-compose.example.yml` to include `TILE_SIGNING_SECRET_KEY` for:
  - celery_worker
  - celery_beat  
  - flower
- Updated `docker-compose.prod.example.yml` with the same additions
- Maintained existing pattern of referencing `${TILE_SIGNING_SECRET_KEY}` from main environment

## Architectural Decision
While these services don't directly use tile signing functionality, they share the same backend image and configuration validation. The alternatives considered were:

1. **Conditional validation** - Complex and error-prone
2. **Separate environment files** - Would require duplication
3. **Current approach** - Simple, consistent, maintainable

The current approach follows the established pattern where all backend services share the same environment configuration, making it easy to deploy and maintain.

## Impact
- **Fixes startup failures** for celery and flower services
- **Maintains security boundaries** (varnish still gets only what it needs)
- **No configuration duplication** (single source of truth preserved)
- **Consistent deployment pattern** across all backend services