### PR TITLE
[Bug] Fix raster layer positioning with vector layers

### DIFF
--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -60,12 +60,6 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
 
   const { state } = useLocation();
 
-  // Calculate the first checked vector layer ID to ensure rasters render below vectors
-  const firstVectorLayerId = useMemo(() => {
-    const checkedLayers = layers.filter((layer) => layer.checked);
-    return checkedLayers.length > 0 ? checkedLayers[0].id : null;
-  }, [layers]);
-
   // Load config for osmLabelFilter
   useEffect(() => {
     fetch('/config.json')
@@ -189,7 +183,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
           <ProjectRasterTiles
             boundingBox={boundingBox}
             dataProduct={activeDataProductSymbology.background}
-            beforeLayerId={firstVectorLayerId}
+            beforeLayerId={activeDataProduct.id}
           />
         );
       } else {
@@ -250,7 +244,6 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
           key={activeDataProduct.id}
           boundingBox={activeDataProduct.bbox || activeProjectBBox || undefined}
           dataProduct={activeDataProduct}
-          beforeLayerId={firstVectorLayerId}
         />
       )}
       {/* Show background raster if one is set */}


### PR DESCRIPTION
## Summary
Fixes an issue where raster layers were not rendering below vector layers correctly. The previous implementation used only the first checked layer ID, which didn't account for the actual layer ordering in MapLibre or polygon border layers. This resulted in rasters sometimes appearing above vectors.

## Changes
  - Frontend: Refactored raster layer positioning logic in `ProjectRasterTiles.tsx`
    - Added `useMapLayerContext` to access current layer state
    - Updated `calculatedBeforeId` logic to iterate through MapLibre's actual layer order
    - Added support for polygon border layers (with `-border` suffix)
    - Removed redundant `firstVectorLayerId` calculation from `HomeMap.tsx`
  - Frontend: Simplified `HomeMap.tsx` layer positioning
    - Removed `firstVectorLayerId` memoization (moved to ProjectRasterTiles)
    - Removed unused `beforeLayerId` prop for active data product raster
    - Changed background raster to use `activeDataProduct.id` as beforeLayerId

## Testing
  - Manual QA steps:
   1. Navigate to a project with both raster and vector layers
   2. Toggle various combinations of vector layers on/off
   3. Verify raster layers always render below all visible vector layers
   4. Test with polygon layers (which create border layers) to ensure proper ordering
   5. Verify background rasters render correctly below the active data product

## Related Issues
Related to maplibre map layer ordering issues