### PR TITLE
display project creator name next to project title

### DIFF
--- a/backend/app/crud/crud_project.py
+++ b/backend/app/crud/crud_project.py
@@ -178,6 +178,7 @@ class CRUDProject(CRUDBase[Project, ProjectCreate, ProjectUpdate]):
             .where(Project.id == project_id)
             .where(Project.is_active)
             .where(ProjectMember.member_id == user_id)
+            .options(selectinload(Project.owner))
         )
         with db as session:
             try:
@@ -224,6 +225,12 @@ class CRUDProject(CRUDBase[Project, ProjectCreate, ProjectUpdate]):
                 setattr(project[0], "flight_count", flight_count)
                 setattr(project[0], "most_recent_flight", most_recent_flight)
                 setattr(project[0], "data_product_count", data_product_count)
+                # Add project owner name (from eager-loaded relationship)
+                setattr(
+                    project[0],
+                    "created_by",
+                    project[0].owner.full_name if project[0].owner else None,
+                )
                 return {
                     "response_code": status.HTTP_200_OK,
                     "message": "Project fetched successfully",

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -68,6 +68,7 @@ class Project(ProjectInDBBase):
     flight_count: int = 0
     most_recent_flight: Optional[date] = None
     role: Role = Role.VIEWER
+    created_by: Optional[str] = None
 
 
 # project boundary centroid

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -254,6 +254,9 @@ def test_get_project_with_owner_role(
     assert str(project.harvest_date) == response_data["harvest_date"]
     assert response_data["location_id"]
     assert response_data["role"] == "owner"
+    # created_by should be owner's full name
+    owner_full_name = f"{current_user.first_name} {current_user.last_name}"
+    assert response_data.get("created_by") == owner_full_name
 
 
 def test_get_project_with_manager_role(
@@ -272,7 +275,8 @@ def test_get_project_with_viewer_role(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
     current_user = get_current_user(db, normal_user_access_token)
-    project = create_project(db)
+    project_owner = create_user(db)
+    project = create_project(db, owner_id=project_owner.id)
     create_project_member(
         db, email=current_user.email, project_id=project.id, role=Role.VIEWER
     )
@@ -281,6 +285,9 @@ def test_get_project_with_viewer_role(
     response_data = response.json()
     assert str(project.id) == response_data["id"]
     assert response_data["role"] != "owner"
+    # created_by should be owner's full name
+    owner_full_name = f"{project_owner.first_name} {project_owner.last_name}"
+    assert response_data.get("created_by") == owner_full_name
 
 
 def test_get_project_by_non_project_member(

--- a/backend/app/tests/crud/test_project.py
+++ b/backend/app/tests/crud/test_project.py
@@ -138,6 +138,9 @@ def test_get_project_by_user_and_project_id(db: Session) -> None:
     assert project.owner_id == stored_project["result"].owner_id
     assert project.is_active == stored_project["result"].is_active
     assert project.is_published == stored_project["result"].is_published
+    # created_by should be owner's full name
+    owner_full_name = f"{user.first_name} {user.last_name}"
+    assert stored_project["result"].created_by == owner_full_name
 
 
 def test_get_project_with_team_by_user_and_project_id(db: Session) -> None:
@@ -159,6 +162,9 @@ def test_get_project_with_team_by_user_and_project_id(db: Session) -> None:
     assert project.owner_id == stored_project["result"].owner_id
     assert project.is_active == stored_project["result"].is_active
     assert project.is_published == stored_project["result"].is_published
+    # created_by should be owner's full name
+    owner_full_name = f"{user.first_name} {user.last_name}"
+    assert stored_project["result"].created_by == owner_full_name
 
 
 def test_get_projects_by_owner(db: Session) -> None:

--- a/frontend/src/components/pages/projects/Project.d.ts
+++ b/frontend/src/components/pages/projects/Project.d.ts
@@ -108,6 +108,7 @@ export interface Project {
   title: string;
   role: string;
   is_published: boolean;
+  created_by: string | null;
 }
 
 export interface ProjectModule {

--- a/frontend/src/components/pages/projects/ProjectDetail.tsx
+++ b/frontend/src/components/pages/projects/ProjectDetail.tsx
@@ -149,6 +149,11 @@ export default function ProjectDetail() {
             <span className="block text-lg font-bold mb-0">
               {project.title}
             </span>
+            {project.created_by && (
+              <span className="block text-sm text-gray-500">
+                Created by: {project.created_by}
+              </span>
+            )}
             <span className="block my-1 mx-0 text-gray-600 text-wrap break-all">
               {project.description}
             </span>

--- a/frontend/src/components/pages/projects/ProjectDetailEditForm.tsx
+++ b/frontend/src/components/pages/projects/ProjectDetailEditForm.tsx
@@ -87,6 +87,11 @@ export default function ProjectDetailEditForm({
                   <TextField name="title" />
                 )}
               </EditField>
+              {project.created_by && (
+                <span className="block text-sm text-gray-500">
+                  Created by: {project.created_by}
+                </span>
+              )}
               <EditField
                 fieldName="description"
                 isEditing={isEditing}


### PR DESCRIPTION
# Add project creator display in UI

## Summary
This PR adds the ability to display the project creator's name in the project detail views, improving transparency about project ownership.

## Changes Made

### Backend
- **Modified `crud_project.get_user_project()`**: Replaced manual owner lookup with eager loading using `selectinload(Project.owner)` for better performance
- **Updated project schema**: Changed field name from `owner_name` to `created_by` to better reflect that it shows the original creator rather than current owners (since projects can have multiple owners)
- **Leveraged existing `User.full_name` property**: Uses the existing computed column property instead of manual string concatenation

### Frontend
- **Updated TypeScript interfaces**: Added `created_by?: string | null` to the `Project` interface
- **Enhanced project detail views**: Added subtle "Created by: {name}" display under the project title in both read-only and edit modes
- **Consistent styling**: Used muted gray text to show creator information without overwhelming the main content

## UI Preview
The creator name appears as a small, muted line under the project title: