### PR TITLE
[Enhancement] Add point size control to Potree viewer

### DIFF
--- a/backend/app/api/extras.py
+++ b/backend/app/api/extras.py
@@ -448,6 +448,58 @@ def generate_potree_viewer_html(
       viewer.loadGUI(() => {{
         viewer.setLanguage('en');
         $("#menu_tools").next().show();
+
+        // Inject Point Size slider into Appearance section
+        setTimeout(() => {{
+          // Check if already injected to avoid duplicates
+          if ($('#sldPointSize').length > 0) return;
+
+          // Find the Appearance section's list
+          const $appearanceList = $('#menu_appearance').next().find('ul.pv-menu-list');
+
+          if ($appearanceList.length === 0) {{
+            console.warn('Appearance list not found');
+            return;
+          }}
+
+          // Create and insert the point size control HTML
+          const $pointSizeControl = $(`
+            <li>
+              <span>Point Size</span>:
+              <span id="lblPointSize"></span>
+              <div id="sldPointSize"></div>
+            </li>
+          `);
+
+          // Insert after the second li (after Point Budget and FOV)
+          const $targetLi = $appearanceList.find('li').eq(1);
+          if ($targetLi.length > 0) {{
+            $targetLi.after($pointSizeControl);
+          }} else {{
+            $appearanceList.prepend($pointSizeControl);
+          }}
+
+          // Initialize slider with current material size
+          const initialSize = PC_IS_MOBILE ? 2.0 : 1.0;
+
+          $('#sldPointSize').slider({{
+            value: initialSize,
+            min: 0.1,
+            max: 10.0,
+            step: 0.1,
+            slide: (event, ui) => {{
+              // Update all point clouds in the scene
+              viewer.scene.pointclouds.forEach(pc => {{
+                pc.material.size = ui.value;
+              }});
+              // Update label display
+              $('#lblPointSize').text(ui.value.toFixed(1));
+            }}
+          }});
+
+          // Set initial label value
+          $('#lblPointSize').text(initialSize.toFixed(1));
+        }}, 100);
       }});
 
       // If we have a CRS, show Cesium and wire up transforms


### PR DESCRIPTION
## Summary
Adds an interactive point size slider to the Potree viewer's Appearance section, allowing users to dynamically adjust point cloud rendering size from 0.1 to 10.0. This improves user control over visualization quality and addresses varying screen sizes and viewing preferences.

## Changes
 - Backend: Modified `backend/app/api/extras.py` to inject a Point Size slider into the Potree viewer UI
 - Slider dynamically updates all point clouds in the scene
 - Default size: 2.0 for mobile devices, 1.0 for desktop
 - Range: 0.1 to 10.0 with 0.1 step increments
 - Control positioned after Point Budget and FOV in the Appearance menu

## Testing
**Manual QA steps:**
 1. Start the application: `docker compose -f docker-compose.quickstart.yml up -d`
 2. Navigate to a project with Potree point cloud visualization
 3. Open the Appearance menu in the Potree viewer
 4. Verify "Point Size" slider appears after Point Budget and FOV controls
 5. Adjust the slider and confirm:
    - Point size updates in real-time
    - Label displays current value (e.g., "2.5")
    - Changes apply to all point clouds in the scene
 6. Test on both desktop and mobile views to verify default sizes

**Results:**
 - Point size control successfully integrates into existing Appearance menu
 - Real-time updates working without performance issues
 - Mobile default (2.0) and desktop default (1.0) applied correctly

## Breaking Changes
None - This is a purely additive enhancement to the viewer UI