### PR TITLE
[Feature] Add ability to update vector layer names

### DIFF
--- a/backend/app/crud/crud_vector_layer.py
+++ b/backend/app/crud/crud_vector_layer.py
@@ -226,6 +226,36 @@ class CRUDVectorLayer(CRUDBase[VectorLayer, VectorLayerCreate, VectorLayerUpdate
         # Each list element is a list of features from a feature collection
         return list(vector_layers.values())
 
+    def update_layer_name_by_id(
+        self, db: Session, project_id: UUID, layer_id: str, layer_name: str
+    ) -> List[Feature]:
+        """Updates the layer_name for all features in a vector layer.
+
+        Args:
+            db (Session): Database session.
+            project_id (UUID): Project ID.
+            layer_id (str): Layer ID for feature collection.
+            layer_name (str): New layer name.
+
+        Returns:
+            List[Feature]: Updated features in Feature Collection.
+        """
+        with db.begin():
+            update_statement = (
+                update(VectorLayer)
+                .values(layer_name=layer_name)
+                .where(
+                    and_(
+                        VectorLayer.layer_id == layer_id,
+                        VectorLayer.project_id == project_id,
+                        VectorLayer.is_active,
+                    )
+                )
+            )
+            db.execute(update_statement)
+
+        return self.get_vector_layer_by_id(db, project_id=project_id, layer_id=layer_id)
+
     def remove_layer_by_id(self, db: Session, project_id: UUID, layer_id: str) -> None:
         """_summary_
 

--- a/backend/app/schemas/vector_layer.py
+++ b/backend/app/schemas/vector_layer.py
@@ -19,7 +19,7 @@ class VectorLayerCreate(VectorLayerBase):
 
 
 class VectorLayerUpdate(VectorLayerBase):
-    pass
+    layer_name: str
 
 
 class VectorLayerInDBBase(VectorLayerBase, from_attributes=True):

--- a/backend/app/tests/crud/test_vector_layer.py
+++ b/backend/app/tests/crud/test_vector_layer.py
@@ -208,6 +208,48 @@ def test_read_vector_layer_by_id_with_metadata(db: Session) -> None:
         assert expected_zonal_stat in vector_layers_with_zonal_metadata[0].properties
 
 
+def test_update_vector_layer_name(db: Session) -> None:
+    project = create_project(db)
+    # Create a point feature collection with one feature
+    point_fc = create_feature_collection(db, "point", project_id=project.id)
+    original_layer_name = point_fc.features[0].properties["layer_name"]
+    layer_id = point_fc.features[0].properties["layer_id"]
+    new_layer_name = "Updated Layer Name"
+
+    # Update the layer name
+    updated_features = crud.vector_layer.update_layer_name_by_id(
+        db, project_id=project.id, layer_id=layer_id, layer_name=new_layer_name
+    )
+
+    # Verify the update
+    assert updated_features and isinstance(updated_features, list)
+    assert len(updated_features) == 1
+    assert updated_features[0].properties
+    assert updated_features[0].properties.get("layer_name") == new_layer_name
+    assert updated_features[0].properties.get("layer_name") != original_layer_name
+
+
+def test_update_vector_layer_name_with_multiple_features(db: Session) -> None:
+    project = create_project(db)
+    # Create a multipoint feature collection with three features
+    multi_fc = create_feature_collection(db, "multipoint", project_id=project.id)
+    layer_id = multi_fc.features[0].properties["layer_id"]
+    new_layer_name = "Updated Multipoint Layer"
+
+    # Update the layer name
+    updated_features = crud.vector_layer.update_layer_name_by_id(
+        db, project_id=project.id, layer_id=layer_id, layer_name=new_layer_name
+    )
+
+    # Verify all three features were updated
+    assert updated_features and isinstance(updated_features, list)
+    assert len(updated_features) == 3
+    for feature in updated_features:
+        assert feature.properties
+        assert feature.properties.get("layer_name") == new_layer_name
+        assert feature.properties.get("layer_id") == layer_id
+
+
 def test_remove_vector_layer(db: Session) -> None:
     project = create_project(db)
     # point feature collection with three points (features)

--- a/frontend/src/components/pages/projects/ProjectContext/actions.tsx
+++ b/frontend/src/components/pages/projects/ProjectContext/actions.tsx
@@ -8,7 +8,9 @@ export type IForesterAction = { type: string; payload: IForester[] | null };
 export type LocationAction = { type: string; payload: GeoJSONFeature | null };
 export type FlightsAction = { type: string; payload: Flight[] | null };
 export type FlightsFilterSelectionAction = { type: string; payload?: string[] };
-export type MapLayersAction = { type: string; payload?: MapLayer[] };
+export type MapLayersAction =
+  | { type: 'set' | 'update' | 'remove' | 'clear'; payload?: MapLayer[] }
+  | { type: 'updateOne'; payload: MapLayer };
 export type ProjectAction = { type: string; payload: Project | null };
 export type ProjectFilterSelectionAction = { type: string; payload?: string[] };
 export type ProjectMembersAction = {

--- a/frontend/src/components/pages/projects/ProjectContext/reducers.tsx
+++ b/frontend/src/components/pages/projects/ProjectContext/reducers.tsx
@@ -109,6 +109,11 @@ function mapLayersReducer(state: MapLayer[], action: MapLayersAction) {
         return state;
       }
     }
+    case 'updateOne': {
+      return state.map((layer) =>
+        layer.layer_id === action.payload.layer_id ? action.payload : layer
+      );
+    }
     case 'remove': {
       if (action.payload) {
         if (state.length > 0 && action.payload.length === 1) {

--- a/frontend/src/components/pages/projects/mapLayers/MapLayersTable.tsx
+++ b/frontend/src/components/pages/projects/mapLayers/MapLayersTable.tsx
@@ -1,9 +1,14 @@
 import { AxiosResponse, isAxiosError } from 'axios';
 import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { PhotoIcon } from '@heroicons/react/24/outline';
+import {
+  PhotoIcon,
+  PencilIcon,
+  CheckIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 
-import { MapLayerFeatureCollection } from '../Project';
+import { MapLayer, MapLayerFeatureCollection } from '../Project';
 import MapLayerDownloadLinks from './MapLayerDownloadLink';
 import ConfirmationModal from '../../../ConfirmationModal';
 import { getMapLayers, useProjectContext } from '../ProjectContext';
@@ -62,6 +67,8 @@ export default function ProjectLayersTable() {
   const { projectId } = useParams();
 
   const [status, setStatus] = useState<Status | null>(null);
+  const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState<string>('');
 
   useInterval(
     () => {
@@ -78,13 +85,88 @@ export default function ProjectLayersTable() {
     );
   }, [mapLayers, projectId]);
 
+  const handleEdit = (layer: MapLayer) => {
+    setEditingLayerId(layer.layer_id);
+    setEditingValue(layer.layer_name);
+  };
+
+  const handleCancel = () => {
+    setEditingLayerId(null);
+    setEditingValue('');
+  };
+
+  const handleSave = async (layer: MapLayer) => {
+    const trimmedValue = editingValue.trim();
+
+    // Validation: prevent empty names
+    if (!trimmedValue) {
+      setStatus({
+        type: 'error',
+        msg: 'Layer name cannot be empty',
+      });
+      return;
+    }
+
+    // If unchanged, just exit edit mode
+    if (trimmedValue === layer.layer_name) {
+      handleCancel();
+      return;
+    }
+
+    if (projectId) {
+      try {
+        const response: AxiosResponse<MapLayerFeatureCollection> =
+          await api.put(
+            `/projects/${projectId}/vector_layers/${layer.layer_id}`,
+            { layer_name: trimmedValue }
+          );
+
+        if (response.status === 200) {
+          // Update the layer in context
+          mapLayersDispatch({
+            type: 'updateOne',
+            payload: { ...layer, layer_name: trimmedValue },
+          });
+          handleCancel();
+          setStatus({
+            type: 'success',
+            msg: 'Layer name updated successfully',
+          });
+        }
+      } catch (err) {
+        if (isAxiosError(err)) {
+          setStatus({
+            type: 'error',
+            msg: err.response?.data.detail || 'Unable to update layer name',
+          });
+        } else {
+          setStatus({
+            type: 'error',
+            msg: 'Unable to update layer name',
+          });
+        }
+      }
+    }
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    layer: MapLayer
+  ) => {
+    if (e.key === 'Enter') {
+      handleSave(layer);
+    } else if (e.key === 'Escape') {
+      handleCancel();
+    }
+  };
+
   return (
     <div className="max-h-96 overflow-auto">
-      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
+      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1 table-fixed">
         <thead>
           <tr className="h-12 sticky top-0 text-white bg-slate-300">
             <th>Preview</th>
-            <th>Name</th>
+            <th className="w-64">Name</th>
             <th>Type</th>
             <th>Download</th>
             {projectRole !== 'viewer' && <th>Remove</th>}
@@ -110,7 +192,53 @@ export default function ProjectLayersTable() {
                     <PhotoIcon />
                   )}
                 </td>
-                <td className="p-4 bg-white">{layer.layer_name}</td>
+                <td className="p-4 bg-white">
+                  {editingLayerId === layer.layer_id ? (
+                    // Edit mode
+                    <div className="flex items-center gap-4">
+                      <input
+                        type="text"
+                        value={editingValue}
+                        onChange={(e) => setEditingValue(e.target.value)}
+                        onKeyDown={(e) => handleKeyDown(e, layer)}
+                        className="w-32 px-2 py-1 border border-gray-400 rounded focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+                        autoFocus
+                      />
+                      <div className="flex gap-4 flex-shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleSave(layer)}
+                          className="inline rounded-full focus:outline-none focus:ring focus:ring-accent2"
+                          title="Save"
+                        >
+                          <CheckIcon className="h-4 w-4 text-slate-400 cursor-pointer" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleCancel}
+                          className="inline rounded-full focus:outline-none focus:ring focus:ring-accent2"
+                          title="Cancel"
+                        >
+                          <XMarkIcon className="h-4 w-4 text-slate-400 cursor-pointer" />
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    // Display mode
+                    <div className="flex items-center gap-8">
+                      <span className="block my-1 mx-0 truncate">{layer.layer_name}</span>
+                      {projectRole !== 'viewer' && (
+                        <span className="flex-shrink-0">
+                          <PencilIcon
+                            className="inline h-4 w-4 text-slate-400 cursor-pointer"
+                            onClick={() => handleEdit(layer)}
+                            title="Edit layer name"
+                          />
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </td>
                 <td className="p-4 bg-white">
                   <div className="flex items-center justify-center gap-2">
                     <img src={getGeomTypeIcon(layer.geom_type)} />


### PR DESCRIPTION
## Summary
Adds a new API endpoint and inline editing UI to allow project owners and managers to update vector layer names. Users can click a pencil icon next to the layer name to edit it directly in the Map Layers table.

## Changes
 - **Backend:**
   - Added `layer_name` field to `VectorLayerUpdate` schema (backend/app/schemas/vector_layer.py:22)
   - Implemented `update_layer_name_by_id()` CRUD method (backend/app/crud/crud_vector_layer.py:229-257)
   - Added `PUT /projects/{project_id}/vector_layers/{layer_id}` endpoint (backend/app/api/api_v1/endpoints/vector_layers.py:410-466)
   - Updates all database records sharing the same `layer_id` to maintain consistency across multi-feature layers
   - Added 2 CRUD tests and 6 API tests covering single/multi-feature updates and role-based permissions

 - **Frontend:**
    - Added `updateOne` action to `MapLayersAction` type (frontend/src/components/pages/projects/ProjectContext/actions.tsx:11-13)
    - Implemented `updateOne` reducer case (frontend/src/components/pages/projects/ProjectContext/reducers.tsx:112-116)
    - Added inline editing UI to MapLayersTable with pencil/check/cancel icons (frontend/src/components/pages/projects/mapLayers/MapLayersTable.tsx)
    - Used Heroicons and styling matching existing `EditField` component pattern
    - Applied `table-fixed` layout to prevent column width changes during editing
    - Keyboard support: Enter to save, Escape to cancel

## Testing
**Backend tests:**
```bash
  docker compose exec backend pytest app/tests/crud/test_vector_layer.py -v
  # Result: 12 passed (including 2 new tests)

  docker compose exec backend pytest app/tests/api/api_v1/test_vector_layers.py -v
  # Result: 30 passed (including 6 new tests)
```

**Manual QA:**
1. Navigate to /projects/{project_id} and click "Map Layers" tab
2. As owner/manager: Click pencil icon next to layer name → edit → click checkmark
3. Verify layer name updates successfully
4. As viewer: Confirm pencil icon does not appear
5. Test validation: Attempt to save empty name → error displayed
6. Test keyboard: Enter saves, Escape cancels
7. Test multi-feature layers: Verify all features update together

**Breaking Changes**
None - this is a new feature with no changes to existing endpoints