### PR TITLE
[Bug] Fix sorting and search bugs in admin users dashboard

### DIFF
--- a/frontend/src/components/pages/admin/DashboardUserList.tsx
+++ b/frontend/src/components/pages/admin/DashboardUserList.tsx
@@ -46,8 +46,8 @@ export default function DashboardUserList({
 }) {
   const { user: currentUser } = useContext(AuthContext);
   const [currentPage, setCurrentPage] = useState(0);
-  const [sortColumn, setSortColumn] = useState<SortColumn>('name');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+  const [sortColumn, setSortColumn] = useState<SortColumn>('created_at');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
 
   const keysToSkip = [
@@ -108,9 +108,9 @@ export default function DashboardUserList({
         await api.patch(`/admin/users/${user.id}/approval`, {
           is_approved: !user.is_approved,
         });
-        // Update parent state
-        setUsers(
-          users.map((u) =>
+        // Update parent state - use callback to update the full user list
+        setUsers((prevUsers) =>
+          prevUsers.map((u) =>
             u.id === user.id ? { ...u, is_approved: !u.is_approved } : u
           )
         );
@@ -132,9 +132,9 @@ export default function DashboardUserList({
 
       switch (sortColumn) {
         case 'name':
-          comparison = `${a.last_name} ${a.first_name}`
+          comparison = `${a.last_name.trim()} ${a.first_name.trim()}`
             .toLowerCase()
-            .localeCompare(`${b.last_name} ${b.first_name}`.toLowerCase());
+            .localeCompare(`${b.last_name.trim()} ${b.first_name.trim()}`.toLowerCase());
           break;
         case 'email':
           comparison = a.email.toLowerCase().localeCompare(b.email.toLowerCase());

--- a/frontend/src/components/pages/admin/DashboardUsers.tsx
+++ b/frontend/src/components/pages/admin/DashboardUsers.tsx
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLoaderData } from 'react-router-dom';
 
 import DashboardUserList from './DashboardUserList';
@@ -74,7 +74,7 @@ export default function DashboardUsers() {
   const [users, setUsers] = useState<User[]>(loadedUsers);
 
   // Sync users when loadedUsers changes
-  useMemo(() => {
+  useEffect(() => {
     setUsers(loadedUsers);
   }, [loadedUsers]);
 
@@ -87,7 +87,7 @@ export default function DashboardUsers() {
       return users
         .slice()
         .sort((a, b) =>
-          sorter(a.last_name.toLowerCase(), b.last_name.toLowerCase())
+          sorter(a.last_name.trim().toLowerCase(), b.last_name.trim().toLowerCase())
         );
     }
 
@@ -101,7 +101,7 @@ export default function DashboardUsers() {
           user.email.toLowerCase().includes(searchTerm)
       )
       .sort((a, b) =>
-        sorter(a.last_name.toLowerCase(), b.last_name.toLowerCase())
+        sorter(a.last_name.trim().toLowerCase(), b.last_name.trim().toLowerCase())
       );
   }, [searchTerm, users]);
 


### PR DESCRIPTION
## Summary
Fixes multiple bugs in the admin users dashboard related to sorting and search functionality. Addresses issues
with whitespace in user names affecting sort order and search breaking after toggling user approval status.

## Changes
- **Frontend**: Fixed sorting to trim whitespace from names before comparison
- **Frontend**: Changed `useMemo` to `useEffect` for proper side effect handling when syncing user state
- **Frontend**: Updated approval toggle to use callback form of `setUsers` to preserve full user list
- **Frontend**: Changed default sort to "Date Joined" in descending order

## Testing
Manual QA steps:
1. Navigate to admin users page (`/admin/users`)
2. Verify users with leading/trailing whitespace in names sort correctly alphabetically
3. Search for users by name (e.g., "so")
4. Toggle approval status for a user in the filtered results
5. Clear the search term and verify all users are still displayed
6. Verify stat cards show correct counts after approval toggles
7. Verify table defaults to sorting by "Date Joined" (newest first)

## Related Issues
Fixes sorting inconsistencies and search state management bugs in admin dashboard.