### PR TITLE
enhance STAC generation with flight names, job deduplication, and improved parameter handling

### DIFF
--- a/backend/app/api/api_v1/endpoints/projects.py
+++ b/backend/app/api/api_v1/endpoints/projects.py
@@ -161,14 +161,7 @@ def get_cached_stac_metadata(
 @router.post("/{project_id}/generate-stac-preview")
 def generate_stac_preview_async(
     project_id: UUID,
-    sci_doi: Optional[str] = Query(None, description="DOI for the scientific citation"),
-    sci_citation: Optional[str] = Query(
-        None, description="Citation text for the scientific citation"
-    ),
-    license: Optional[str] = Query(None, description="License for the dataset"),
-    custom_titles: Optional[str] = Query(
-        None, description="JSON string of custom titles for STAC items"
-    ),
+    metadata_request: schemas.STACMetadataRequest,
     project: models.Project = Depends(deps.can_read_write_delete_project),
     current_user: models.User = Depends(deps.get_current_approved_user),
     db: Session = Depends(deps.get_db),
@@ -211,23 +204,14 @@ def generate_stac_preview_async(
             "task_id": str(existing_jobs[0].id),  # Return the existing job ID
         }
 
-    # Parse custom titles from JSON string if provided
-    parsed_custom_titles = None
-    if custom_titles:
-        try:
-            parsed_custom_titles = json.loads(custom_titles)
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning(f"Failed to parse custom_titles JSON: {e}")
-            parsed_custom_titles = None
-
     # Start the background task
     task = generate_stac_preview.apply_async(
         args=[str(project_id)],
         kwargs={
-            "sci_doi": sci_doi,
-            "sci_citation": sci_citation,
-            "license": license,
-            "custom_titles": parsed_custom_titles,
+            "sci_doi": metadata_request.sci_doi,
+            "sci_citation": metadata_request.sci_citation,
+            "license": metadata_request.license,
+            "custom_titles": metadata_request.custom_titles,
         },
     )
 
@@ -241,14 +225,7 @@ def generate_stac_preview_async(
 @router.put("/{project_id}/publish-stac-async")
 def publish_project_to_stac_catalog_async(
     project_id: UUID,
-    sci_doi: Optional[str] = Query(None, description="DOI for the scientific citation"),
-    sci_citation: Optional[str] = Query(
-        None, description="Citation text for the scientific citation"
-    ),
-    license: Optional[str] = Query(None, description="License for the dataset"),
-    custom_titles: Optional[str] = Query(
-        None, description="JSON string of custom titles for STAC items"
-    ),
+    metadata_request: schemas.STACMetadataRequest,
     project: models.Project = Depends(deps.can_read_write_delete_project),
     current_user: models.User = Depends(deps.get_current_approved_user),
     db: Session = Depends(deps.get_db),
@@ -291,23 +268,14 @@ def publish_project_to_stac_catalog_async(
             "task_id": str(existing_jobs[0].id),  # Return the existing job ID
         }
 
-    # Parse custom titles from JSON string if provided
-    parsed_custom_titles = None
-    if custom_titles:
-        try:
-            parsed_custom_titles = json.loads(custom_titles)
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning(f"Failed to parse custom_titles JSON: {e}")
-            parsed_custom_titles = None
-
     # Start the background task
     task = publish_stac_catalog.apply_async(
         args=[str(project_id)],
         kwargs={
-            "sci_doi": sci_doi,
-            "sci_citation": sci_citation,
-            "license": license,
-            "custom_titles": parsed_custom_titles,
+            "sci_doi": metadata_request.sci_doi,
+            "sci_citation": metadata_request.sci_citation,
+            "license": metadata_request.license,
+            "custom_titles": metadata_request.custom_titles,
         },
     )
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -38,7 +38,14 @@ from .shortened_url import (
     ShortenedUrlApiResponse,
 )
 from .single_use_token import SingleUseToken, SingleUseTokenCreate
-from .stac import STACReport, ItemStatus, STACError, STACPreview, STACResponse
+from .stac import (
+    STACReport,
+    ItemStatus,
+    STACError,
+    STACPreview,
+    STACResponse,
+    STACMetadataRequest,
+)
 from .team import Team, TeamCreate, TeamUpdate
 from .team_extension import TeamExtension, TeamExtensionCreate, TeamExtensionUpdate
 from .team_member import TeamMember, TeamMemberCreate, TeamMemberUpdate

--- a/backend/app/schemas/stac.py
+++ b/backend/app/schemas/stac.py
@@ -34,4 +34,13 @@ class STACPreview(BaseModel):
     failed_items: Optional[List[ItemStatus]] = None
 
 
+class STACMetadataRequest(BaseModel):
+    """Request body for STAC operations (preview generation and catalog publishing)."""
+
+    sci_doi: Optional[str] = None
+    sci_citation: Optional[str] = None
+    license: Optional[str] = None
+    custom_titles: Optional[Dict[str, str]] = None
+
+
 STACResponse = Union[STACReport, STACPreview]

--- a/backend/app/tasks/stac_tasks.py
+++ b/backend/app/tasks/stac_tasks.py
@@ -77,7 +77,7 @@ def generate_stac_preview(
 
     # Create job for tracking
     job = JobManager(job_name="stac_preview")
-    job.start()
+    job.update(status=Status.INPROGRESS, extra={"project_id": str(project_uuid)})
 
     try:
         # Generate STAC collection and items
@@ -154,7 +154,7 @@ def publish_stac_catalog(
 
     # Create job for tracking
     job = JobManager(job_name="stac_publish")
-    job.start()
+    job.update(status=Status.INPROGRESS, extra={"project_id": str(project_uuid)})
 
     try:
         # Generate STAC collection and items
@@ -281,7 +281,7 @@ def generate_stac_preview_task(
 
     # Create job for tracking
     job = JobManager(job_name="stac_preview")
-    job.start()
+    job.update(status=Status.INPROGRESS, extra={"project_id": str(project_uuid)})
 
     try:
         # Generate STAC collection and items
@@ -365,7 +365,7 @@ def publish_stac_catalog_task(
 
     # Create job for tracking
     job = JobManager(job_name="stac_publish")
-    job.start()
+    job.update(status=Status.INPROGRESS, extra={"project_id": str(project_uuid)})
 
     try:
         # Generate STAC collection and items

--- a/backend/app/tests/utils/test_stac.py
+++ b/backend/app/tests/utils/test_stac.py
@@ -333,7 +333,8 @@ def test_stac_generator_no_flights(db: Session) -> None:
 
     # Try to create STACGenerator
     with pytest.raises(
-        ValueError, match="Project must have at least one flight to publish"
+        ValueError,
+        match="Project must have at least one flight with a data product to publish",
     ):
         STACGenerator(db=db, project_id=project.id)
 

--- a/backend/app/tests/utils/test_stac.py
+++ b/backend/app/tests/utils/test_stac.py
@@ -177,13 +177,19 @@ def test_stac_generator(db: Session) -> None:
     # Create new project
     project = create_project(db)
 
-    # Add sample data product to project
-    data_product = SampleDataProduct(db, project=project)
+    # Create flight with a name and data product
+    flight_with_name = create_flight(db, project_id=project.id, name="Test Flight Name")
+    data_product_with_name = SampleDataProduct(
+        db, project=project, flight=flight_with_name
+    )
 
-    # Get flight from data product
-    flight = data_product.flight
+    # Create flight without a name and data product
+    flight_without_name = create_flight(db, project_id=project.id, name=None)
+    data_product_without_name = SampleDataProduct(
+        db, project=project, flight=flight_without_name
+    )
 
-    # Generate STAC Item
+    # Generate STAC Items
     sg = STACGenerator(db, project_id=project.id)
 
     # Get STAC generated STAC items
@@ -192,18 +198,32 @@ def test_stac_generator(db: Session) -> None:
     # Get STAC generated STAC collection
     stac_collection = sg.collection
 
-    # Assert that the STAC item was created
-    assert len(stac_items) == 1
-    assert stac_items[0].id == str(data_product.obj.id)
+    # Assert that both STAC items were created
+    assert len(stac_items) == 2
 
-    # Validate STAC Item
-    assert validate(stac_items[0])
-
-    # Validate STAC Collection
+    # Validate STAC Items and Collection
+    for item in stac_items:
+        assert validate(item)
     assert validate(stac_collection)
 
-    # Confirm flight id is present in STAC Item
-    assert stac_items[0].properties["flight_details"]["flight_id"] == str(flight.id)
+    # Test flight_name handling for each item
+    for item in stac_items:
+        flight_details = item.properties["flight_details"]
+
+        if item.id == str(data_product_with_name.obj.id):
+            # Flight with name should include flight_name
+            assert "flight_name" in flight_details
+            assert flight_details["flight_name"] == "Test Flight Name"
+            assert flight_details["flight_id"] == str(flight_with_name.id)
+        elif item.id == str(data_product_without_name.obj.id):
+            # Flight without name should NOT include flight_name
+            assert "flight_name" not in flight_details
+            assert flight_details["flight_id"] == str(flight_without_name.id)
+
+        # Verify other expected fields are present in both cases
+        assert "acquisition_date" in flight_details
+        assert "platform" in flight_details
+        assert "sensor" in flight_details
 
 
 def test_fetch_public_items(stac_collection_published: STACCollectionHelper) -> None:

--- a/backend/app/utils/STACGenerator.py
+++ b/backend/app/utils/STACGenerator.py
@@ -148,7 +148,7 @@ class STACGenerator:
         project = crud.project.get(db=self.db, id=self.project_id)
 
         if not project:
-            raise ValueError("Project not found.")
+            raise ValueError("Project not found")
 
         return project
 
@@ -166,7 +166,7 @@ class STACGenerator:
         )
         if len(flights) == 0:
             raise ValueError(
-                "Project must have at least one flight with a data product to publish."
+                "Project must have at least one flight with a data product to publish"
             )
 
         return list(flights)

--- a/backend/app/utils/STACGenerator.py
+++ b/backend/app/utils/STACGenerator.py
@@ -229,21 +229,25 @@ class STACGenerator:
         data_product: models.DataProduct,
         flight: models.Flight,
     ) -> Item:
+        flight_details = {
+            "flight_id": str(flight.id),
+            "acquisition_date": date_to_datetime(flight.acquisition_date).isoformat(),
+            "altitude": flight.altitude,
+            "forward_overlap": flight.forward_overlap,
+            "side_overlap": flight.side_overlap,
+            "platform": flight.platform,
+            "sensor": flight.sensor,
+        }
+
+        # Include flight name if provided
+        if flight.name:
+            flight_details["flight_name"] = flight.name
+
         flight_properties = {
             "data_product_details": {
                 "data_type": data_product.data_type,
             },
-            "flight_details": {
-                "flight_id": str(flight.id),
-                "acquisition_date": date_to_datetime(
-                    flight.acquisition_date
-                ).isoformat(),
-                "altitude": flight.altitude,
-                "forward_overlap": flight.forward_overlap,
-                "side_overlap": flight.side_overlap,
-                "platform": flight.platform,
-                "sensor": flight.sensor,
-            },
+            "flight_details": flight_details,
         }
         # Add title to properties - use custom title if provided, otherwise use default
         title = generate_item_title(data_product, flight, self.custom_titles)

--- a/frontend/src/components/pages/projects/stac/ItemsList.tsx
+++ b/frontend/src/components/pages/projects/stac/ItemsList.tsx
@@ -60,6 +60,12 @@ export default function ItemsList({ allItems }: ItemsListProps) {
                         <span className="font-medium">Title:</span> {item.title}
                       </p>
                     )}
+                    {item.flightName && (
+                      <p>
+                        <span className="font-medium">Flight Name:</span>{' '}
+                        {item.flightName}
+                      </p>
+                    )}
                     {item.browserUrl && (
                       <p>
                         <a

--- a/frontend/src/components/pages/projects/stac/ProjectSTACPublishing.tsx
+++ b/frontend/src/components/pages/projects/stac/ProjectSTACPublishing.tsx
@@ -65,7 +65,7 @@ export default function ProjectSTACPublishing() {
   const { stacMetadata, allItems, generatePreview } = useSTACData({
     projectId: projectId!,
     initialStacMetadata,
-    buildQueryParams: formState.buildQueryParams,
+    buildRequestPayload: formState.buildRequestPayload,
     setCurrentOperation: operations.setCurrentOperation,
     setStatus: operations.setStatus,
     setPollingStatus: operations.setPollingStatus,
@@ -74,7 +74,7 @@ export default function ProjectSTACPublishing() {
   // Action handlers
   const actions = useSTACActions({
     projectId: projectId!,
-    buildQueryParams: formState.buildQueryParams,
+    buildRequestPayload: formState.buildRequestPayload,
     setCurrentOperation: operations.setCurrentOperation,
     setStatus: operations.setStatus,
   });

--- a/frontend/src/components/pages/projects/stac/STACItemTitlesForm.tsx
+++ b/frontend/src/components/pages/projects/stac/STACItemTitlesForm.tsx
@@ -1,20 +1,4 @@
-interface STACItem {
-  id: string;
-  type: string;
-  properties: {
-    title?: string;
-    datetime: string;
-    data_product_details: {
-      data_type: string;
-    };
-    flight_details: {
-      acquisition_date: string;
-      platform: string;
-      sensor: string;
-    };
-  };
-  browser_url?: string;
-}
+import { STACItem } from './STACTypes';
 
 interface STACItemTitlesFormProps {
   items: STACItem[];
@@ -75,9 +59,14 @@ export default function STACItemTitlesForm({
                 </p>
                 <p className="text-xs text-gray-500">
                   {item.properties.data_product_details.data_type} •{' '}
-                  {new Date(
-                    item.properties.flight_details.acquisition_date
-                  ).toLocaleDateString()}{' '}
+                  {
+                    new Date(item.properties.flight_details.acquisition_date)
+                      .toISOString()
+                      .split('T')[0]
+                  }{' '}
+                  {item.properties.flight_details.flight_name && (
+                    <>• {item.properties.flight_details.flight_name} </>
+                  )}
                   • {item.properties.flight_details.sensor} •{' '}
                   {item.properties.flight_details.platform.replace(/_/g, ' ')}
                 </p>

--- a/frontend/src/components/pages/projects/stac/STACTypes.d.ts
+++ b/frontend/src/components/pages/projects/stac/STACTypes.d.ts
@@ -11,6 +11,7 @@ export interface STACItem {
       acquisition_date: string;
       platform: string;
       sensor: string;
+      flight_name?: string;
     };
   };
   browser_url?: string;
@@ -25,6 +26,7 @@ export interface STACError {
     data_type: string;
     filepath: string;
     flight_id: string;
+    flight_name?: string;
     title?: string;
     acquisition_date?: string;
     platform?: string;
@@ -66,6 +68,7 @@ export interface CombinedSTACItem {
   id: string;
   isSuccessful: boolean;
   title?: string;
+  flightName?: string;
   dataType?: string;
   acquisitionDate?: string;
   platform?: string;

--- a/frontend/src/components/pages/projects/stac/hooks/useSTACData.ts
+++ b/frontend/src/components/pages/projects/stac/hooks/useSTACData.ts
@@ -4,10 +4,17 @@ import { usePolling } from '../../../../hooks/usePolling';
 import { Status } from '../../../../Alert';
 import api from '../../../../../api';
 
+interface STACRequestPayload {
+  sci_doi?: string;
+  sci_citation?: string;
+  license?: string;
+  custom_titles?: Record<string, string>;
+}
+
 interface UseSTACDataProps {
   projectId: string;
   initialStacMetadata: STACMetadata | null;
-  buildQueryParams: () => URLSearchParams;
+  buildRequestPayload: () => STACRequestPayload;
   setCurrentOperation: (operation: 'idle' | 'generating' | 'checking') => void;
   setStatus: (status: Status | null) => void;
   setPollingStatus: (status: string) => void;
@@ -23,7 +30,7 @@ interface UseSTACDataReturn {
 export function useSTACData({
   projectId,
   initialStacMetadata,
-  buildQueryParams,
+  buildRequestPayload,
   setCurrentOperation,
   setStatus,
   setPollingStatus,
@@ -185,12 +192,8 @@ export function useSTACData({
       }
 
       try {
-        const queryString = buildQueryParams().toString();
-        await api.post(
-          `/projects/${projectId}/generate-stac-preview${
-            queryString ? `?${queryString}` : ''
-          }`
-        );
+        const payload = buildRequestPayload();
+        await api.post(`/projects/${projectId}/generate-stac-preview`, payload);
 
         if (usePolling || isBackgroundCheck) {
           if (isBackgroundCheck) {
@@ -221,7 +224,7 @@ export function useSTACData({
     },
     [
       projectId,
-      buildQueryParams,
+      buildRequestPayload,
       setCurrentOperation,
       setStatus,
       isPolling,

--- a/frontend/src/components/pages/projects/stac/hooks/useSTACData.ts
+++ b/frontend/src/components/pages/projects/stac/hooks/useSTACData.ts
@@ -33,6 +33,7 @@ export function useSTACData({
   );
   const hasCheckedForUpdates = useRef(false);
   const isBackgroundPolling = useRef(false);
+  const hasInitialEffectRun = useRef(false);
 
   // Helper function to detect meaningful metadata changes
   const hasMetadataChanged = useCallback(
@@ -241,15 +242,24 @@ export function useSTACData({
 
   // Initial data loading effect
   useEffect(() => {
+    // Prevent double execution of this effect
+    if (hasInitialEffectRun.current) {
+      return;
+    }
+
+    // Set flags to prevent double execution
+    hasInitialEffectRun.current = true;
     hasCheckedForUpdates.current = false;
 
+    // Generate preview if no initial metadata is provided
     if (!initialStacMetadata) {
       generatePreview();
     } else {
+      // Check for updates if initial metadata is provided
       hasCheckedForUpdates.current = true;
       checkForUpdates();
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   // Cleanup effect
   useEffect(() => {

--- a/frontend/src/components/pages/projects/stac/hooks/useSTACData.ts
+++ b/frontend/src/components/pages/projects/stac/hooks/useSTACData.ts
@@ -93,6 +93,7 @@ export function useSTACData({
           id: item.id,
           isSuccessful: true,
           title: item.properties.title,
+          flightName: item.properties.flight_details.flight_name,
           dataType: item.properties.data_product_details.data_type,
           acquisitionDate: item.properties.flight_details.acquisition_date,
           platform: item.properties.flight_details.platform,

--- a/frontend/src/components/pages/projects/stac/hooks/useSTACForm.ts
+++ b/frontend/src/components/pages/projects/stac/hooks/useSTACForm.ts
@@ -8,13 +8,20 @@ interface FormState {
   customTitles: Record<string, string>;
 }
 
+interface STACRequestPayload {
+  sci_doi?: string;
+  sci_citation?: string;
+  license?: string;
+  custom_titles?: Record<string, string>;
+}
+
 interface UseSTACFormReturn {
   formState: FormState;
   updateFormField: <K extends keyof FormState>(
     field: K,
     value: FormState[K]
   ) => void;
-  buildQueryParams: () => URLSearchParams;
+  buildRequestPayload: () => STACRequestPayload;
   resetForm: () => void;
 }
 
@@ -66,16 +73,17 @@ export function useSTACForm(
     setFormState((prev) => ({ ...prev, [field]: value }));
   };
 
-  const buildQueryParams = (): URLSearchParams => {
-    const params = new URLSearchParams();
-    if (formState.sciDoi) params.append('sci_doi', formState.sciDoi);
-    if (formState.sciCitation)
-      params.append('sci_citation', formState.sciCitation);
-    if (formState.license) params.append('license', formState.license);
+  const buildRequestPayload = (): STACRequestPayload => {
+    const payload: STACRequestPayload = {};
+
+    if (formState.sciDoi) payload.sci_doi = formState.sciDoi;
+    if (formState.sciCitation) payload.sci_citation = formState.sciCitation;
+    if (formState.license) payload.license = formState.license;
     if (Object.keys(formState.customTitles).length > 0) {
-      params.append('custom_titles', JSON.stringify(formState.customTitles));
+      payload.custom_titles = formState.customTitles;
     }
-    return params;
+
+    return payload;
   };
 
   const resetForm = () => {
@@ -90,7 +98,7 @@ export function useSTACForm(
   return {
     formState,
     updateFormField,
-    buildQueryParams,
+    buildRequestPayload,
     resetForm,
   };
 }


### PR DESCRIPTION
### Summary
This PR improves STAC metadata generation and job management with several key enhancements:

### Changes Made

#### Flight Name Integration
- **Added conditional flight names to STAC metadata**: Flight names are now included in STAC item `flight_details` when available, and gracefully omitted when not set
- **Updated frontend and backend interfaces**: Added optional `flight_name` field to TypeScript interfaces and backend schemas
- **Enhanced display**: Frontend now shows flight names in STAC item listings when available

#### Improved Parameter Handling  
- **Switched from query params to request body**: STAC generation endpoints now accept metadata parameters (DOI, citation, custom titles, license) via POST/PUT request body instead of query parameters
- **Better data structure**: Cleaner API design that supports complex nested data like custom title objects

#### Job Deduplication & Management
- **Prevent duplicate jobs**: Added checks to prevent starting new STAC generation jobs when one is already running for the same project
- **Stale job handling**: Jobs older than 24 hours are considered stale and new jobs can be started (handles stuck/failed jobs)
- **Improved reliability**: Reduces server load and prevents conflicting concurrent STAC generation processes