### PR TITLE
fix STAC configuration not working in production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ These aspects make D2S a powerful tool for researchers looking to manage, share,
 
 - `VITE_MAPBOX_ACCESS_TOKEN`: Mapbox access token for satellite imagery (optional).
 - `VITE_MAPTILER_API_KEY`: Maptiler API key for OSM labels (optional).
-- `VITE_STAC_ENABLED`: Set to `true` to enable STAC feature.
 
 3. Open `backend.env` in a text editor. Below is a list of the environment variables that can be set inside `backend.env`. You may use the default values or change them as needed.
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -12,6 +12,8 @@ services:
     restart: always
     depends_on:
       - backend
+    environment:
+      - VITE_STAC_ENABLED=false
     env_file:
       - frontend.env
 

--- a/docker-compose.prod.example.yml
+++ b/docker-compose.prod.example.yml
@@ -1,6 +1,8 @@
 services:
   frontend:
     build:
+      args:
+        - VITE_STAC_ENABLED=false
       context: ./frontend
       dockerfile: frontend.prod.dockerfile
     image: d2s-app:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,8 @@
 services:
   frontend:
     build:
+      args:
+        - VITE_STAC_ENABLED=true
       context: ./frontend
       dockerfile: frontend.prod.dockerfile
     image: d2s-app:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     restart: always
     depends_on:
       - backend
+    environment:
+      - VITE_STAC_ENABLED=true
     env_file:
       - frontend.env
 

--- a/frontend/frontend.prod.dockerfile
+++ b/frontend/frontend.prod.dockerfile
@@ -1,5 +1,11 @@
 FROM node:18-bullseye-slim AS build-stage
 
+# Accept build arguments
+ARG VITE_STAC_ENABLED
+
+# Set environment variables so Vite can use them during build
+ENV VITE_STAC_ENABLED=$VITE_STAC_ENABLED
+
 WORKDIR /app/
 
 COPY ./package.json ./yarn.lock ./


### PR DESCRIPTION
## Issue
STAC functionality was not working in production builds because `VITE_STAC_ENABLED` was only defined in `frontend.env`, which is not available during the `yarn build` process in the Dockerfile.

## Root Cause
- `VITE_STAC_ENABLED=true` was only in `frontend.env`
- Production Dockerfile runs `yarn build` which needs environment variables at **build time**
- `frontend.env` is not loaded during the Docker build process
- Result: Vite treated `import.meta.env.VITE_STAC_ENABLED` as undefined, disabling STAC routes

## Fix
- **Production**: Added `VITE_STAC_ENABLED=true` as build arg in `docker-compose.prod.yml`
- **Production**: Added `ARG VITE_STAC_ENABLED` + `ENV` support to `frontend.prod.dockerfile`
- **Development**: Moved `VITE_STAC_ENABLED` from `frontend.env` to `docker-compose.yml` environment section for consistency
- **Cleanup**: Removed `VITE_STAC_ENABLED` from `frontend.env`