### PR TITLE
[Enhancement] Add dynamic filenames for zonal statistics downloads

### DIFF
--- a/frontend/src/components/pages/projects/flights/DataProducts/ToolboxModal.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/ToolboxModal.tsx
@@ -201,7 +201,7 @@ export default function ToolboxModal({
                     getNumOfBands(dataProduct) === 1 && (
                       <>
                         <HillshadeTools />
-                        <ZonalStatisticTools dataProductId={dataProduct.id} />
+                        <ZonalStatisticTools dataProduct={dataProduct} />
                       </>
                     )}
                   {/* point cloud tools */}

--- a/frontend/src/components/pages/projects/flights/DataProducts/ToolboxTools.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/ToolboxTools.tsx
@@ -296,16 +296,17 @@ const MultiSpectralTools = ({ dataProduct }: { dataProduct: DataProduct }) => {
 };
 
 const DownloadZonalStatistics = ({
-  dataProductId,
+  dataProduct,
   layerId,
 }: {
-  dataProductId: string;
+  dataProduct: DataProduct;
   layerId: string;
 }) => {
   const [zonalFeatureCollection, setZonalFeatureCollection] =
     useState<ZonalFeatureCollection | null>(null);
 
   const { projectId, flightId } = useParams();
+  const { project, flights } = useProjectContext();
 
   const keysToSkip = [
     'id',
@@ -316,12 +317,47 @@ const DownloadZonalStatistics = ({
     'data_product_id',
   ];
 
+  const generateFilename = (extension: string): string => {
+    // Helper function to sanitize filename parts
+    const sanitize = (str: string | null | undefined): string => {
+      if (!str) return '';
+      return str.replace(/[^a-zA-Z0-9-]/g, '-');
+    };
+
+    // Get project title
+    const projectTitle = sanitize(project?.title);
+
+    // Get current flight data
+    const currentFlight = flights?.find((f) => f.id === flightId);
+    const acquisitionDate = currentFlight?.acquisition_date || '';
+    const sensor = sanitize(currentFlight?.sensor);
+
+    // Get data type
+    const dataType = sanitize(dataProduct.data_type);
+
+    // Build filename parts (exclude empty strings)
+    const parts = [
+      projectTitle,
+      acquisitionDate,
+      sensor,
+      dataType,
+      'zonal_statistics',
+    ].filter(Boolean);
+
+    // Fallback to original filename if we don't have enough data
+    if (parts.length < 2) {
+      return `zonal_statistics.${extension}`;
+    }
+
+    return `${parts.join('_')}.${extension}`;
+  };
+
   useEffect(() => {
     async function fetchZonalStats() {
       try {
         const response: AxiosResponse<ZonalFeatureCollection | null> =
           await api.get(
-            `/projects/${projectId}/flights/${flightId}/data_products/${dataProductId}/zonal_statistics?layer_id=${layerId}`
+            `/projects/${projectId}/flights/${flightId}/data_products/${dataProduct.id}/zonal_statistics?layer_id=${layerId}`
           );
         if (response.status === 200) {
           setZonalFeatureCollection(response.data);
@@ -336,7 +372,7 @@ const DownloadZonalStatistics = ({
         );
       }
     }
-    if (projectId && flightId && dataProductId) {
+    if (projectId && flightId && dataProduct.id) {
       fetchZonalStats();
     }
   }, []);
@@ -363,7 +399,7 @@ const DownloadZonalStatistics = ({
             )
           );
           const csvFile = new Blob([csvData], { type: 'text/csv' });
-          downloadCSV(csvFile, 'zonal_statistics.csv');
+          downloadCSV(csvFile, generateFilename('csv'));
         }}
       >
         Download CSV
@@ -375,7 +411,7 @@ const DownloadZonalStatistics = ({
           downloadGeoJSON(
             'json',
             removeKeysFromFeatureProperties(zonalFeatureCollection, keysToSkip),
-            'zonal_statistics.geojson'
+            generateFilename('geojson')
           );
         }}
       >
@@ -385,7 +421,7 @@ const DownloadZonalStatistics = ({
   );
 };
 
-const ZonalStatisticTools = ({ dataProductId }: { dataProductId: string }) => {
+const ZonalStatisticTools = ({ dataProduct }: { dataProduct: DataProduct }) => {
   const { values } = useFormikContext<ToolboxFields>();
   const { mapLayers } = useProjectContext();
 
@@ -430,7 +466,7 @@ const ZonalStatisticTools = ({ dataProductId }: { dataProductId: string }) => {
                     {(geom_type.toLowerCase() === 'polygon' ||
                       geom_type.toLowerCase() === 'multipolygon') && (
                       <DownloadZonalStatistics
-                        dataProductId={dataProductId}
+                        dataProduct={dataProduct}
                         layerId={layer_id}
                       />
                     )}


### PR DESCRIPTION
## Summary
Improves the zonal statistics download feature by generating descriptive filenames that include project title, flight acquisition date, sensor, and data type instead of the generic "zonal_statistics.csv" and "zonal_statistics.geojson".

## Changes
 - Frontend: Updated `DownloadZonalStatistics` component to generate dynamic filenames from project, flight, and data product metadata
 - Frontend: Modified `ZonalStatisticTools` to pass full `DataProduct` object instead of just the ID
 - Frontend: Updated `ToolboxModal` to pass complete data product to zonal statistics tools
 - Implemented sanitization logic that replaces special characters with hyphens while using underscores as field separators

## Testing
**Manual QA steps:**
1. Navigate to a project with flights and data products (single-band raster with DTM/DSM/DEM)
2. Open the Toolbox modal for a data product
3. Enable "Zonal Statistics" and select a polygon layer
4. Click "Download CSV" and verify the filename follows the pattern: `{project_title}_{acquisition_date}_{sensor}_{data_type}_zonal_statistics.csv`
5. Click "Download GeoJSON" and verify similar filename pattern with `.geojson` extension
6. Verify special characters in project title or sensor name are replaced with hyphens
7. Test fallback: If data is missing, should default to `zonal_statistics.{ext}`

Example filename: `Corn-Field-Study_2024-01-15_RGB_DSM_zonal_statistics.csv`

## Breaking Changes
None - changes are backwards compatible with proper fallback handling