### PR TITLE
update dockerfile to use varnish v7

### DIFF
--- a/varnish/varnish.dockerfile
+++ b/varnish/varnish.dockerfile
@@ -1,5 +1,5 @@
 # Use the official varnish image as the base
-FROM varnish:latest
+FROM varnish:7
 
 # set the user to root, and install build dependencies
 USER root


### PR DESCRIPTION
## Summary
Updates the Varnish Docker image tag from `latest` to `7` for better version pinning and reproducible builds.

## Changes
- **File:** `varnish/varnish.dockerfile`
- **Change:** Updated base image from `varnish:latest` to `varnish:7`

## Motivation
- **Reproducible builds**: Using a specific version tag ensures consistent behavior across different environments and deployments
- **Stability**: Pinning to version 7 prevents unexpected breaking changes that could occur with automatic latest updates
- **Version control**: Makes it explicit which version of Varnish is being used in the application stack

## Impact
- No functional changes expected as version 7 is the current latest stable release
- Improves deployment predictability and debugging capabilities
- Follows best practices for Docker image versioning in production environments