### PR TITLE
  [Enhancement] Improve measurement unit consistency and remove elevation display

### DIFF
--- a/frontend/src/components/maps/MeasureTerraDrawControl.tsx
+++ b/frontend/src/components/maps/MeasureTerraDrawControl.tsx
@@ -39,7 +39,9 @@ export default function MeasureTerraDrawControl({
       measureUnitType: unitType,
       distancePrecision: 2,
       areaPrecision: 2,
-      computeElevation: true,
+      forceAreaUnit: unitType === 'metric' ? 'square meters' : 'acres',
+      forceDistanceUnit: unitType === 'metric' ? 'meter' : 'foot',
+      computeElevation: false,
     });
 
     // Set font glyphs to use fonts available in OpenMapTiles


### PR DESCRIPTION
## Summary
Improves the measurement tool user experience by constraining unit display to preferred units (meters/feet for distance, square meters/acres for area) and removes elevation computation to avoid potential confusion from inaccurate elevation data.

## Changes
 - Frontend: Added `forceAreaUnit` to constrain area measurements to square meters (metric) or acres (imperial)
 - Frontend: Added `forceDistanceUnit` to constrain distance measurements to meters (metric) or feet (imperial)
 - Frontend: Disabled `computeElevation` to prevent displaying potentially inaccurate elevation data

## Testing
Manual QA steps:
 1. Navigate to a map view and expand the measurement tools
 2. Set units to Metric and draw a line - verify distance displays in meters
 3. Draw a polygon in Metric mode - verify area displays in square meters
 4. Switch to Imperial units and draw a line - verify distance displays in feet
 5. Draw a polygon in Imperial mode - verify area displays in acres
 6. Verify no elevation data is displayed in measurements

## Related Issues
Improves measurement display consistency by using preferred units and removing potentially confusing elevation information.