### PR TITLE
[Bug] Fix measure tool buttons blocked by units toggle overlay

### DIFF
--- a/frontend/src/components/maps/MeasureToolsToggle.tsx
+++ b/frontend/src/components/maps/MeasureToolsToggle.tsx
@@ -38,9 +38,9 @@ export default function MeasureToolsToggle() {
 
   return (
     <>
-      <div className="absolute bottom-9 right-2 m-2.5 flex flex-col items-end gap-2 z-10">
+      <div className="absolute bottom-9 right-2 m-2.5 flex flex-col items-end gap-2 z-10 pointer-events-none">
         {isExpanded && (
-          <div className="bg-white rounded-md shadow-md px-3 py-2 flex items-center gap-2 relative z-10">
+          <div className="bg-white rounded-md shadow-md px-3 py-2 flex items-center gap-2 relative z-10 pointer-events-auto">
             <span className="text-xs text-slate-500">Units:</span>
             <button
               type="button"
@@ -58,7 +58,7 @@ export default function MeasureToolsToggle() {
           {shouldRender && <MeasureTerraDrawControl unitType={unitType} />}
           <button
             type="button"
-            className="h-12 w-12 bg-white rounded-md shadow-md flex items-center justify-center text-slate-600 hover:text-slate-800 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-accent2 transition-colors relative z-10"
+            className="h-12 w-12 bg-white rounded-md shadow-md flex items-center justify-center text-slate-600 hover:text-slate-800 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-accent2 transition-colors relative z-10 pointer-events-auto"
             aria-label={
               isExpanded ? 'Hide measurement tools' : 'Show measurement tools'
             }


### PR DESCRIPTION
## Summary
Fixes a pointer event issue where the MeasureToolsToggle component's container div was blocking clicks to the MeasureTerraDrawControl buttons underneath, preventing some measure buttons from being clickable even though they were visually unobstructed.

## Changes
 - Frontend: Added `pointer-events-none` to the MeasureToolsToggle container div to allow clicks to pass through
 - Frontend: Added `pointer-events-auto` to interactive child elements (units toggle and ruler button) to re-enable their click handlers
 - Maintains visual layering (z-index) while fixing event propagation

## Testing
Manual QA steps:
 1. Navigate to a map view with the measurement tools
 2. Click the ruler button to expand the measure tools
 3. Verify all measure tool buttons (point, linestring, polygon, rectangle, circle, etc.) are clickable
 4. Verify the units toggle button remains clickable
 5. Verify the ruler toggle button remains clickable

## Related Issues
Resolves issue where measure tool buttons were visually present but unclickable due to pointer event blocking.