### PR TITLE
fix RPC client reliability and connection handling

### DIFF
--- a/backend/app/tasks/raw_image_processing_tasks.py
+++ b/backend/app/tasks/raw_image_processing_tasks.py
@@ -219,6 +219,8 @@ def start_raw_data_processing(task_data: Tuple[UUID, str]) -> None:
     """
     job_id, raw_data_identifier = task_data
 
+    rpc_client = None
+
     try:
         # Get job manager for current job
         job = JobManager(job_id=job_id)
@@ -239,5 +241,5 @@ def start_raw_data_processing(task_data: Tuple[UUID, str]) -> None:
         # update job
         job.update(status=Status.FAILED)
     finally:
-        if isinstance(rpc_client, RpcClient):
+        if rpc_client and getattr(rpc_client.connection, "is_open", False):
             rpc_client.connection.close()

--- a/backend/app/utils/RpcClient.py
+++ b/backend/app/utils/RpcClient.py
@@ -1,7 +1,9 @@
+import time
 import uuid
 from typing import Optional
 
 import pika
+from pika.exceptions import AMQPError
 
 from app.utils.rabbitmq import get_pika_connection
 
@@ -11,7 +13,8 @@ class RpcClient:
         self.connection = get_pika_connection()
         self.channel = self.connection.channel()
 
-        result = self.channel.queue_declare(queue="", exclusive=True)
+        # transient, exclusive reply queue
+        result = self.channel.queue_declare(queue="", exclusive=True, auto_delete=True)
         self.callback_queue = result.method.queue
 
         self.channel.basic_consume(
@@ -22,7 +25,6 @@ class RpcClient:
 
         self.response: Optional[bytes] = None
         self.corr_id: Optional[str] = None
-
         self.routing_key = routing_key
 
     def on_response(
@@ -35,23 +37,35 @@ class RpcClient:
         if self.corr_id == properties.correlation_id:
             self.response = body
 
-    def call(self, message: str) -> Optional[str]:
+    def call(self, message: str, rpc_timeout_sec: int = 900) -> Optional[str]:
         self.response = None
         self.corr_id = str(uuid.uuid4())
+
         self.channel.basic_publish(
             exchange="",
             routing_key=self.routing_key,
             properties=pika.BasicProperties(
                 reply_to=self.callback_queue,
                 correlation_id=self.corr_id,
+                content_type="text/plain; charset=utf-8",
+                delivery_mode=1,
             ),
-            body=message,
+            body=message.encode("utf-8"),
         )
+
+        start_time = time.time()
+
+        # Pump I/O so heartbeats are sent and replies received
         while self.response is None:
-            self.connection.process_data_events()
+            self.connection.process_data_events(time_limit=1.0)
 
-        # check if response is an error
-        if self.response.decode("utf-8").startswith("Error:"):
+            if time.time() - start_time > rpc_timeout_sec:
+                return None
+
+            if self.connection.is_closed:
+                raise AMQPError("Connection closed while waiting for RPC reply")
+
+        text = self.response.decode("utf-8", errors="replace")
+        if text.startswith("Error:"):
             return None
-
-        return self.response.decode("utf-8")
+        return text


### PR DESCRIPTION
## Summary
This PR improves the reliability of the RPC client used for communication with external image processing services and fixes connection handling issues in raw data processing tasks.

## Changes Made

### RpcClient.py
- **Added timeout support**: RPC calls now have a configurable timeout (default 900 seconds) to prevent indefinite blocking
- **Improved heartbeat handling**: Added proper I/O pumping with time limits to ensure heartbeats are sent and received
- **Enhanced error handling**: Added detection for closed connections and proper AMQP error handling
- **Better message encoding**: Messages are now properly encoded as UTF-8 with error handling
- **Queue configuration**: Added `auto_delete=True` to reply queues for better cleanup
- **Message properties**: Added content type and delivery mode for better message handling

### raw_image_processing_tasks.py
- **Fixed connection cleanup**: Improved the finally block to properly check if the RPC client connection is open before attempting to close it
- **Better error handling**: Added proper null checking for the RPC client before cleanup

## Impact
- Prevents RPC calls from hanging indefinitely
- Reduces connection leaks and resource issues
- Improves reliability of external image processing job initiation
- Better error reporting and debugging capabilities