### PR TITLE
add fallback for compound CRS in CHM generation when to_epsg() returns None

### DIFF
--- a/backend/app/utils/toolbox/chm.py
+++ b/backend/app/utils/toolbox/chm.py
@@ -75,7 +75,12 @@ def run(in_point_cloud: str, out_raster: str, params: dict) -> str:
 
         crs = las.header.parse_crs()
         srs_out = osr.SpatialReference()
-        srs_out.ImportFromEPSG(int(crs.to_epsg()))
+        try:
+            srs_out.ImportFromEPSG(int(crs.to_epsg()))
+        except TypeError:
+            srs_out.ImportFromWkt(crs.to_wkt())
+        except Exception as e:
+            raise ValueError(f"Error importing CRS: {e}")
 
         x = np.array(las.x)
         y = np.array(las.y)
@@ -210,7 +215,11 @@ if __name__ == "__main__":
         help="CHM resolution",
     )
     parser.add_argument(
-        "--chm_percentile", type=float, required=True, default=98.0, help="CHM percentile"
+        "--chm_percentile",
+        type=float,
+        required=True,
+        default=98.0,
+        help="CHM percentile",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
This PR fixes a bug in the CHM (Canopy Height Model) generation process where LiDAR files with compound coordinate reference systems (CRS) would fail during raster creation.

## Problem
When processing LiDAR files with compound CRS (e.g., files that combine horizontal and vertical coordinate systems), the `crs.to_epsg()` method returns `None` instead of an EPSG code. This caused a `TypeError` when attempting to convert `None` to an integer in the line:

```python
srs_out.ImportFromEPSG(int(crs.to_epsg()))
```

## Solution
Added a fallback mechanism that catches the `TypeError` and uses the WKT (Well-Known Text) representation of the CRS instead:

```python
try:
    srs_out.ImportFromEPSG(int(crs.to_epsg()))
except TypeError:
    srs_out.ImportFromWkt(crs.to_wkt())
```

This ensures that CHM generation can handle both simple EPSG-based CRS and compound CRS that require WKT representation.