### PR TITLE
[Bug] Fix race condition causing raster layers to disappear when vector layers are toggled

### DIFF
--- a/frontend/src/components/maps/ProjectRasterTiles.tsx
+++ b/frontend/src/components/maps/ProjectRasterTiles.tsx
@@ -60,6 +60,28 @@ export default function ProjectRasterTiles({
     [dataProduct, symbology, tileScale]
   );
 
+  // Determine the beforeId, but only use it if the layer actually exists in the map
+  const safeBeforeId = useMemo(() => {
+    if (!map) return undefined;
+
+    // Try the provided beforeLayerId first
+    if (beforeLayerId && map.getLayer(beforeLayerId)) {
+      return beforeLayerId;
+    }
+
+    // Fallback to activeDataProduct if this is not the active one
+    if (
+      dataProduct.id !== activeDataProduct?.id &&
+      activeDataProduct?.id &&
+      map.getLayer(activeDataProduct.id)
+    ) {
+      return activeDataProduct.id;
+    }
+
+    // No valid beforeId found, render on top
+    return undefined;
+  }, [map, beforeLayerId, dataProduct.id, activeDataProduct?.id]);
+
   if (!symbology || !isLoaded || !map || !tiles) return null;
 
   return (
@@ -82,12 +104,7 @@ export default function ProjectRasterTiles({
           'raster-opacity':
             symbology.opacity != null ? symbology.opacity / 100 : 1,
         }}
-        beforeId={
-          beforeLayerId ||
-          (dataProduct.id !== activeDataProduct?.id
-            ? activeDataProduct?.id
-            : undefined)
-        }
+        beforeId={safeBeforeId}
       />
     </Source>
   );

--- a/frontend/src/components/maps/ProjectVectorTiles.tsx
+++ b/frontend/src/components/maps/ProjectVectorTiles.tsx
@@ -1,4 +1,5 @@
-import { Layer, Source } from 'react-map-gl/maplibre';
+import { useEffect, useRef } from 'react';
+import { Layer, Source, useMap } from 'react-map-gl/maplibre';
 
 import { getProjectVectorLayer } from './layerProps';
 import { useMapLayerContext } from './MapLayersContext';
@@ -7,6 +8,43 @@ export default function ProjectVectorTile() {
   const {
     state: { layers },
   } = useMapLayerContext();
+  const { current: map } = useMap();
+  const previousLayersRef = useRef<Set<string>>(new Set());
+
+  // Clean up layers that were unchecked (polygon layers create border layers)
+  useEffect(() => {
+    if (!map) return;
+
+    const currentLayerIds = new Set(
+      layers.filter((layer) => layer.checked).map((layer) => layer.id)
+    );
+
+    // Find layers that were removed (previously checked, now unchecked)
+    const removedLayerIds = Array.from(previousLayersRef.current).filter(
+      (id) => !currentLayerIds.has(id)
+    );
+
+    // Clean up removed layers
+    removedLayerIds.forEach((layerId) => {
+      // Remove border layer first (for polygon layers)
+      const borderLayerId = `${layerId}-border`;
+      if (map.getLayer(borderLayerId)) {
+        map.removeLayer(borderLayerId);
+      }
+
+      // Remove main layer
+      if (map.getLayer(layerId)) {
+        map.removeLayer(layerId);
+      }
+
+      // Remove source last
+      if (map.getSource(layerId)) {
+        map.removeSource(layerId);
+      }
+    });
+
+    previousLayersRef.current = currentLayerIds;
+  }, [layers, map]);
 
   return layers
     .filter((layer) => layer.checked)


### PR DESCRIPTION
## Summary
Fixes a race condition where raster layers would disappear when toggling vector layers on/off, accompanied by MapLibre console errors about non-existent layers and source removal conflicts.

## Root Cause
Recent performance improvements to project fetching (PR #266) exposed a latent race condition in layer rendering logic introduced in commit 83ea4203. The faster database queries removed an accidental timing buffer that was masking the bug—vector layers and raster layers now render nearly simultaneously, causing MapLibre layer reference errors.

## Changes
 - **Frontend: ProjectVectorTiles.tsx**
   - Added explicit layer cleanup logic using `useEffect` to track checked/unchecked layers
   - Properly removes polygon border layers before removing sources to prevent dependency conflicts
   - Prevents "Source cannot be removed while layer is using it" errors

 - **Frontend: ProjectRasterTiles.tsx**
    - Added `safeBeforeId` logic that validates layer existence before using `beforeId` prop
    - Checks if referenced layers actually exist in MapLibre before attempting to position rasters
    - Gracefully falls back to rendering on top if no valid reference layer exists
    - Prevents "Cannot move layer before non-existing layer" errors

## Testing
 - ✅ Activate a flight and data product → raster tiles display correctly
 - ✅ Toggle vector layers on → vector layers appear above rasters, rasters remain visible
 - ✅ Toggle vector layers off → layers cleanly removed, no console errors
 - ✅ Rapid switching between projects and layers → no race condition errors
 - ✅ Console errors eliminated: no more MapLibre layer reference errors

## Technical Details
The bug occurred because:
1. `ProjectRasterTiles` used `beforeId={firstVectorLayerId}` to position rasters below vectors
2. Performance improvements made renders happen nearly simultaneously
3. Raster layers tried to reference vector layer IDs before those layers existed in MapLibre
4. Polygon layers created border layers (`${layer.id}-border`) that weren't explicitly cleaned up

The fix makes layer positioning defensive by checking layer existence and handles cleanup in the correct dependency order (border layer → main layer → source).

## Related Issues
Fixes the issue where raster layers disappear when activating vector layers, introduced after commit 83ea4203 and exposed by performance improvements in PR #266.