### PR TITLE
restore dynamic tile resolution scaling in ProjectRasterTiles

### DIFF
--- a/frontend/src/components/maps/ProjectRasterTiles.tsx
+++ b/frontend/src/components/maps/ProjectRasterTiles.tsx
@@ -13,7 +13,8 @@ import { useMapContext } from './MapContext';
 
 function constructRasterTileUrl(
   dataProduct: DataProduct,
-  symbologySettings: SingleBandSymbology | MultibandSymbology | null
+  symbologySettings: SingleBandSymbology | MultibandSymbology | null,
+  tileScale: number
 ): string {
   if (!symbologySettings) return '';
 
@@ -24,7 +25,7 @@ function constructRasterTileUrl(
   const tms = 'WebMercatorQuad';
 
   // parts of path for fetching tiles
-  const resourcePath = `/cog/tiles/${tms}/{z}/{x}/{y}@2x`;
+  const resourcePath = `/cog/tiles/${tms}/{z}/{x}/{y}@${tileScale}x`;
   const basePath = window.location.origin;
   const queryParams = getTitilerQueryParams(
     cogUrl,
@@ -46,15 +47,15 @@ export default function ProjectRasterTiles({
 }) {
   const { current: map } = useMap();
 
-  const { activeDataProduct } = useMapContext();
+  const { activeDataProduct, tileScale } = useMapContext();
 
   const { state } = useRasterSymbologyContext();
 
   const { isLoaded, symbology } = state[dataProduct.id] || {};
 
   const tiles = useMemo(
-    () => [constructRasterTileUrl(dataProduct, symbology)],
-    [dataProduct, symbology]
+    () => [constructRasterTileUrl(dataProduct, symbology, tileScale)],
+    [dataProduct, symbology, tileScale]
   );
 
   if (!symbology || !isLoaded || !map || !tiles) return null;


### PR DESCRIPTION
## Summary
This PR fixes a bug where the `tileScale` context was not being properly utilized in the `ProjectRasterTiles` component, causing raster tiles to ignore the user's tile resolution preference.

## Problem
The `tileScale` context was available in `MapContext` and the UI controls in `MapToolbar` were functional, but the `ProjectRasterTiles` component was not using the `tileScale` value when constructing titiler URLs. This meant that regardless of the user's tile resolution setting, all raster tiles were being served at the default resolution.

## Root Cause
The `constructRasterTileUrl` function was missing the `tileScale` parameter, and the component was not passing the `tileScale` from context to the URL construction function.

## Solution
- Added `tileScale` parameter to the `constructRasterTileUrl` function signature
- Updated the titiler URL path to include the scale parameter: `/cog/tiles/${tms}/{z}/{x}/{y}@${tileScale}x`
- Modified the component to pass `tileScale` from `MapContext` to the URL construction function
- Added `tileScale` to the `useMemo` dependency array to ensure tiles update when scale changes

## Impact
This fix restores the intended functionality where users can control tile resolution through the existing UI controls, improving both performance and visualization quality options.