### PR TITLE
[Enhancement] Add parquet and FlatGeobuf URLs to vector layer payload and improve table responsive design

### DIFF
--- a/backend/app/api/api_v1/endpoints/vector_layers.py
+++ b/backend/app/api/api_v1/endpoints/vector_layers.py
@@ -229,6 +229,8 @@ def read_vector_layers(
                 "geom_type": layer[2],
                 "signed_url": get_tile_url_with_signed_payload(layer[0]),
                 "preview_url": get_preview_url(str(project.id), layer[0]),
+                "parquet_url": get_parquet_url(str(project.id), layer[0]),
+                "fgb_url": get_fgb_url(str(project.id), layer[0]),
             }
             for layer in vector_layers
         ]
@@ -585,3 +587,35 @@ def get_preview_url(project_id: str, layer_id: str) -> str:
     base_static_url = f"{settings.API_DOMAIN}{static_dir}"
 
     return f"{base_static_url}/projects/{project_id}/vector/{layer_id}/preview.png"
+
+
+def get_parquet_url(project_id: str, layer_id: str) -> str:
+    """Returns URL for vector layer GeoParquet file.
+
+    Args:
+        project_id (str): Unique project ID.
+        layer_id (str): Unique layer ID.
+
+    Returns:
+        str: URL to vector layer GeoParquet file.
+    """
+    static_dir = get_static_dir()
+    base_static_url = f"{settings.API_DOMAIN}{static_dir}"
+
+    return f"{base_static_url}/projects/{project_id}/vector/{layer_id}/{layer_id}.parquet"
+
+
+def get_fgb_url(project_id: str, layer_id: str) -> str:
+    """Returns URL for vector layer FlatGeobuf file.
+
+    Args:
+        project_id (str): Unique project ID.
+        layer_id (str): Unique layer ID.
+
+    Returns:
+        str: URL to vector layer FlatGeobuf file.
+    """
+    static_dir = get_static_dir()
+    base_static_url = f"{settings.API_DOMAIN}{static_dir}"
+
+    return f"{base_static_url}/projects/{project_id}/vector/{layer_id}/{layer_id}.fgb"

--- a/backend/app/schemas/vector_layer.py
+++ b/backend/app/schemas/vector_layer.py
@@ -53,3 +53,5 @@ class VectorLayerPayload(BaseModel):
     geom_type: str
     signed_url: AnyHttpUrl
     preview_url: AnyHttpUrl
+    parquet_url: AnyHttpUrl
+    fgb_url: AnyHttpUrl

--- a/backend/app/tests/api/api_v1/test_vector_layers.py
+++ b/backend/app/tests/api/api_v1/test_vector_layers.py
@@ -167,6 +167,8 @@ def test_read_vector_layers_with_project_owner_role(
         assert "geom_type" in layer
         assert "signed_url" in layer
         assert "preview_url" in layer
+        assert "parquet_url" in layer
+        assert "fgb_url" in layer
         assert os.path.exists(layer["preview_url"].split(settings.API_DOMAIN)[1])
 
 
@@ -193,6 +195,8 @@ def test_read_vector_layers_with_project_manager_role(
         assert "geom_type" in layer
         assert "signed_url" in layer
         assert "preview_url" in layer
+        assert "parquet_url" in layer
+        assert "fgb_url" in layer
         assert os.path.exists(layer["preview_url"].split(settings.API_DOMAIN)[1])
 
 
@@ -219,6 +223,8 @@ def test_read_vector_layers_with_project_viewer_role(
         assert "geom_type" in layer
         assert "signed_url" in layer
         assert "preview_url" in layer
+        assert "parquet_url" in layer
+        assert "fgb_url" in layer
         assert os.path.exists(layer["preview_url"].split(settings.API_DOMAIN)[1])
 
 

--- a/frontend/src/components/pages/projects/Project.d.ts
+++ b/frontend/src/components/pages/projects/Project.d.ts
@@ -59,6 +59,8 @@ export type MapLayer = {
   geom_type: string;
   signed_url: string;
   preview_url: string;
+  parquet_url: string;
+  fgb_url: string;
 };
 
 type ZonalFeatureProperties = {

--- a/frontend/src/components/pages/projects/mapLayers/MapLayerDownloadLink.tsx
+++ b/frontend/src/components/pages/projects/mapLayers/MapLayerDownloadLink.tsx
@@ -2,24 +2,25 @@ import { useParams } from 'react-router-dom';
 
 interface MapLayerDownloadLinksProps {
   layerId: string;
+  parquetUrl: string;
+  fgbUrl: string;
 }
 
 export default function MapLayerDownloadLinks({
   layerId,
+  parquetUrl,
+  fgbUrl,
 }: MapLayerDownloadLinksProps) {
   const { projectId } = useParams();
 
-  const parquetUrl = `/static/projects/${projectId}/vector/${layerId}/${layerId}.parquet`;
-  const flatgeobufUrl = `/static/projects/${projectId}/vector/${layerId}/${layerId}.fgb`;
-
   return (
-    <div className="flex flex-row items-center justify-center gap-2">
+    <div className="flex flex-row flex-wrap items-center justify-center gap-x-2 gap-y-1">
       <a
         href={`${
           import.meta.env.VITE_API_V1_STR
         }/projects/${projectId}/vector_layers/${layerId}/download?format=json`}
         download={`${layerId}.geojson`}
-        className="text-sky-600 hover:text-sky-800 hover:underline"
+        className="text-sky-600 hover:text-sky-800 hover:underline whitespace-nowrap"
       >
         GeoJSON
       </a>
@@ -29,7 +30,7 @@ export default function MapLayerDownloadLinks({
           import.meta.env.VITE_API_V1_STR
         }/projects/${projectId}/vector_layers/${layerId}/download?format=shp`}
         download={`${layerId}.zip`}
-        className="text-sky-600 hover:text-sky-800 hover:underline"
+        className="text-sky-600 hover:text-sky-800 hover:underline whitespace-nowrap"
       >
         Shapefile
       </a>
@@ -37,15 +38,15 @@ export default function MapLayerDownloadLinks({
       <a
         href={parquetUrl}
         download={`${layerId}.parquet`}
-        className="text-sky-600 hover:text-sky-800 hover:underline"
+        className="text-sky-600 hover:text-sky-800 hover:underline whitespace-nowrap"
       >
         GeoParquet
       </a>
       <span className="text-gray-400">|</span>
       <a
-        href={flatgeobufUrl}
+        href={fgbUrl}
         download={`${layerId}.fgb`}
-        className="text-sky-600 hover:text-sky-800 hover:underline"
+        className="text-sky-600 hover:text-sky-800 hover:underline whitespace-nowrap"
       >
         FlatGeobuf
       </a>

--- a/frontend/src/components/pages/projects/mapLayers/MapLayersTable.tsx
+++ b/frontend/src/components/pages/projects/mapLayers/MapLayersTable.tsx
@@ -173,16 +173,26 @@ export default function ProjectLayersTable() {
 
   return (
     <div className="max-h-96 overflow-auto">
-      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1 table-fixed">
+      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
         <thead>
           <tr className="h-12 sticky top-0 text-white bg-slate-300">
-            <th scope="col">Preview</th>
-            <th scope="col" className="w-64">
+            <th scope="col" className="min-w-[100px] w-[100px]">
+              Preview
+            </th>
+            <th scope="col" className="min-w-[180px]">
               Name
             </th>
-            <th scope="col">Type</th>
-            <th scope="col">Download</th>
-            {projectRole !== 'viewer' && <th scope="col">Remove</th>}
+            <th scope="col" className="min-w-[120px] w-[120px]">
+              Type
+            </th>
+            <th scope="col" className="min-w-[280px]">
+              Download
+            </th>
+            {projectRole !== 'viewer' && (
+              <th scope="col" className="min-w-[80px] w-[80px]">
+                Remove
+              </th>
+            )}
           </tr>
         </thead>
         <tbody>
@@ -192,7 +202,7 @@ export default function ProjectLayersTable() {
                 key={layer.layer_id}
                 className="text-center border-2 border-slate-400"
               >
-                <td className="py-2 bg-white">
+                <td className="py-2 bg-white min-w-[100px] w-[100px]">
                   {layer.preview_url ? (
                     <button
                       type="button"
@@ -215,7 +225,7 @@ export default function ProjectLayersTable() {
                     </div>
                   )}
                 </td>
-                <td className="p-4 bg-white">
+                <td className="p-4 bg-white min-w-[180px]">
                   {editingLayerId === layer.layer_id ? (
                     // Edit mode
                     <div className="flex items-center gap-4">
@@ -268,7 +278,7 @@ export default function ProjectLayersTable() {
                     </div>
                   )}
                 </td>
-                <td className="p-4 bg-white">
+                <td className="p-4 bg-white min-w-[120px] w-[120px]">
                   <div className="flex items-center justify-center gap-2">
                     <img
                       src={getGeomTypeIcon(layer.geom_type)}
@@ -277,13 +287,17 @@ export default function ProjectLayersTable() {
                     {layer.geom_type}
                   </div>
                 </td>
-                <td className="bg-white">
+                <td className="bg-white min-w-[280px] p-2">
                   <div className="flex flex-col gap-4">
-                    <MapLayerDownloadLinks layerId={layer.layer_id} />
+                    <MapLayerDownloadLinks
+                      layerId={layer.layer_id}
+                      parquetUrl={layer.parquet_url}
+                      fgbUrl={layer.fgb_url}
+                    />
                   </div>
                 </td>
                 {projectRole !== 'viewer' && (
-                  <td className="p-4 bg-white">
+                  <td className="p-4 bg-white min-w-[80px] w-[80px]">
                     <ConfirmationModal
                       btnName="Remove map layer"
                       btnType="trashIcon"


### PR DESCRIPTION
## Summary
Adds `parquet_url` and `fgb_url` fields to the vector layer payload returned by the backend API, eliminating the need for manual URL construction on the frontend. Also resolves responsive layout issues in the Map Layers table where content would overflow into adjacent columns on small screens.

## Changes

### Backend
 - **Schema**: Added `parquet_url` and `fgb_url` fields to `VectorLayerPayload` schema
 - **API Endpoints**: Created helper functions `get_parquet_url()` and `get_fgb_url()` to generate static file URLs
 - **Endpoints**: Updated `read_vector_layers` endpoint to include GeoParquet and FlatGeobuf URLs in payload
 - **Tests**: Updated vector layer tests to verify new URL fields are present in responses

### Frontend
 - **Type Definitions**: Added `parquet_url` and `fgb_url` to `MapLayer` type interface
 - **Components**: Refactored `MapLayerDownloadLinks` to accept URLs as props instead of manually constructing paths
 - **Responsive Design**:
   - Removed `table-fixed` class that caused overflow issues
   - Added minimum and fixed widths to table columns (Preview: 100px, Name: 180px min, Type: 120px, Download: 280px min, Remove: 80px)
   - Enabled download link wrapping with `flex-wrap` for better mobile experience
   - Added `whitespace-nowrap` to prevent link text from breaking mid-word

## Testing

```bash
docker compose exec backend pytest app/tests/api/api_v1/test_vector_layers.py -v
```
 - All 32 tests passing
 - Verified parquet_url and fgb_url fields present in payload
 - Confirmed URLs follow expected format: {API_DOMAIN}{STATIC_DIR}/projects/{project_id}/vector/{layer_id}/{layer_id}.{ext}

##  Breaking Changes

None - this is a backward-compatible enhancement. Existing functionality preserved.

##  Related Issues
N/A