### PR TITLE
[Enhancement] Increase maximum zoom level to 26 for all map components

### DIFF
--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -203,6 +203,7 @@ export default function CompareMap() {
         style={LeftMapStyle}
         mapboxAccessToken={mapboxAccessToken || undefined}
         mapStyle={mapStyle}
+        maxZoom={26}
         reuseMaps={true}
       >
         {/* Display project boundary when project activated */}
@@ -256,6 +257,7 @@ export default function CompareMap() {
         style={RightMapStyle}
         mapboxAccessToken={mapboxAccessToken}
         mapStyle={mapStyle}
+        maxZoom={26}
         reuseMaps={true}
       >
         {/* Display project boundary when project activated */}

--- a/frontend/src/components/maps/DrawFieldMap/DrawFieldMap.tsx
+++ b/frontend/src/components/maps/DrawFieldMap/DrawFieldMap.tsx
@@ -261,6 +261,7 @@ export default function DrawFieldMap({
       style={{ width: '100%', height: '100%' }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
+      maxZoom={26}
     >
       {/* Render GeoJSON feature collection if it exists */}
       {featureCollection && !editFeature && (

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -219,6 +219,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
+      maxZoom={26}
       onClick={handleMapClick}
       onMoveEnd={handleMoveEnd}
     >

--- a/frontend/src/components/maps/ShareMap.tsx
+++ b/frontend/src/components/maps/ShareMap.tsx
@@ -178,6 +178,7 @@ export default function ShareMap() {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
+      maxZoom={26}
       reuseMaps={true}
     >
       {/* Display raster tiles */}

--- a/frontend/src/components/pages/admin/DashboardMap.tsx
+++ b/frontend/src/components/pages/admin/DashboardMap.tsx
@@ -106,6 +106,7 @@ export default function DashboardMap() {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
+      maxZoom={26}
       reuseMaps={true}
       onClick={handleMapClick}
     >

--- a/frontend/src/components/pages/projects/iForester/IForesterMap.tsx
+++ b/frontend/src/components/pages/projects/iForester/IForesterMap.tsx
@@ -139,6 +139,7 @@ export default function IForesterMap() {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
+      maxZoom={26}
       reuseMaps={true}
     >
       {/* Cluster markers */}


### PR DESCRIPTION
## Summary
Increases the maximum zoom level from the default (typically 22) to 26 across all map components in the application. This allows users to zoom in much closer to high-resolution imagery and better examine fine details in data products like orthomosaics.

## Changes
**Frontend**
 - Added `maxZoom={26}` prop to all Map components across the application:
   - CompareMap (both left and right map instances)
   - DrawFieldMap
   - HomeMap
   - ShareMap
   - DashboardMap
   - IForesterMap

## Testing
 - Manual QA: Navigate to each map view and verify zoom controls allow zooming to level 26
 - Tested all map components:
    - `/compare` - Both split and side-by-side modes
    - `/draw-field` - Field boundary drawing interface
    - `/` - Home map with project overview
    - `/share/:id` - Shared project view
    - `/admin/dashboard` - Admin dashboard map
    - `/projects/:id/iforester` - iForester integration map
  - Confirmed zoom behavior is smooth and no performance degradation at higher zoom levels

 ## Breaking Changes
 None