### PR TITLE
remember original destination after login redirect

### DIFF
--- a/frontend/src/components/pages/auth/LoginForm.tsx
+++ b/frontend/src/components/pages/auth/LoginForm.tsx
@@ -1,7 +1,12 @@
 import { isAxiosError } from 'axios';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { Fragment, useContext, useState } from 'react';
-import { Link, useSearchParams, useNavigate } from 'react-router-dom';
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 import Alert, { Status } from '../../Alert';
@@ -42,6 +47,7 @@ export default function LoginForm() {
   const { login } = useContext(AuthContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const methods = useForm<LoginFormData>({
     defaultValues,
@@ -60,7 +66,11 @@ export default function LoginForm() {
         username: values.email,
         password: values.password,
       };
-      await login(data).then(() => navigate('/home'));
+      await login(data).then(() => {
+        // Check if there's a redirect location from the navigation state
+        const from = location.state?.from?.pathname || '/home';
+        navigate(from, { replace: true });
+      });
     } catch (err) {
       if (isAxiosError(err)) {
         const errMsg = err.response?.data.detail;


### PR DESCRIPTION
# Fix: Remember original destination after login redirect

## Description

Fixes the issue where users were always redirected to the home page (`/home`) after logging in, even when they were originally trying to access a different protected route.

## Problem

Previously, when a logged-out user tried to access a protected route (e.g., `/auth/profile`), they would be redirected to the login page. After successfully logging in, they would always be taken to the home page instead of their original destination.

## Solution

Modified the `LoginForm` component to:
- Check for the original destination stored in React Router's navigation state
- Redirect users to their intended destination after successful login
- Fall back to `/home` if no original destination is stored (maintaining backward compatibility)

## Changes

- **Added `useLocation` hook** to access navigation state in `LoginForm.tsx`
- **Updated login success handler** to extract the original destination from `location.state?.from?.pathname`
- **Improved user experience** by preserving navigation intent across authentication

## Example Flow

**Before:**
1. User visits `/auth/profile` (while logged out)
2. Gets redirected to `/auth/login`
3. Logs in successfully
4. Gets redirected to `/home` ❌

**After:**
1. User visits `/auth/profile` (while logged out)
2. Gets redirected to `/auth/login` with state
3. Logs in successfully
4. Gets redirected to `/auth/profile` ✅

## Backward Compatibility

- Users logging in directly via `/auth/login` will still be redirected to `/home`
- No breaking changes to existing authentication flow
- Works with both `RequireAuth` and `RequireAdmin` protected routes