### PR TITLE
[Bug] Fix quickstart image references and empty URL environment variable handling

### DIFF
--- a/backend.example.env
+++ b/backend.example.env
@@ -12,7 +12,7 @@ ENABLE_STAC=false
 
 # Adds external link to a viewer application in published STAC Items
 # Assumes the URL will accept a "url" query parameter
-EXTERNAL_VIEWER_URL=
+#EXTERNAL_VIEWER_URL=
 
 # Enable OpenTelemetry
 ENABLE_OPENTELEMETRY=false

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -139,6 +139,19 @@ class Settings(BaseSettings):
     STAC_BROWSER_URL: Optional[AnyHttpUrl] = None
     EXTERNAL_VIEWER_URL: Optional[AnyHttpUrl] = None
 
+    @field_validator(
+        "EXTERNAL_VIEWER_URL",
+        "STAC_API_URL",
+        "STAC_API_TEST_URL",
+        "STAC_BROWSER_URL",
+        mode="before",
+    )
+    @classmethod
+    def empty_str_to_none(cls, v):
+        if v == "":
+            return None
+        return v
+
     @property
     def get_stac_api_url(self) -> Optional[AnyHttpUrl]:
         """Get the appropriate STAC API URL based on whether we're running tests."""

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: d2s-app:latest
+    image: gdslab/d2s-app:latest
     platform: linux/x86_64
     depends_on:
       - backend
@@ -24,7 +24,7 @@ services:
       - frontend.env
 
   backend:
-    image: d2s-api:latest
+    image: gdslab/d2s-api:latest
     platform: linux/x86_64
     volumes:
       # - external-data:/srv/external-data
@@ -113,7 +113,7 @@ services:
       - no-new-privileges=true
 
   celery_worker:
-    image: d2s-api:latest
+    image: gdslab/d2s-api:latest
     platform: linux/x86_64
     command: /app/celery/worker-start.sh
     volumes:
@@ -148,7 +148,7 @@ services:
       - db.env
 
   celery_beat:
-    image: d2s-api:latest
+    image: gdslab/d2s-api:latest
     platform: linux/x86_64
     command: /app/celery/beat-start.sh
     volumes:
@@ -182,7 +182,7 @@ services:
       - db.env
 
   proxy:
-    image: d2s-proxy:dev
+    image: gdslab/d2s-proxy:dev
     platform: linux/x86_64
     tmpfs:
       - /tmp
@@ -206,7 +206,7 @@ services:
       - no-new-privileges=true
 
   varnish:
-    image: d2s-varnish:latest
+    image: gdslab/d2s-varnish:latest
     tmpfs:
       - /var/lib/varnish/varnishd:exec
     command: "-p default_keep=300"


### PR DESCRIPTION
## Summary
Fixes two configuration issues: updates quickstart Docker Compose to use published `gdslab/` images instead of local-only tags, and adds proper handling for optional URL environment variables that are set to empty strings.

## Changes
- **Docker Compose**: Updated all image references in `docker-compose.quickstart.yml` from local tags (`d2s-api:latest`, `d2s-app:latest`, etc.) to published `gdslab/` namespace images for quickstart compatibility
- **Backend Config**: Added `empty_str_to_none` field validator in `backend/app/core/config.py` for `STAC_API_URL`, `STAC_API_TEST_URL`, `STAC_BROWSER_URL`, and `EXTERNAL_VIEWER_URL` to convert empty strings to `None`
- **Config Template**: Commented out `EXTERNAL_VIEWER_URL` in `backend.example.env` to demonstrate recommended pattern for optional URLs

## Testing
 - Verified quickstart compose file references correct published images
 - Confirmed validator converts empty string URL values to `None` without validation errors
 - Tested that optional URLs can be left commented out or set to empty strings
 - Verified STAC functionality respects `ENABLE_STAC` feature flag with proper URL handling

## Breaking Changes
None. Changes improve quickstart usability and configuration robustness.