### PR TITLE
fit camera to aabb, autoset orbit limits

### DIFF
--- a/frontend/src/components/maps/PlayCanvasViewer.tsx
+++ b/frontend/src/components/maps/PlayCanvasViewer.tsx
@@ -1,4 +1,5 @@
-import { RESOLUTION_AUTO } from 'playcanvas';
+import { RESOLUTION_AUTO, Entity as PcEntity } from 'playcanvas';
+import { useEffect, useRef, useState } from 'react';
 import { Application, Entity } from '@playcanvas/react';
 import { Camera, GSplat } from '@playcanvas/react/components';
 import { OrbitControls } from '@playcanvas/react/scripts';
@@ -6,17 +7,92 @@ import { useSplat } from '@playcanvas/react/hooks';
 
 function Scene({ splatUrl }: { splatUrl: string }) {
   const { asset } = useSplat(splatUrl);
+  const gsplatEntityRef = useRef<PcEntity | null>(null);
+
+  const [controls, setControls] = useState<{
+    distanceMin: number;
+    distanceMax: number;
+    distance: number;
+    mouse: { distanceSensitivity: number };
+    touch: { distanceSensitivity: number };
+    focusEntity: PcEntity | null;
+    frameOnStart: boolean;
+  }>({
+    distanceMin: 0.05,
+    distanceMax: 10,
+    distance: 3,
+    mouse: { distanceSensitivity: 0.1 },
+    touch: { distanceSensitivity: 0.1 },
+    focusEntity: null,
+    frameOnStart: true,
+  });
+
+  useEffect(() => {
+    if (!asset) return;
+
+    const entity = gsplatEntityRef.current as unknown as {
+      gsplat?: {
+        instance?: {
+          resource?: {
+            aabb?: { halfExtents: { x: number; y: number; z: number } };
+          };
+        };
+      };
+    } | null;
+
+    // Prefer aabb from asset.resource if available, otherwise fall back to entity.gsplat.instance.resource
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const aabb: any =
+      (asset as any)?.resource?.aabb ??
+      entity?.gsplat?.instance?.resource?.aabb;
+    if (!aabb?.halfExtents) return;
+
+    const hx = aabb.halfExtents.x ?? 1;
+    const hy = aabb.halfExtents.y ?? 1;
+    const hz = aabb.halfExtents.z ?? 1;
+    const radius = Math.max(Math.hypot(hx, hy, hz), 1e-3);
+
+    const distanceMin = Math.max(radius * 0.05, 0.02);
+    const distanceMax = Math.max(radius * 30, distanceMin + radius * 2);
+    const distance = Math.min(
+      Math.max(radius * 3, distanceMin + radius * 0.5),
+      distanceMax - radius * 0.1
+    );
+    const sensitivity = Math.min(Math.max(radius * 0.1, 0.02), 5);
+
+    setControls({
+      distanceMin,
+      distanceMax,
+      distance,
+      mouse: { distanceSensitivity: sensitivity },
+      touch: { distanceSensitivity: sensitivity },
+      focusEntity: (gsplatEntityRef.current as PcEntity | null) ?? null,
+      frameOnStart: true,
+    });
+  }, [asset]);
 
   if (!asset) return null;
 
   return (
     <>
-      <Entity position={[0, -0.7, 0]} rotation={[0, 0, 180]}>
+      <Entity
+        ref={gsplatEntityRef}
+        position={[0, -0.7, 0]}
+        rotation={[0, 0, 180]}
+      >
         <GSplat asset={asset} />
       </Entity>
       <Entity position={[0, 0, -2.5]}>
         <Camera />
-        <OrbitControls />
+        <OrbitControls
+          distanceMin={controls.distanceMin}
+          distanceMax={controls.distanceMax}
+          distance={controls.distance}
+          mouse={{ distanceSensitivity: controls.mouse.distanceSensitivity }}
+          touch={{ distanceSensitivity: controls.touch.distanceSensitivity }}
+          focusEntity={controls.focusEntity}
+          frameOnStart={controls.frameOnStart}
+        />
       </Entity>
     </>
   );

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -699,11 +699,6 @@
     rw "^1.3.3"
     tinyqueue "^3.0.0"
 
-"@mkkellogg/gaussian-splats-3d@^0.4.7":
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/@mkkellogg/gaussian-splats-3d/-/gaussian-splats-3d-0.4.7.tgz#1e1d7d81ae57d2746cbfb9de692bcd69e47f2d13"
-  integrity sha512-0vy9/i9sJLFH/v3WJZ4axCsqjkToe8UsV3xY7bvK5EUC0akiRsWZODoCiSzpxhTLNyzSKTsyQKozIFeNA5RWRA==
-
 "@mui/core-downloads-tracker@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.2.0.tgz#52953b858eaf3204ac505bf0329528fd3130c775"
@@ -4862,11 +4857,6 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
-
-three@^0.179.1:
-  version "0.179.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.179.1.tgz#6c0b43e046eaad0f42b163143517a44ae44ed446"
-  integrity sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==
 
 tiny-case@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
# Dynamic Zoom Controls for Gaussian Splats

## Description

Implements dynamic zoom distance and sensitivity controls for the PlayCanvas Gaussian Splat viewer to automatically adapt to different splat sizes. This resolves issues where some splats couldn't be zoomed in/out adequately due to fixed control parameters.

## Changes

- **Dynamic distance calculation**: Computes appropriate `distanceMin`, `distanceMax`, and initial `distance` based on the splat's bounding box (AABB)
- **Adaptive sensitivity**: Sets mouse/touch `distanceSensitivity` proportional to splat size for consistent zoom feel
- **Auto-framing**: Adds `focusEntity` and `frameOnStart` to `OrbitControls` for better initial positioning
- **Fallback handling**: Safely handles cases where AABB data is unavailable with sensible defaults

## Technical Details

The implementation:
1. Uses a ref to access the GSplat entity after asset loading
2. Extracts `halfExtents` from the asset's AABB (`asset.resource.aabb` or `entity.gsplat.instance.resource.aabb`)
3. Calculates a bounding radius: `radius = max(hypot(hx, hy, hz), 1e-3)`
4. Sets control parameters based on radius:
   - `distanceMin = max(radius * 0.05, 0.02)`
   - `distanceMax = max(radius * 30, distanceMin + radius * 2)`
   - `distance = radius * 3` (clamped between min/max)
   - `distanceSensitivity = clamp(radius * 0.1, 0.02, 5)`

## Files Changed

- `frontend/src/components/maps/PlayCanvasViewer.tsx`