### PR TITLE
drop custom zoom sensitivity

### DIFF
--- a/frontend/src/components/maps/PlayCanvasViewer.tsx
+++ b/frontend/src/components/maps/PlayCanvasViewer.tsx
@@ -13,16 +13,12 @@ function Scene({ splatUrl }: { splatUrl: string }) {
     distanceMin: number;
     distanceMax: number;
     distance: number;
-    mouse: { distanceSensitivity: number };
-    touch: { distanceSensitivity: number };
     focusEntity: PcEntity | null;
     frameOnStart: boolean;
   }>({
     distanceMin: 0.05,
     distanceMax: 10,
     distance: 3,
-    mouse: { distanceSensitivity: 0.1 },
-    touch: { distanceSensitivity: 0.1 },
     focusEntity: null,
     frameOnStart: true,
   });
@@ -58,14 +54,11 @@ function Scene({ splatUrl }: { splatUrl: string }) {
       Math.max(radius * 3, distanceMin + radius * 0.5),
       distanceMax - radius * 0.1
     );
-    const sensitivity = Math.min(Math.max(radius * 0.1, 0.02), 5);
 
     setControls({
       distanceMin,
       distanceMax,
       distance,
-      mouse: { distanceSensitivity: sensitivity },
-      touch: { distanceSensitivity: sensitivity },
       focusEntity: (gsplatEntityRef.current as PcEntity | null) ?? null,
       frameOnStart: true,
     });
@@ -88,8 +81,6 @@ function Scene({ splatUrl }: { splatUrl: string }) {
           distanceMin={controls.distanceMin}
           distanceMax={controls.distanceMax}
           distance={controls.distance}
-          mouse={{ distanceSensitivity: controls.mouse.distanceSensitivity }}
-          touch={{ distanceSensitivity: controls.touch.distanceSensitivity }}
           focusEntity={controls.focusEntity}
           frameOnStart={controls.frameOnStart}
         />


### PR DESCRIPTION
# Remove custom zoom sensitivity from PlayCanvasViewer

## Description

Removed custom zoom sensitivity calculation from the PlayCanvas GSplat viewer and reverted to using PlayCanvas default sensitivity values.

### What Changed
- Removed `mouse` and `touch` `distanceSensitivity` properties from `OrbitControls`
- Deleted radius-based sensitivity calculation (`radius * 0.015`)
- Simplified `controls` state to only include distance bounds and focus settings
- Kept existing AABB-based distance min/max/initial positioning logic

### Why
The custom sensitivity heuristic (`radius * multiplier`) was producing inconsistent user experience across different datasets:
- Large datasets felt overly sensitive/twitchy
- Small datasets felt sluggish
- PlayCanvas defaults provide more consistent, predictable zoom behavior

### Impact
- **User Experience**: More consistent zoom sensitivity across all datasets
- **Code**: Simplified component with less custom logic
- **Performance**: No performance impact
- **API**: No breaking changes

### Testing
- Manually tested with multiple datasets of varying scales
- Confirmed improved consistency in zoom responsiveness
- Linter passes with no errors

### Rollback Plan
If issues arise, can revert this commit or reintroduce sensitivity props with a more conservative multiplier (e.g., `radius * 0.01`).