### PR TITLE
add JWT/API key auth for BreedBase connections

### DIFF
--- a/backend/app/api/api_v1/endpoints/breedbase_connections.py
+++ b/backend/app/api/api_v1/endpoints/breedbase_connections.py
@@ -17,8 +17,10 @@ study_router = APIRouter()
 def create_breedbase_connection(
     project_id: UUID,
     breedbase_connection_in: schemas.BreedbaseConnectionCreate,
-    project: models.Project = Depends(deps.can_read_write_project),
-    current_user: models.User = Depends(deps.get_current_approved_user),
+    project: models.Project = Depends(deps.can_read_write_project_with_jwt_or_api_key),
+    current_user: models.User = Depends(
+        deps.get_current_approved_user_by_jwt_or_api_key
+    ),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     breedbase_connection = crud.breedbase_connection.create_with_project(
@@ -41,7 +43,9 @@ def read_breedbase_connection(
 def read_breedbase_connection_by_study_id(
     study_id: str,
     db: Session = Depends(deps.get_db),
-    current_user: models.User = Depends(deps.get_current_approved_user),
+    current_user: models.User = Depends(
+        deps.get_current_approved_user_by_jwt_or_api_key
+    ),
 ) -> Any:
     breedbase_connections = crud.breedbase_connection.get_by_study_id(
         db, study_id=study_id, user_id=current_user.id
@@ -52,7 +56,7 @@ def read_breedbase_connection_by_study_id(
 @router.get("", response_model=List[schemas.BreedbaseConnection])
 def read_breedbase_connections(
     db: Session = Depends(deps.get_db),
-    project: models.Project = Depends(deps.can_read_project),
+    project: models.Project = Depends(deps.can_read_project_with_jwt_or_api_key),
 ) -> Any:
     breedbase_connections = crud.breedbase_connection.get_multi_by_project_id(
         db, project_id=project.id
@@ -65,7 +69,7 @@ def update_breedbase_connection(
     breedbase_connection_id: UUID,
     breedbase_connection_in: schemas.BreedbaseConnectionUpdate,
     db: Session = Depends(deps.get_db),
-    project: models.Project = Depends(deps.can_read_write_project),
+    project: models.Project = Depends(deps.can_read_write_project_with_jwt_or_api_key),
 ) -> Any:
     # Get breedbase connection
     breedbase_connection = crud.breedbase_connection.get(db, id=breedbase_connection_id)
@@ -86,7 +90,7 @@ def update_breedbase_connection(
 def delete_breedbase_connection(
     breedbase_connection_id: UUID,
     db: Session = Depends(deps.get_db),
-    project: models.Project = Depends(deps.can_read_write_project),
+    project: models.Project = Depends(deps.can_read_write_project_with_jwt_or_api_key),
 ) -> Any:
     # Get breedbase connection
     breedbase_connection = crud.breedbase_connection.get(db, id=breedbase_connection_id)

--- a/backend/app/api/api_v1/endpoints/flights.py
+++ b/backend/app/api/api_v1/endpoints/flights.py
@@ -65,8 +65,10 @@ def read_flights(
     project_id: UUID,
     include_all: bool = True,
     has_raster: bool = False,
-    current_user: models.User = Depends(deps.get_current_approved_user),
-    project: schemas.Project = Depends(deps.can_read_project),
+    current_user: models.User = Depends(
+        deps.get_current_approved_user_by_jwt_or_api_key
+    ),
+    project: schemas.Project = Depends(deps.can_read_project_with_jwt_or_api_key),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     """Retrieve flights associated with project user can access."""

--- a/backend/app/api/api_v1/endpoints/vector_layers.py
+++ b/backend/app/api/api_v1/endpoints/vector_layers.py
@@ -175,7 +175,7 @@ def read_vector_layer(
     ],
 )
 def read_vector_layers(
-    project: models.Project = Depends(deps.can_read_project),
+    project: models.Project = Depends(deps.can_read_project_with_jwt_or_api_key),
     format: str = Query(None),
     db: Session = Depends(deps.get_db),
 ) -> Any:
@@ -236,7 +236,7 @@ def download_vector_layer(
     layer_id: str,
     background_tasks: BackgroundTasks,
     format: str = Query("json", pattern="^(json|shp)$"),
-    project: models.Project = Depends(deps.can_read_project),
+    project: models.Project = Depends(deps.can_read_project_with_jwt_or_api_key),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     # Fetch GeoJSON features for vector layer

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -301,6 +301,23 @@ def can_read_write_project(
     return project
 
 
+def can_read_project_with_jwt_or_api_key(
+    project_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_approved_user_by_jwt_or_api_key),
+) -> schemas.Project:
+    """Return project if current user is project owner, manager, or viewer."""
+    if current_user.is_demo:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied"
+        )
+    project_response = crud.project.get_user_project(
+        db, user_id=current_user.id, project_id=project_id, permission="r"
+    )
+    project = verify_resource_response(project_response, "Project")
+    return project
+
+
 def can_read_write_project_with_jwt_or_api_key(
     project_id: UUID,
     db: Session = Depends(get_db),


### PR DESCRIPTION
**PR description**
**What**: Enable dual authentication (JWT or X-API-KEY) for BreedBase connection endpoints; fix study lookup route to prevent 422 validation errors.
**Why**: Support BreedBase integrations that use API keys while retaining JWT compatibility.
**Changes**:
**Auth deps**: Introduce and use get_current_approved_user_by_jwt_or_api_key, can_read_project_with_jwt_or_api_key, can_read_write_project_with_jwt_or_api_key.
**BreedBase endpoints**: Migrate to dual-auth dependencies so requests can be authorized via JWT or API key.
**Consistency**: Apply the same dual-auth pattern to related endpoints in flights and vector layers where applicable.