### PR TITLE
[Bug] Fix null value sorting in user list date columns

### DIFF
--- a/frontend/src/components/pages/admin/DashboardUserList.tsx
+++ b/frontend/src/components/pages/admin/DashboardUserList.tsx
@@ -146,18 +146,32 @@ export default function DashboardUserList({
             new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
           break;
         case 'last_login_at':
-          // Handle null values - put them at the end
-          if (a.last_login_at === null && b.last_login_at === null) comparison = 0;
-          else if (a.last_login_at === null) comparison = 1;
-          else if (b.last_login_at === null) comparison = -1;
-          else comparison = new Date(a.last_login_at).getTime() - new Date(b.last_login_at).getTime();
+          // Handle null values - always put them at the end regardless of sort direction
+          if (a.last_login_at === null && b.last_login_at === null) {
+            comparison = 0;
+          } else if (a.last_login_at === null) {
+            // a is null, so it should go after b (return positive to sort a after b)
+            comparison = sortDirection === 'asc' ? 1 : -1;
+          } else if (b.last_login_at === null) {
+            // b is null, so it should go after a (return negative to sort a before b)
+            comparison = sortDirection === 'asc' ? -1 : 1;
+          } else {
+            comparison = new Date(a.last_login_at).getTime() - new Date(b.last_login_at).getTime();
+          }
           break;
         case 'last_activity_at':
-          // Handle null values - put them at the end
-          if (a.last_activity_at === null && b.last_activity_at === null) comparison = 0;
-          else if (a.last_activity_at === null) comparison = 1;
-          else if (b.last_activity_at === null) comparison = -1;
-          else comparison = new Date(a.last_activity_at).getTime() - new Date(b.last_activity_at).getTime();
+          // Handle null values - always put them at the end regardless of sort direction
+          if (a.last_activity_at === null && b.last_activity_at === null) {
+            comparison = 0;
+          } else if (a.last_activity_at === null) {
+            // a is null, so it should go after b (return positive to sort a after b)
+            comparison = sortDirection === 'asc' ? 1 : -1;
+          } else if (b.last_activity_at === null) {
+            // b is null, so it should go after a (return negative to sort a before b)
+            comparison = sortDirection === 'asc' ? -1 : 1;
+          } else {
+            comparison = new Date(a.last_activity_at).getTime() - new Date(b.last_activity_at).getTime();
+          }
           break;
         case 'is_approved':
           comparison = Number(b.is_approved) - Number(a.is_approved);


### PR DESCRIPTION
## Summary
Fixed counterintuitive sorting behavior where users with null `last_login_at` and `last_activity_at` values appeared at the top when sorting in descending order. Null values now consistently appear at the end regardless of sort direction, making it easier to find users with recent activity.

## Changes
 - Frontend: Updated sort logic in `DashboardUserList.tsx` to always place null values at the end for `last_login_at` and `last_activity_at` columns, regardless of ascending or descending sort order.

## Testing
Manual QA steps:
1. Navigate to Admin Dashboard user list
2. Sort by "Last Login" in descending order
3. Verify users with actual login dates appear at top, null values at bottom
4. Sort by "Last Login" in ascending order
5. Verify users with earliest login dates appear at top, null values still at bottom
6. Repeat steps 2-5 for "Last Activity" column
7. Confirm expected behavior: dates sorted correctly with nulls always at end