### PR TITLE
[Bug] Fix TypeScript warnings in ProjectVectorTiles

### DIFF
--- a/frontend/src/components/maps/ProjectVectorTiles.tsx
+++ b/frontend/src/components/maps/ProjectVectorTiles.tsx
@@ -15,6 +15,8 @@ export default function ProjectVectorTile() {
   useEffect(() => {
     if (!map) return;
 
+    const mapInstance = map.getMap();
+
     const currentLayerIds = new Set(
       layers.filter((layer) => layer.checked).map((layer) => layer.id)
     );
@@ -28,18 +30,18 @@ export default function ProjectVectorTile() {
     removedLayerIds.forEach((layerId) => {
       // Remove border layer first (for polygon layers)
       const borderLayerId = `${layerId}-border`;
-      if (map.getLayer(borderLayerId)) {
-        map.removeLayer(borderLayerId);
+      if (mapInstance.getLayer(borderLayerId)) {
+        mapInstance.removeLayer(borderLayerId);
       }
 
       // Remove main layer
-      if (map.getLayer(layerId)) {
-        map.removeLayer(layerId);
+      if (mapInstance.getLayer(layerId)) {
+        mapInstance.removeLayer(layerId);
       }
 
       // Remove source last
-      if (map.getSource(layerId)) {
-        map.removeSource(layerId);
+      if (mapInstance.getSource(layerId)) {
+        mapInstance.removeSource(layerId);
       }
     });
 


### PR DESCRIPTION
## Summary
Fixes TypeScript errors in ProjectVectorTiles.tsx where `MapRef` methods were being called directly instead of accessing the underlying MapLibre `Map` instance.

## Changes
- **Frontend: ProjectVectorTiles.tsx**
  - Use `map.getMap()` to access the MapLibre Map instance before calling `removeLayer()` and `removeSource()`
  - Resolves TS2551 and TS2339 errors about missing methods on `MapRef` type

## Testing
 - ✅ TypeScript compilation passes without errors for modified files
 - ✅ Functionality remains unchanged from previous PR (#276)
 - ✅ Vector layer cleanup still works correctly
 - ✅ No console errors when toggling layers on/off

## Technical Details
The `useMap()` hook from react-map-gl/maplibre returns a `MapRef` wrapper object, not the raw MapLibre `Map` instance. The `MapRef` type doesn't have `removeLayer()` or `removeSource()` methods—these exist on the underlying map instance accessed via `.getMap()`.

## Related PRs
Follow-up to PR #276 which fixed the race condition in layer rendering.

