### PR TITLE
fix STAC metadata persistence issues on page refresh and form submission

### DIFF
--- a/frontend/src/components/pages/projects/stac/hooks/useSTACForm.ts
+++ b/frontend/src/components/pages/projects/stac/hooks/useSTACForm.ts
@@ -40,12 +40,35 @@ export function useSTACForm(
   // Initialize form fields from existing metadata
   useEffect(() => {
     if (stacMetadata?.collection) {
-      setFormState((prev) => ({
-        ...prev,
-        sciDoi: stacMetadata.collection['sci:doi'] || '',
-        sciCitation: stacMetadata.collection['sci:citation'] || '',
-        license: (stacMetadata.collection as any).license || DEFAULT_LICENSE,
-      }));
+      setFormState((prev) => {
+        // Get server values
+        const serverSciDoi = stacMetadata.collection['sci:doi'] || '';
+        const serverSciCitation = stacMetadata.collection['sci:citation'] || '';
+        const serverLicense =
+          (stacMetadata.collection as any).license || DEFAULT_LICENSE;
+
+        // Preserve user input if it differs from server data
+        // This prevents form values from reverting after submission
+        const finalSciDoi =
+          prev.sciDoi && prev.sciDoi !== serverSciDoi
+            ? prev.sciDoi
+            : serverSciDoi;
+        const finalSciCitation =
+          prev.sciCitation && prev.sciCitation !== serverSciCitation
+            ? prev.sciCitation
+            : serverSciCitation;
+        const finalLicense =
+          prev.license && prev.license !== serverLicense
+            ? prev.license
+            : serverLicense;
+
+        return {
+          ...prev,
+          sciDoi: finalSciDoi,
+          sciCitation: finalSciCitation,
+          license: finalLicense,
+        };
+      });
     }
 
     // Initialize custom titles from STAC items


### PR DESCRIPTION
# Fix STAC metadata persistence issues on page refresh and form submission

## Summary
Fixes critical data loss issues where custom titles, scientific metadata (DOI/citation), and license selections were not persisting correctly across page refreshes and form submissions in the STAC publishing workflow.

## Problems Fixed

### 1. Custom Titles Lost on Page Refresh
- **Issue**: Custom STAC item titles were overwritten with generated defaults when page refreshed
- **Root Cause**: `STACGenerator.generate_item_title()` only checked `custom_titles` parameter but ignored existing titles in cached items
- **Impact**: Users lost custom title work when navigating away and back

### 2. Scientific Metadata Reverted After Submission  
- **Issue**: DOI, citation, and license fields reverted to previous values immediately after "Update Catalog" submission
- **Root Cause**: Frontend form state was overwritten with stale server data when metadata updated
- **Impact**: Users saw their form inputs disappear, creating confusion about whether changes were saved

### 3. Clear/Reset Button Not Working
- **Issue**: "Clear (use default)" button didn't actually reset custom titles to generated defaults
- **Root Cause**: Button only deleted local state but didn't override server-stored custom titles
- **Impact**: Users couldn't revert custom titles back to auto-generated defaults

## Solutions Implemented

### Backend Changes (`STACGenerator.py`)

**Enhanced title generation priority system:**
```python
def generate_item_title(data_product, flight, custom_titles=None, cached_item=None):
    # 1. New custom title from current request (highest priority)
    # 2. Existing title from cached item (if not default pattern)  
    # 3. Generated default title (fallback)
```

**Enhanced collection metadata preservation:**
```python
# Preserve license, sci:doi, and sci:citation from cached collection
# when new values are not provided in the request
```

### Frontend Changes

**Fixed form state management (`useSTACForm.ts`):**
- Added preservation logic for scientific fields similar to custom titles
- Prevents form values from reverting after submission
- Maintains user input during async server operations

**Improved title display logic (`STACItemTitlesForm.tsx`):**
- Shows server-stored custom titles when no local custom title exists
- Updated "Reset to default" button to explicitly set generated default title
- Ensures button properly overrides server-stored custom titles

## Technical Details

### Priority System for All Metadata
1. **New values from current form submission** (highest priority)
2. **Existing values from cached STAC data** (preserve previous work)
3. **Generated defaults or fallbacks** (when no custom values exist)

### Key Files Modified
- `backend/app/utils/STACGenerator.py` - Enhanced metadata preservation
- `frontend/src/components/pages/projects/stac/hooks/useSTACForm.ts` - Fixed form state management
- `frontend/src/components/pages/projects/stac/STACItemTitlesForm.tsx` - Improved title handling and reset functionality

## Testing Scenarios Addressed
- ✅ Custom titles persist across page refreshes
- ✅ Scientific metadata (DOI/citation/license) maintains values after form submission
- ✅ "Reset to default" button properly reverts custom titles to generated defaults
- ✅ New custom values properly override cached values
- ✅ Form state remains consistent during async server operations

## Breaking Changes
None - all changes are backward compatible and improve existing functionality.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (enhancement to existing functionality)