### PR TITLE
[Bug] Reduce max zoom level to 25 to prevent performance issues on laptops

### DIFF
--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -203,7 +203,7 @@ export default function CompareMap() {
         style={LeftMapStyle}
         mapboxAccessToken={mapboxAccessToken || undefined}
         mapStyle={mapStyle}
-        maxZoom={26}
+        maxZoom={25}
         reuseMaps={true}
       >
         {/* Display project boundary when project activated */}
@@ -257,7 +257,7 @@ export default function CompareMap() {
         style={RightMapStyle}
         mapboxAccessToken={mapboxAccessToken}
         mapStyle={mapStyle}
-        maxZoom={26}
+        maxZoom={25}
         reuseMaps={true}
       >
         {/* Display project boundary when project activated */}

--- a/frontend/src/components/maps/DrawFieldMap/DrawFieldMap.tsx
+++ b/frontend/src/components/maps/DrawFieldMap/DrawFieldMap.tsx
@@ -261,7 +261,7 @@ export default function DrawFieldMap({
       style={{ width: '100%', height: '100%' }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
-      maxZoom={26}
+      maxZoom={25}
     >
       {/* Render GeoJSON feature collection if it exists */}
       {featureCollection && !editFeature && (

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -219,7 +219,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
-      maxZoom={26}
+      maxZoom={25}
       onClick={handleMapClick}
       onMoveEnd={handleMoveEnd}
     >

--- a/frontend/src/components/maps/ShareMap.tsx
+++ b/frontend/src/components/maps/ShareMap.tsx
@@ -178,7 +178,7 @@ export default function ShareMap() {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
-      maxZoom={26}
+      maxZoom={25}
       reuseMaps={true}
     >
       {/* Display raster tiles */}

--- a/frontend/src/components/pages/admin/DashboardMap.tsx
+++ b/frontend/src/components/pages/admin/DashboardMap.tsx
@@ -106,7 +106,7 @@ export default function DashboardMap() {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
-      maxZoom={26}
+      maxZoom={25}
       reuseMaps={true}
       onClick={handleMapClick}
     >

--- a/frontend/src/components/pages/projects/iForester/IForesterMap.tsx
+++ b/frontend/src/components/pages/projects/iForester/IForesterMap.tsx
@@ -139,7 +139,7 @@ export default function IForesterMap() {
       }}
       mapboxAccessToken={mapboxAccessToken || undefined}
       mapStyle={mapStyle}
-      maxZoom={26}
+      maxZoom={25}
       reuseMaps={true}
     >
       {/* Cluster markers */}


### PR DESCRIPTION
## Summary
Reduces the maximum zoom level from 26 to 25 across all map components to fix panning and zooming lockup on laptops. While zoom level 26 worked well on desktop machines, it caused rendering bottlenecks on resource-constrained devices when reaching max zoom, likely due to GPU memory pressure from overzooming tiles and maintaining large canvas surfaces.

## Changes
 - Frontend: Updated `maxZoom` prop from 26 to 25 on all map components
    - CompareMap (both left and right maps)
    - DrawFieldMap
    - HomeMap
    - ShareMap
    - DashboardMap
    - IForesterMap

## Testing
 - Manual QA: Tested zoom behavior on both desktop and laptop devices
 - Confirmed zoom level 25 provides sufficient detail for orthomosaics and raster datasets
 - Verified no panning/zooming lockup occurs at max zoom on laptops
 - All map interactions (pan, zoom, click events) remain smooth and responsive

## Related Issues
Fixes regression introduced in #271 (which increased max zoom to 26)