### PR TITLE
move team selection to context and use team selection when filtering project cluster

### DIFF
--- a/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
@@ -34,14 +34,14 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
   const [sortSelection, setSortSelection] = useState<SortSelection>(
     getSortPreferenceFromLocalStorage('sortPreference')
   );
-  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
-
   const {
     activeDataProductDispatch,
     activeProjectDispatch,
     projectFilterSelection,
     projectFilterSelectionDispatch,
     projectsVisible,
+    selectedTeamIds,
+    selectedTeamIdsDispatch,
   } = useMapContext();
 
   // Filter projects by filter selection
@@ -187,7 +187,9 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
                   sublistParentValue="myTeams"
                   sublistCategories={teamCategories}
                   sublistSelected={selectedTeamIds}
-                  setSublistSelected={setSelectedTeamIds}
+                  setSublistSelected={(teamIds) =>
+                    selectedTeamIdsDispatch({ type: 'set', payload: teamIds })
+                  }
                 />
                 <Sort
                   sortSelection={sortSelection}

--- a/frontend/src/components/maps/MapContext.tsx
+++ b/frontend/src/components/maps/MapContext.tsx
@@ -19,6 +19,7 @@ import {
   ProjectsLoadedAction,
   ProjectFilterSelectionAction,
   ProjectsVisibleAction,
+  SelectedTeamIdsAction,
   TileScaleAction,
 } from './Maps';
 
@@ -176,6 +177,23 @@ function projectFilterSelectionReducer(
   }
 }
 
+function selectedTeamIdsReducer(
+  state: string[],
+  action: SelectedTeamIdsAction
+) {
+  switch (action.type) {
+    case 'set': {
+      return action.payload;
+    }
+    case 'reset': {
+      return [];
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
 export type ProjectsLoadedState = 'initial' | 'loading' | 'loaded' | 'error';
 
 function projectsLoadedReducer(
@@ -245,6 +263,8 @@ const context: {
   projectFilterSelectionDispatch: React.Dispatch<ProjectFilterSelectionAction>;
   projectsVisible: string[];
   projectsVisibleDispatch: React.Dispatch<ProjectsVisibleAction>;
+  selectedTeamIds: string[];
+  selectedTeamIdsDispatch: React.Dispatch<SelectedTeamIdsAction>;
   tileScale: number;
   tileScaleDispatch: React.Dispatch<TileScaleAction>;
 } = {
@@ -269,6 +289,8 @@ const context: {
   projectFilterSelectionDispatch: () => {},
   projectsVisible: [],
   projectsVisibleDispatch: () => {},
+  selectedTeamIds: [],
+  selectedTeamIdsDispatch: () => {},
   tileScale: 2,
   tileScaleDispatch: () => {},
 };
@@ -314,6 +336,10 @@ export function MapContextProvider({
   );
   const [projectsVisible, projectsVisibleDispatch] = useReducer(
     projectsVisibleReducer,
+    []
+  );
+  const [selectedTeamIds, selectedTeamIdsDispatch] = useReducer(
+    selectedTeamIdsReducer,
     []
   );
   const [tileScale, tileScaleDispatch] = useReducer(tileScaleReducer, 2);
@@ -372,6 +398,8 @@ export function MapContextProvider({
         projectsLoadedDispatch,
         projectsVisible,
         projectsVisibleDispatch,
+        selectedTeamIds,
+        selectedTeamIdsDispatch,
         tileScale,
         tileScaleDispatch,
       }}

--- a/frontend/src/components/maps/Maps.d.ts
+++ b/frontend/src/components/maps/Maps.d.ts
@@ -21,6 +21,8 @@ export type FlightsAction = { type: string; payload: Flight[] };
 
 export type ProjectFilterSelectionAction = { type: string; payload?: string[] };
 
+export type SelectedTeamIdsAction = { type: string; payload: string[] };
+
 export type ProjectsAction = { type: string; payload: Project[] | null };
 
 export type ProjectsLoadedAction = {

--- a/frontend/src/components/maps/ProjectCluster.tsx
+++ b/frontend/src/components/maps/ProjectCluster.tsx
@@ -32,7 +32,8 @@ export default function ProjectCluster({
   includeAll = false,
   setIsMapReady,
 }: ProjectClusterProps) {
-  const { projects, projectsLoaded, projectFilterSelection } = useMapContext();
+  const { projects, projectsLoaded, projectFilterSelection, selectedTeamIds } =
+    useMapContext();
 
   const [geojsonData, setGeojsonData] =
     useState<ProjectFeatureCollection | null>(null);
@@ -59,8 +60,17 @@ export default function ProjectCluster({
       );
     }
 
+    if (
+      projectFilterSelection.includes('myTeams') &&
+      selectedTeamIds.length > 0
+    ) {
+      filteredProjects = filteredProjects.filter(
+        (project) => project.team && selectedTeamIds.includes(project.team.id)
+      );
+    }
+
     return filteredProjects;
-  }, [projects, projectFilterSelection]);
+  }, [projects, projectFilterSelection, selectedTeamIds]);
 
   const projectsFeatureCollection = useMemo(() => {
     if (!filteredProjects || filteredProjects.length === 0) return null;


### PR DESCRIPTION
# Fix team filtering in map project clusters

## Summary
This PR fixes a missing team filtering implementation in the map's project clusters. Previously, team filtering only worked in the project list sidebar but not for the clustered project points displayed on the map itself.

## Changes Made

### 🔧 Shared State Management
- **Added `SelectedTeamIdsAction`** type to `Maps.d.ts` for consistent action typing
- **Enhanced MapContext** with shared team selection state:
  - Added `selectedTeamIdsReducer` for managing team selection state
  - Added `selectedTeamIds` and `selectedTeamIdsDispatch` to context interface
  - Integrated team selection into the provider value

### 🗺️ Map Component Updates
- **ProjectsPane.tsx**: Refactored to use shared team selection state instead of local state
- **ProjectCluster.tsx**: Added missing team filtering logic that matches other components
- **Consistent filtering behavior** across all map components

### 🎯 Bug Fix Details
- **Issue**: Team filtering worked in sidebar but not on map clusters
- **Root cause**: `ProjectCluster` component wasn't accessing team selection state
- **Solution**: Moved team selection to shared map context and applied filtering in clusters

## Technical Implementation
- Team filtering logic checks `project.team?.id` against selected team IDs
- Maintains existing filter patterns for consistency
- Updates dependency arrays to include `selectedTeamIds` for proper reactivity
- Uses dispatch pattern for state updates: `selectedTeamIdsDispatch({ type: 'set', payload: teamIds })`

This fix ensures that when users select teams in the filter dropdown, both the sidebar project list and the map project clusters are filtered accordingly, providing a consistent user experience.