### PR TITLE
[Enhancement] Upgrade Node.js from 18 to 22 in frontend Dockerfiles

### DIFF
--- a/frontend/frontend.dockerfile
+++ b/frontend/frontend.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:22-trixie-slim
 
 WORKDIR /app/
 

--- a/frontend/frontend.prod.dockerfile
+++ b/frontend/frontend.prod.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim AS build-stage
+FROM node:22-trixie-slim AS build-stage
 
 # Accept build arguments
 ARG VITE_STAC_ENABLED


### PR DESCRIPTION
## Summary
Upgrades the Node.js base image from version 18 (Bullseye) to version 22 (Trixie) in the frontend Docker configurations to leverage newer language features, improved performance, and continued LTS support.

## Changes
 - Frontend: Updated `frontend/frontend.dockerfile` base image from `node:18-bullseye-slim` to `node:22-trixie-slim`
 - Frontend: Updated `frontend/frontend.prod.dockerfile` build stage base image from `node:18-bullseye-slim` to `node:22-trixie-slim`