### PR TITLE
[Enhancement] Revise COG conversion to use gdal_translate and calculate statistics

### DIFF
--- a/backend/app/utils/ImageProcessor.py
+++ b/backend/app/utils/ImageProcessor.py
@@ -139,7 +139,7 @@ def get_info(in_raster: Path) -> dict | NoReturn:
         dict: _description_
     """
     result: subprocess.CompletedProcess = subprocess.run(
-        ["gdalinfo", "-approx_stats", "-json", in_raster],
+        ["gdalinfo", "-json", in_raster],
         stdout=subprocess.PIPE,
         check=True,
     )
@@ -202,7 +202,7 @@ def convert_to_cog(
     project_to_utm: bool,
     num_threads: int | None = None,
 ) -> None:
-    """Runs gdalwarp to generate new raster in COG layout.
+    """Runs gdal_translate to generate new raster in COG layout.
 
     Args:
         in_raster (Path): Path to input raster dataset.
@@ -215,7 +215,7 @@ def convert_to_cog(
 
     # Build the base command
     command: List[str] = [
-        "gdalwarp",
+        "gdal_translate",
         str(in_raster),
         str(out_raster),
         "-of",
@@ -226,8 +226,8 @@ def convert_to_cog(
         f"NUM_THREADS={num_threads}",
         "-co",
         "BIGTIFF=YES",
-        "-wm",
-        "500",
+        "-co",
+        "STATISTICS=YES",
     ]
 
     # Add projection parameters if needed


### PR DESCRIPTION
 ## Summary
Improves Cloud Optimized GeoTIFF (COG) generation by switching from `gdalwarp` to `gdal_translate` and enabling automatic statistics calculation during conversion, resulting in more efficient processing and better metadata for generated rasters.

## Changes
 - Backend: Replaced `gdalwarp` with `gdal_translate` in `ImageProcessor.py` COG conversion function
 - Backend: Added `STATISTICS=YES` creation option to calculate raster statistics during COG generation
 - Backend: Removed `-wm 500` memory parameter (not applicable to gdal_translate)
 - Backend: Removed `-approx_stats` flag from `gdalinfo` calls to avoid redundant computation

## Testing
 - Manual testing: Processed orthomosaics through the full pipeline and verified COG generation
 - Confirmed generated COGs include statistics metadata
 - Verified COGs are properly tiled and optimized for web serving