### PR TITLE
 [Refactor] Distinguish ProjectDetail and ProjectItem type definitions

### DIFF
--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -9,8 +9,7 @@ import {
   TrashIcon,
 } from '@heroicons/react/24/outline';
 
-import { DataProduct } from './pages/projects/Project';
-import { Project } from './pages/projects/ProjectList';
+import { DataProduct, ProjectDetail, ProjectItem } from './pages/projects/Project';
 import { Status } from './Alert';
 
 import api from '../api';
@@ -238,7 +237,7 @@ export function CopyURLButton({
 
 interface CopyShortenURLButton extends CopyURLButton {
   dataProduct: DataProduct;
-  project: Project;
+  project: ProjectDetail | ProjectItem;
   setStatus: React.Dispatch<React.SetStateAction<Status | null>>;
 }
 

--- a/frontend/src/components/Sort.tsx
+++ b/frontend/src/components/Sort.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Project } from './pages/projects/ProjectList';
+import { ProjectItem } from './pages/projects/Project';
 
 import { sorter } from './utils';
 
@@ -59,9 +59,9 @@ function setSortPreferenceInLocalStorage(
  * @returns Array of sorted projects.
  */
 export function sortProjects(
-  projects: Project[],
+  projects: ProjectItem[],
   sortSelection: SortSelection
-): Project[] {
+): ProjectItem[] {
   return projects.sort((a, b) => {
     // First sort by liked status (liked projects come first)
     if (a.liked !== b.liked) {

--- a/frontend/src/components/maps/LayerPane/ActiveProjectPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ActiveProjectPane.tsx
@@ -7,13 +7,13 @@ import MapLayersPanel from './MapLayersPanel';
 import { useMapContext } from '../MapContext';
 import { useMapLayerContext } from '../MapLayersContext';
 import MapToolbar from '../MapToolbar';
-import { Project } from '../../pages/projects/ProjectList';
+import { ProjectItem } from '../../pages/projects/Project';
 
 import { sortedFlightsByDateAndId } from './utils';
 
 import uasIcon from '../../../assets/uas-icon.svg';
 
-type ActiveProjectPaneProps = { project: Project };
+type ActiveProjectPaneProps = { project: ProjectItem };
 
 export default function ActiveProjectPane({ project }: ActiveProjectPaneProps) {
   const { flights, activeDataProduct } = useMapContext();

--- a/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
@@ -12,7 +12,7 @@ import CountBadge from '../../CountBadge';
 import Filter from '../../Filter';
 import LayerCard from './LayerCard';
 import Pagination, { getPaginationResults } from '../../Pagination';
-import { Project } from '../../pages/projects/ProjectList';
+import { ProjectItem } from '../../pages/projects/Project';
 import ProjectSearch from '../../pages/projects/ProjectSearch';
 import Sort, { sortProjects, SortSelection } from '../../Sort';
 import { useMapContext } from '../MapContext';
@@ -22,7 +22,7 @@ import { getCategory } from '../utils';
 const MAX_ITEMS = 10; // max number of projects per page in left-side pane
 
 type ProjectsPaneProps = {
-  projects: Project[] | null;
+  projects: ProjectItem[] | null;
 };
 
 export default function ProjectsPane({ projects }: ProjectsPaneProps) {
@@ -118,7 +118,7 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
 
   // Activate clicked on project and clear any active data products
   const handleProjectClick = useCallback(
-    (project: Project) => () => {
+    (project: ProjectItem) => () => {
       activeDataProductDispatch({ type: 'clear', payload: null });
       activeProjectDispatch({ type: 'set', payload: project });
     },

--- a/frontend/src/components/maps/MapContext.tsx
+++ b/frontend/src/components/maps/MapContext.tsx
@@ -6,8 +6,8 @@ import {
   DataProduct,
   Flight,
   MapLayerFeatureCollection,
+  ProjectItem,
 } from '../pages/projects/Project';
-import { Project } from '../pages/projects/ProjectList';
 import {
   ActiveDataProductAction,
   ActiveMapToolAction,
@@ -62,7 +62,7 @@ function activeMapToolReducer(state: MapTool, action: ActiveMapToolAction) {
 }
 
 function activeProjectReducer(
-  state: Project | null,
+  state: ProjectItem | null,
   action: ActiveProjectAction
 ) {
   switch (action.type) {
@@ -146,7 +146,7 @@ function projectLayersReducer(
   }
 }
 
-function projectsReducer(state: Project[] | null, action: ProjectsAction) {
+function projectsReducer(state: ProjectItem[] | null, action: ProjectsAction) {
   switch (action.type) {
     case 'set': {
       return action.payload;
@@ -246,7 +246,7 @@ const context: {
   activeDataProductDispatch: React.Dispatch<ActiveDataProductAction>;
   activeMapTool: MapTool;
   activeMapToolDispatch: React.Dispatch<ActiveMapToolAction>;
-  activeProject: Project | null;
+  activeProject: ProjectItem | null;
   activeProjectDispatch: React.Dispatch<ActiveProjectAction>;
   flights: Flight[];
   geoRasterId: string;
@@ -255,7 +255,7 @@ const context: {
   mapViewPropertiesDispatch: React.Dispatch<MapViewPropertiesAction>;
   projectLayers: MapLayerFeatureCollection[];
   projectLayersDispatch: React.Dispatch<ProjectLayersAction>;
-  projects: Project[] | null;
+  projects: ProjectItem[] | null;
   projectsDispatch: React.Dispatch<ProjectsAction>;
   projectsLoaded: ProjectsLoadedState;
   projectsLoadedDispatch: React.Dispatch<ProjectsLoadedAction>;

--- a/frontend/src/components/maps/Maps.d.ts
+++ b/frontend/src/components/maps/Maps.d.ts
@@ -1,7 +1,6 @@
 import { FeatureCollection, Point } from 'geojson';
 
-import { DataProduct, Flight } from '../pages/projects/Project';
-import { Project } from '../pages/projects/ProjectList';
+import { DataProduct, Flight, ProjectItem } from '../pages/projects/Project';
 import { ProjectsLoadedState } from './MapContext';
 
 export type MapTool = 'map' | 'compare' | 'timeline';
@@ -13,7 +12,7 @@ export type ActiveDataProductAction = {
 
 export type ActiveMapToolAction = { type: string; payload: MapTool };
 
-export type ActiveProjectAction = { type: string; payload: Project | null };
+export type ActiveProjectAction = { type: string; payload: ProjectItem | null };
 
 export type BBox = [number, number, number, number];
 
@@ -23,7 +22,7 @@ export type ProjectFilterSelectionAction = { type: string; payload?: string[] };
 
 export type SelectedTeamIdsAction = { type: string; payload: string[] };
 
-export type ProjectsAction = { type: string; payload: Project[] | null };
+export type ProjectsAction = { type: string; payload: ProjectItem[] | null };
 
 export type ProjectsLoadedAction = {
   type: string;

--- a/frontend/src/components/maps/ProjectLoader.tsx
+++ b/frontend/src/components/maps/ProjectLoader.tsx
@@ -2,7 +2,7 @@ import { AxiosResponse, isAxiosError } from 'axios';
 import { useEffect } from 'react';
 
 import { useMapContext } from './MapContext';
-import { Project } from '../pages/projects/ProjectList';
+import { ProjectItem } from '../pages/projects/Project';
 
 import api from '../../api';
 import {
@@ -19,7 +19,7 @@ export default function ProjectLoader() {
     const fetchProjects = async () => {
       try {
         const geojsonUrl = `/projects?include_all=${false}`;
-        const response: AxiosResponse<Project[]> = await api.get(geojsonUrl);
+        const response: AxiosResponse<ProjectItem[]> = await api.get(geojsonUrl);
 
         // Filter out projects with invalid geographic coordinates
         const validProjects = filterValidProjects(response.data);

--- a/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologyAccessControls.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologyAccessControls.tsx
@@ -9,9 +9,8 @@ import {
   CopyURLButton,
   DownloadQRButton,
 } from '../../Buttons';
-import { DataProduct } from '../../pages/projects/Project';
+import { DataProduct, ProjectDetail, ProjectItem } from '../../pages/projects/Project';
 import { useMapContext } from '../MapContext';
-import { Project } from '../../pages/projects/ProjectList';
 import {
   MultibandSymbology,
   SingleBandSymbology,
@@ -27,7 +26,7 @@ export default function RasterSymbologyAccessControls({
   refreshUrl,
 }: {
   dataProduct: DataProduct;
-  project: Project;
+  project: ProjectDetail | ProjectItem;
   symbology?: SingleBandSymbology | MultibandSymbology;
   refreshUrl?: string;
 }) {

--- a/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologySaveAndShare.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologySaveAndShare.tsx
@@ -2,9 +2,8 @@ import { AxiosResponse } from 'axios';
 import { useState } from 'react';
 
 import { Button } from '../../Buttons';
-import { DataProduct } from '../../pages/projects/Project';
+import { DataProduct, ProjectDetail, ProjectItem } from '../../pages/projects/Project';
 import Modal from '../../Modal';
-import { Project } from '../../pages/projects/ProjectList';
 import RasterSymbologyAccessControls from './RasterSymbologyAccessControls';
 import { useMapContext } from '../MapContext';
 import {
@@ -21,7 +20,7 @@ function RasterSymbologyShare({
   symbology,
 }: {
   dataProduct: DataProduct;
-  project: Project;
+  project: ProjectDetail | ProjectItem;
   symbology: SingleBandSymbology | MultibandSymbology;
 }) {
   const [open, setOpen] = useState(false);

--- a/frontend/src/components/maps/utils.tsx
+++ b/frontend/src/components/maps/utils.tsx
@@ -13,9 +13,9 @@ import {
   Flight,
   MapLayer,
   ProjectFeatureCollection,
+  ProjectItem,
   STACProperties,
 } from '../pages/projects/Project';
-import { Project } from '../pages/projects/ProjectList';
 import {
   SingleBandSymbology,
   MultibandSymbology,
@@ -64,7 +64,7 @@ function isValidCoordinate(lng: number, lat: number): boolean {
  * @param projects Array of projects to filter.
  * @returns Filtered array with only projects having valid geographic coordinates.
  */
-function filterValidProjects(projects: Project[]): Project[] {
+function filterValidProjects(projects: ProjectItem[]): ProjectItem[] {
   return projects.filter((project) => {
     if (!project.centroid) {
       console.warn(
@@ -481,11 +481,11 @@ const getMultibandMinMax = (
  * Checks local storage for previously stored projects.
  * @returns Array of projects retrieved from local storage.
  */
-function getLocalStorageProjects(): Project[] | null {
+function getLocalStorageProjects(): ProjectItem[] | null {
   if ('projects' in localStorage) {
     const lsProjectsString = localStorage.getItem('projects');
     if (lsProjectsString) {
-      const lsProjects: Project[] = JSON.parse(lsProjectsString);
+      const lsProjects: ProjectItem[] = JSON.parse(lsProjectsString);
       if (lsProjects && lsProjects.length > 0) {
         return lsProjects;
       }
@@ -545,7 +545,7 @@ function getTitilerQueryParams(
  * @param projects Array of projects with unique `id` strings.
  * @returns Array of sorted projects.
  */
-function sortProjects(projects: Project[]): Project[] {
+function sortProjects(projects: ProjectItem[]): ProjectItem[] {
   return projects.slice().sort((a, b) => a.id.localeCompare(b.id));
 }
 
@@ -557,8 +557,8 @@ function sortProjects(projects: Project[]): Project[] {
  * @returns True if both arrays match, otherwise false.
  */
 function areProjectsEqual(
-  oldProjects: Project[],
-  newProjects: Project[]
+  oldProjects: ProjectItem[],
+  newProjects: ProjectItem[]
 ): boolean {
   const sortedOld = sortProjects(oldProjects);
   const sortedNew = sortProjects(newProjects);
@@ -571,7 +571,7 @@ function areProjectsEqual(
  * the API differ.
  * @param projects Projects returned from API.
  */
-function setLocalStorageProjects(projects: Project[]): void {
+function setLocalStorageProjects(projects: ProjectItem[]): void {
   const projectsString = JSON.stringify(projects);
   const storedProjects = getLocalStorageProjects();
 

--- a/frontend/src/components/pages/Workspace.tsx
+++ b/frontend/src/components/pages/Workspace.tsx
@@ -2,14 +2,15 @@ import { AxiosResponse, isAxiosError } from 'axios';
 import { useState, useEffect, useTransition } from 'react';
 import { useLoaderData, useRevalidator } from 'react-router-dom';
 
-import ProjectList, { Project } from './projects/ProjectList';
+import ProjectList from './projects/ProjectList';
+import { ProjectItem } from './projects/Project';
 
 import api from '../../api';
 import { getLocalStorageProjects } from '../maps/utils';
 
 export async function loader() {
   // Fetch projects from localStorage
-  let cachedProjects: Project[] | null = null;
+  let cachedProjects: ProjectItem[] | null = null;
   try {
     const projectsFromCache = getLocalStorageProjects();
     if (projectsFromCache) {
@@ -22,7 +23,7 @@ export async function loader() {
   // Fetch list of user's projects
   const freshProjects = api
     .get('/projects')
-    .then((response: AxiosResponse<Project[]>) => {
+    .then((response: AxiosResponse<ProjectItem[]>) => {
       // Update localStorage with latest projects
       localStorage.setItem('projects', JSON.stringify(response.data));
       return response;
@@ -45,13 +46,13 @@ export async function loader() {
 
 export default function Workspace() {
   const { cachedProjects, freshProjects } = useLoaderData() as {
-    cachedProjects: Project[] | null;
-    freshProjects: Promise<AxiosResponse<Project[]>>;
+    cachedProjects: ProjectItem[] | null;
+    freshProjects: Promise<AxiosResponse<ProjectItem[]>>;
   };
   const revalidator = useRevalidator();
 
   // Immediately display cached projects
-  const [projects, setProjects] = useState<Project[] | null>(cachedProjects);
+  const [projects, setProjects] = useState<ProjectItem[] | null>(cachedProjects);
   // Prevent interrupting user interactions with useTransition
   const [_isPending, startTransition] = useTransition();
 

--- a/frontend/src/components/pages/projects/Project.d.ts
+++ b/frontend/src/components/pages/projects/Project.d.ts
@@ -1,4 +1,4 @@
-import { Feature, FeatureCollection, Geometry } from 'geojson';
+import { Feature, FeatureCollection, Geometry, Point } from 'geojson';
 
 import { FieldCampaignInitialValues } from './fieldCampaigns/FieldCampaign';
 import { SymbologySettings } from '../../maps/Maps';
@@ -6,6 +6,64 @@ import {
   SingleBandSymbology,
   MultibandSymbology,
 } from '../../maps/RasterSymbologyContext';
+import { Team } from '../teams/Teams';
+
+// raster band info from gdalinfo
+export interface Band {
+  data_type: string;
+  nodata: string | null;
+  stats: {
+    maximum: number;
+    mean: number;
+    minimum: number;
+    stddev: number;
+  };
+  unit: string;
+}
+
+// geojson object collected from leaflet
+export type Coordinates = number[][];
+
+// data product object returned from api
+export interface DataProduct {
+  id: string;
+  bbox?: [number, number, number, number];
+  crs?: {
+    epsg: number;
+    unit: string;
+  };
+  data_type: string;
+  filepath: string;
+  flight_id: string;
+  original_filename: string;
+  public: boolean;
+  resolution?: {
+    unit: string;
+    x: number;
+    y: number;
+  };
+  signature?: {
+    expires: number;
+    secure: string;
+  };
+  stac_properties: STACProperties;
+  status: string;
+  url: string;
+  user_style: SingleBandSymbology | MultibandSymbology;
+}
+
+// earth observation info from gdalinfo
+export interface EO {
+  description: string;
+  name: string;
+}
+
+export type FieldCampaign = {
+  id: string;
+  form_data: FieldCampaignInitialValues;
+  lead_id: string;
+  title: string;
+};
 
 // geojson object representing project field boundary
 export type FieldGeoJSONFeature = Omit<Feature, 'properties'> & {
@@ -14,21 +72,77 @@ export type FieldGeoJSONFeature = Omit<Feature, 'properties'> & {
   };
 };
 
-// geojson object collected from leaflet
-export type Coordinates = number[][];
+// flight object returned from api
+export interface Flight {
+  id: string;
+  acquisition_date: string;
+  altitude: number;
+  data_products: DataProduct[];
+  forward_overlap: number;
+  name: string | null;
+  pilot_id: string;
+  platform: string;
+  project_id: string;
+  sensor: string;
+  side_overlap: number;
+}
+
 export interface GeoJSONFeature {
-  type: string;
   geometry: {
-    type: string;
     coordinates: Coordinates[] | Coordinates[][];
+    type: string;
   };
   properties: {
     [key: string]: string;
   };
+  type: string;
 }
 
-type FieldGeoJSONFeature = Omit<Feature, 'properties'> & {
-  properties: FieldProperties;
+export type IForester = {
+  id: string;
+  dbh: number;
+  depthFile: string;
+  distance: number;
+  imageFile: string;
+  latitude: number;
+  longitude: number;
+  note: string;
+  phoneDirection: number;
+  phoneID: string;
+  species: string;
+  timeStamp: string;
+  user: string;
+};
+
+export type Job = {
+  id: string;
+  data_product_id: string;
+  end_time: string;
+  extra: { [key: string]: any };
+  name: string;
+  raw_data_id: string;
+  start_time: string;
+  state: string;
+  status: string;
+};
+
+export interface Location {
+  center: {
+    lat: number;
+    lng: number;
+  };
+  geojson: GeoJSONFeature;
+  type: string;
+}
+
+export type MapLayer = {
+  fgb_url: string;
+  geom_type: string;
+  layer_id: string;
+  layer_name: string;
+  parquet_url: string;
+  preview_url: string;
+  signed_url: string;
 };
 
 type MapLayerProperties = {
@@ -53,14 +167,101 @@ export interface MapLayerFeatureCollection<
   };
 }
 
-export type MapLayer = {
-  layer_id: string;
-  layer_name: string;
-  geom_type: string;
-  signed_url: string;
-  preview_url: string;
-  parquet_url: string;
-  fgb_url: string;
+// pilot for flight
+export interface Pilot {
+  label: string;
+  value: string;
+}
+
+// project object returned from api (detail view)
+export interface ProjectDetail {
+  id: string;
+  created_at: string;
+  created_by: {
+    email: string;
+    first_name: string;
+    last_name: string;
+  } | null;
+  data_product_count: number;
+  deactivated_at: string | null;
+  description: string;
+  field: GeoJSONFeature;
+  flight_count: number;
+  harvest_date: string;
+  is_active: boolean;
+  is_published: boolean;
+  location_id: string;
+  most_recent_flight: string | null;
+  planting_date: string;
+  role: string;
+  team_id: string;
+  title: string;
+  updated_at: string;
+}
+
+// Feature collection of project point features with custom properties
+export type ProjectFeatureCollection = FeatureCollection<
+  Point,
+  ProjectPointFeatureProperties
+>;
+
+// project object returned from api (list view)
+export interface ProjectItem {
+  id: string;
+  centroid: {
+    x: number;
+    y: number;
+  };
+  data_product_count: number;
+  description: string;
+  field: FieldGeoJSONFeature;
+  flight_count: number;
+  liked: boolean;
+  location_id: string;
+  most_recent_flight: string;
+  role: string;
+  team: Team | null;
+  team_id: string;
+  title: string;
+}
+
+// project data initially loaded on project detail page
+export interface ProjectLoaderData {
+  fieldCampaigns: FieldCampaign[];
+  flights: Flight[];
+  pilots: Pilot[];
+  project: ProjectDetail;
+  project_modules: ProjectModule[];
+  role: string;
+  teams: Team[];
+}
+
+export interface ProjectModule {
+  id: string;
+  description?: string;
+  enabled: boolean;
+  label?: string;
+  module_name: string;
+  project_id: string;
+  required?: boolean;
+  sort_order?: number;
+}
+
+// Properties for a project point feature
+export interface ProjectPointFeatureProperties {
+  id: string;
+  description: string;
+  title: string;
+}
+
+// Project point feature with custom properties
+export type ProjectPointFeature = Feature<Point, ProjectPointFeatureProperties>;
+
+export type SetLocation = React.Dispatch<React.SetStateAction<Location | null>>;
+
+export type STACProperties = {
+  eo: EO[];
+  raster: Band[];
 };
 
 type ZonalFeatureProperties = {
@@ -85,188 +286,3 @@ export interface ZonalFeatureCollection<
 > extends FeatureCollection<G, P> {
   features: Array<ZonalFeature<G, P>>;
 }
-
-export interface Location {
-  geojson: GeoJSONFeature;
-  center: {
-    lat: number;
-    lng: number;
-  };
-  type: string;
-}
-
-export type SetLocation = React.Dispatch<React.SetStateAction<Location | null>>;
-
-// project object returned from api
-export interface Project {
-  id: string;
-  description: string;
-  field: GeoJSONFeature;
-  flight_count: number;
-  harvest_date: string;
-  location_id: string;
-  planting_date: string;
-  team_id: string;
-  title: string;
-  role: string;
-  is_published: boolean;
-  created_by: {
-    first_name: string;
-    last_name: string;
-    email: string;
-  } | null;
-}
-
-export interface ProjectModule {
-  description?: string;
-  enabled: boolean;
-  id: string;
-  label?: string;
-  module_name: string;
-  project_id: string;
-  required?: boolean;
-  sort_order?: number;
-}
-
-export interface ProjectModule {
-  description?: string;
-  enabled: boolean;
-  id: string;
-  label?: string;
-  module_name: string;
-  project_id: string;
-  required?: boolean;
-  sort_order?: number;
-}
-
-// raster band info from gdalinfo
-export interface Band {
-  data_type: string;
-  nodata: string | null;
-  stats: {
-    mean: number;
-    stddev: number;
-    maximum: number;
-    minimum: number;
-  };
-  unit: string;
-}
-
-// earth observation info from gdalinfo
-export interface EO {
-  name: string;
-  description: string;
-}
-
-export type STACProperties = {
-  raster: Band[];
-  eo: EO[];
-};
-
-// data product object returned from api
-export interface DataProduct {
-  id: string;
-  data_type: string;
-  original_filename: string;
-  filepath: string;
-  url: string;
-  flight_id: string;
-  bbox?: [number, number, number, number];
-  crs?: {
-    epsg: number;
-    unit: string;
-  };
-  resolution?: {
-    x: number;
-    y: number;
-    unit: string;
-  };
-  public: boolean;
-  signature?: {
-    secure: string;
-    expires: number;
-  };
-  stac_properties: STACProperties;
-  status: string;
-  user_style: SingleBandSymbology | MultibandSymbology;
-}
-
-// flight object returned from api
-export interface Flight {
-  id: string;
-  name: string | null;
-  acquisition_date: string;
-  altitude: number;
-  side_overlap: number;
-  forward_overlap: number;
-  sensor: string;
-  platform: string;
-  project_id: string;
-  pilot_id: string;
-  data_products: DataProduct[];
-}
-
-// pilot for flight
-export interface Pilot {
-  label: string;
-  value: string;
-}
-
-// project data initially loaded on project detail page
-export interface ProjectLoaderData {
-  pilots: Pilot[];
-  project: Project;
-  project_modules: ProjectModule[];
-  role: string;
-  fieldCampaigns: FieldCampaign[];
-  flights: Flight[];
-  teams: Team[];
-}
-
-export type FieldCampaign = {
-  id: string;
-  title: string;
-  lead_id: string;
-  form_data: FieldCampaignInitialValues;
-};
-
-export type Job = {
-  id: string;
-  name: string;
-  extra: { [key: string]: any };
-  state: string;
-  status: string;
-  start_time: string;
-  end_time: string;
-  data_product_id: string;
-  raw_data_id: string;
-};
-
-export type IForester = {
-  id: string;
-  dbh: number;
-  depthFile: string;
-  distance: number;
-  imageFile: string;
-  latitude: number;
-  longitude: number;
-  note: string;
-  phoneDirection: number;
-  phoneID: string;
-  species: string;
-  user: string;
-  timeStamp: string;
-};
-
-// Properties for a project point feature
-export interface ProjectPointFeatureProperties {
-  id: string;
-  title: string;
-  description: string;
-}
-
-// Project point feature with custom properties
-export type ProjectPointFeature = Feature<Point, ProjectPointFeatureProperties>;
-
-// Feature collection of project point features with custom properties
-export type ProjectFeatureCollection = FeatureCollection<ProjectPointFeature>;

--- a/frontend/src/components/pages/projects/ProjectCard.tsx
+++ b/frontend/src/components/pages/projects/ProjectCard.tsx
@@ -7,7 +7,7 @@ import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid';
 
 import CountBadge from '../../CountBadge';
 import { GridIcon } from './GridIcon';
-import { Project } from './ProjectList';
+import { ProjectItem } from './Project';
 
 import api from '../../../api';
 import { getCategory } from '../../maps/utils';
@@ -16,7 +16,7 @@ export default function ProjectCard({
   project,
   revalidate,
 }: {
-  project: Project;
+  project: ProjectItem;
   revalidate: () => void;
 }) {
   const [liked, setLiked] = useState(project.liked);

--- a/frontend/src/components/pages/projects/ProjectContext/ProjectContext.tsx
+++ b/frontend/src/components/pages/projects/ProjectContext/ProjectContext.tsx
@@ -7,9 +7,9 @@ import {
   GeoJSONFeature,
   IForester,
   MapLayer,
+  ProjectDetail,
   ProjectModule,
 } from '../Project';
-import { Project } from '../ProjectList';
 import { ProjectMember } from '../ProjectAccess';
 import { User } from '../../../../AuthContext';
 
@@ -47,7 +47,7 @@ interface Context {
   locationDispatch: React.Dispatch<LocationAction>;
   mapLayers: MapLayer[];
   mapLayersDispatch: React.Dispatch<MapLayersAction>;
-  project: Project | null;
+  project: ProjectDetail | null;
   projectDispatch: React.Dispatch<ProjectAction>;
   projectMembers: ProjectMember[] | null;
   projectMembersDispatch: React.Dispatch<ProjectMembersAction>;
@@ -191,7 +191,7 @@ export function ProjectContextProvider({ children }: ProjectContextProvider) {
   const params = useParams();
 
   useEffect(() => {
-    async function getLocation(project: Project) {
+    async function getLocation(project: ProjectDetail) {
       try {
         const response: AxiosResponse<GeoJSONFeature> = await api.get(
           `/locations/${project.id}/${project.location_id}`
@@ -264,7 +264,7 @@ export function ProjectContextProvider({ children }: ProjectContextProvider) {
   useEffect(() => {
     async function getProject() {
       try {
-        const response: AxiosResponse<Project> = await api.get(
+        const response: AxiosResponse<ProjectDetail> = await api.get(
           `/projects/${params.projectId}`
         );
         if (response) {

--- a/frontend/src/components/pages/projects/ProjectContext/actions.tsx
+++ b/frontend/src/components/pages/projects/ProjectContext/actions.tsx
@@ -1,7 +1,6 @@
 import { IForester } from '../Project';
 import { GeoJSONFeature, MapLayer } from '../Project';
-import { Flight, ProjectModule } from '../Project';
-import { Project } from '../ProjectList';
+import { Flight, ProjectDetail, ProjectModule } from '../Project';
 import { ProjectMember } from '../ProjectAccess';
 
 export type IForesterAction = { type: string; payload: IForester[] | null };
@@ -11,7 +10,7 @@ export type FlightsFilterSelectionAction = { type: string; payload?: string[] };
 export type MapLayersAction =
   | { type: 'set' | 'update' | 'remove' | 'clear'; payload?: MapLayer[] }
   | { type: 'updateOne'; payload: MapLayer };
-export type ProjectAction = { type: string; payload: Project | null };
+export type ProjectAction = { type: string; payload: ProjectDetail | null };
 export type ProjectFilterSelectionAction = { type: string; payload?: string[] };
 export type ProjectMembersAction = {
   type: string;

--- a/frontend/src/components/pages/projects/ProjectContext/reducers.tsx
+++ b/frontend/src/components/pages/projects/ProjectContext/reducers.tsx
@@ -1,7 +1,6 @@
 import { IForester } from '../Project';
 import { GeoJSONFeature, MapLayer } from '../Project';
-import { Flight, ProjectModule } from '../Project';
-import { Project } from '../ProjectList';
+import { Flight, ProjectDetail, ProjectModule } from '../Project';
 import { ProjectMember } from '../ProjectAccess';
 
 import {
@@ -139,7 +138,7 @@ function mapLayersReducer(state: MapLayer[], action: MapLayersAction) {
   }
 }
 
-function projectReducer(state: Project | null, action: ProjectAction) {
+function projectReducer(state: ProjectDetail | null, action: ProjectAction) {
   switch (action.type) {
     case 'set': {
       return action.payload;

--- a/frontend/src/components/pages/projects/ProjectDeleteModal.tsx
+++ b/frontend/src/components/pages/projects/ProjectDeleteModal.tsx
@@ -5,11 +5,11 @@ import { AlertBar, Status } from '../../Alert';
 import { Button } from '../../Buttons';
 import { ConfirmationPopup } from '../../ConfirmationPopup';
 import Modal from '../../Modal';
-import { Project } from './Project';
+import { ProjectDetail } from './Project';
 
 import api from '../../../api';
 
-export default function ProjectDeleteModal({ project }: { project: Project }) {
+export default function ProjectDeleteModal({ project }: { project: ProjectDetail }) {
   const [openConfirmationPopup, setOpenConfirmationPopup] = useState(false);
   const [status, setStatus] = useState<Status | null>(null);
   const navigate = useNavigate();

--- a/frontend/src/components/pages/projects/ProjectDetail.tsx
+++ b/frontend/src/components/pages/projects/ProjectDetail.tsx
@@ -4,7 +4,7 @@ import { Params, useLoaderData } from 'react-router-dom';
 
 import { User } from '../../../AuthContext';
 import { useProjectContext } from './ProjectContext';
-import { Flight, Project, ProjectLoaderData, ProjectModule } from './Project';
+import { Flight, type ProjectDetail, ProjectLoaderData, ProjectModule } from './Project';
 import { ProjectMember } from './ProjectAccess';
 import ProjectDetailEditForm from './ProjectDetailEditForm';
 import ProjectTabNav from './ProjectTabNav';
@@ -19,7 +19,7 @@ export async function loader({ params }: { params: Params<string> }) {
   if (!user) return null;
 
   try {
-    const project: AxiosResponse<Project> = await api.get(
+    const project: AxiosResponse<ProjectDetail> = await api.get(
       `/projects/${params.projectId}`
     );
     const project_member: AxiosResponse<ProjectMember> = await api.get(

--- a/frontend/src/components/pages/projects/ProjectDetailEditForm.tsx
+++ b/frontend/src/components/pages/projects/ProjectDetailEditForm.tsx
@@ -7,7 +7,7 @@ import Alert from '../../Alert';
 import { LinkButton } from '../../Buttons';
 import { EditField, Editing, SelectField, TextField } from '../../InputFields';
 import Modal from '../../Modal';
-import { Project } from './Project';
+import { ProjectDetail } from './Project';
 import { useProjectContext } from './ProjectContext';
 import ProjectDeleteModal from './ProjectDeleteModal';
 import ProjectFormMap from './ProjectFormMap';
@@ -20,7 +20,7 @@ import { projectUpdateValidationSchema } from './validationSchema';
 import api from '../../../api';
 
 interface ProjectDetailEditForm {
-  project: Project;
+  project: ProjectDetail;
   teams: Team[];
 }
 

--- a/frontend/src/components/pages/projects/ProjectList.tsx
+++ b/frontend/src/components/pages/projects/ProjectList.tsx
@@ -12,42 +12,13 @@ import Sort, {
   getSortPreferenceFromLocalStorage,
   sortProjects,
 } from '../../Sort';
-import { Team } from '../teams/Teams';
-
-interface FieldProperties {
-  id: string;
-  center_x: number;
-  center_y: number;
-}
-
-type FieldGeoJSONFeature = Omit<GeoJSON.Feature, 'properties'> & {
-  properties: FieldProperties;
-};
-
-export interface Project {
-  id: string;
-  centroid: {
-    x: number;
-    y: number;
-  };
-  data_product_count: number;
-  description: string;
-  field: FieldGeoJSONFeature;
-  flight_count: number;
-  liked: boolean;
-  location_id: string;
-  most_recent_flight: string;
-  role: string;
-  team_id: string;
-  title: string;
-  team: Team | null;
-}
+import { ProjectItem } from './Project';
 
 export default function ProjectList({
   projects,
   revalidate,
 }: {
-  projects: Project[] | null;
+  projects: ProjectItem[] | null;
   revalidate: () => void;
 }) {
   const [currentPage, setCurrentPage] = useState(0);
@@ -115,7 +86,7 @@ export default function ProjectList({
    * @param projs Projects to filter.
    * @returns
    */
-  function filterSearch(projs: Project[]) {
+  function filterSearch(projs: ProjectItem[]) {
     return projs.filter(
       (project) =>
         !project.title ||
@@ -129,7 +100,7 @@ export default function ProjectList({
    * @param projs Projects to filter.
    * @returns Array of filtered and sliced projects.
    */
-  function filterAndSlice(projs: Project[]): Project[] {
+  function filterAndSlice(projs: ProjectItem[]): ProjectItem[] {
     return filterSearch(projs).slice(
       currentPage * MAX_ITEMS,
       MAX_ITEMS + currentPage * MAX_ITEMS

--- a/frontend/src/components/pages/projects/flights/DataProducts/DataProductsTable.tsx
+++ b/frontend/src/components/pages/projects/flights/DataProducts/DataProductsTable.tsx
@@ -16,11 +16,10 @@ import { CopyURLButton } from '../../../../Buttons';
 import DataProductDeleteModal from './DataProductDeleteModal';
 import EditableDataType from './EditableDataType';
 import { useProjectContext } from '../../ProjectContext';
-import { Project } from '../../ProjectList';
 import Table, { TableBody, TableHead } from '../../../../Table';
 import ToolboxModal from './ToolboxModal';
 import DataProductShareModal from './DataProductShareModal';
-import { DataProduct } from '../../Project';
+import { DataProduct, ProjectDetail } from '../../Project';
 
 export function isGeoTIFF(dataType: string): boolean {
   return (
@@ -51,7 +50,7 @@ function getDataProductActions(
   role: string | undefined,
   data: DataProduct[],
   navigate: NavigateFunction,
-  project: Project | null
+  project: ProjectDetail | null
 ) {
   const getDeleteAction = (dataProduct: DataProduct) => ({
     key: `action-delete-${dataProduct.id}`,

--- a/frontend/src/components/pages/projects/flights/MoveFlightModal.tsx
+++ b/frontend/src/components/pages/projects/flights/MoveFlightModal.tsx
@@ -5,7 +5,7 @@ import { useRevalidator } from 'react-router-dom';
 import { FolderIcon } from '@heroicons/react/24/outline';
 
 import { AlertBar, Status } from '../../../Alert';
-import { Flight, Project } from '../Project';
+import { Flight, ProjectItem } from '../Project';
 import Modal from '../../../Modal';
 import { Button } from '../../../Buttons';
 
@@ -40,7 +40,7 @@ export default function MoveFlightModal({
 
   useEffect(() => {
     async function getProjects() {
-      const response: AxiosResponse<Project[]> = await api.get(`/projects`);
+      const response: AxiosResponse<ProjectItem[]> = await api.get(`/projects`);
       if (response) {
         const ownedProjects = response.data
           .filter(({ id, role }) => role === 'owner' && id !== srcProjectId)

--- a/frontend/src/components/pages/projects/stac/ActionButtons.tsx
+++ b/frontend/src/components/pages/projects/stac/ActionButtons.tsx
@@ -1,9 +1,9 @@
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { Button } from '../../../Buttons';
-import { Project } from '../Project';
+import { ProjectDetail } from '../Project';
 
 interface ActionButtonsProps {
-  project: Project;
+  project: ProjectDetail;
   isPublishing: boolean;
   isUnpublishing: boolean;
   isUpdating: boolean;

--- a/frontend/src/components/pages/projects/stac/CollectionPreview.tsx
+++ b/frontend/src/components/pages/projects/stac/CollectionPreview.tsx
@@ -1,9 +1,9 @@
 import { STACMetadata } from './STACTypes';
-import { Project } from '../Project';
+import { ProjectDetail } from '../Project';
 
 interface CollectionPreviewProps {
   stacMetadata: STACMetadata;
-  project: Project;
+  project: ProjectDetail;
 }
 
 export default function CollectionPreview({

--- a/frontend/src/components/pages/projects/stac/ItemsList.tsx
+++ b/frontend/src/components/pages/projects/stac/ItemsList.tsx
@@ -1,9 +1,9 @@
 import { CombinedSTACItem } from './STACTypes';
-import { Project } from '../Project';
+import { ProjectDetail } from '../Project';
 
 interface ItemsListProps {
   allItems: CombinedSTACItem[];
-  project: Project;
+  project: ProjectDetail;
   includeRawDataLinks: Set<string>;
   onToggleRawDataLink: (itemId: string) => void;
   onToggleAllRawDataLinks: () => void;

--- a/frontend/src/components/pages/projects/stac/ProjectSTACPublishing.tsx
+++ b/frontend/src/components/pages/projects/stac/ProjectSTACPublishing.tsx
@@ -1,6 +1,6 @@
 import { LoaderFunctionArgs, useLoaderData, useParams } from 'react-router-dom';
 
-import { Project } from '../Project';
+import { ProjectDetail } from '../Project';
 import { STACItem, STACMetadata } from './STACTypes';
 
 // Custom hooks
@@ -53,7 +53,7 @@ export default function ProjectSTACPublishing() {
   const { stacMetadata: initialStacMetadata, project: loaderProject } =
     useLoaderData() as {
       stacMetadata: STACMetadata | null;
-      project: Project;
+      project: ProjectDetail;
     };
   const { projectId } = useParams();
 

--- a/frontend/src/components/pages/projects/stac/components/STACCustomizationPanel.tsx
+++ b/frontend/src/components/pages/projects/stac/components/STACCustomizationPanel.tsx
@@ -1,5 +1,5 @@
 import Alert, { Status } from '../../../../Alert';
-import { Project } from '../../Project';
+import { ProjectDetail } from '../../Project';
 import ContactForm from '../ContactForm';
 import ScientificCitationForm from '../ScientificCitationForm';
 import STACItemTitlesForm from '../STACItemTitlesForm';
@@ -17,7 +17,7 @@ interface FormState {
 }
 
 interface STACCustomizationPanelProps {
-  project: Project;
+  project: ProjectDetail;
   formState: FormState;
   updateFormField: <K extends keyof FormState>(
     field: K,

--- a/frontend/src/components/pages/projects/stac/components/STACPreviewPanel.tsx
+++ b/frontend/src/components/pages/projects/stac/components/STACPreviewPanel.tsx
@@ -2,12 +2,12 @@ import CollectionPreview from '../CollectionPreview';
 import ProcessingSummary from '../ProcessingSummary';
 import ItemsList from '../ItemsList';
 import { STACMetadata, CombinedSTACItem } from '../STACTypes';
-import { Project } from '../../Project';
+import { ProjectDetail } from '../../Project';
 
 interface STACPreviewPanelProps {
   stacMetadata: STACMetadata;
   allItems: CombinedSTACItem[];
-  project: Project;
+  project: ProjectDetail;
   includeRawDataLinks: Set<string>;
   onToggleRawDataLink: (itemId: string) => void;
   onToggleAllRawDataLinks: () => void;

--- a/frontend/src/components/pages/teams/TeamCreate.tsx
+++ b/frontend/src/components/pages/teams/TeamCreate.tsx
@@ -13,7 +13,7 @@ import Alert from '../../Alert';
 import AuthContext from '../../../AuthContext';
 import { Button, OutlineButton } from '../../Buttons';
 import Card from '../../Card';
-import { Project } from '../projects/ProjectList';
+import { ProjectItem } from '../projects/Project';
 import { SelectField, TextField } from '../../InputFields';
 import SearchUsers, { UserSearch } from './SearchUsers';
 
@@ -23,7 +23,7 @@ import validationSchema from './validationSchema';
 import api from '../../../api';
 
 export async function loader() {
-  const response: AxiosResponse<Project[]> = await api.get('/projects');
+  const response: AxiosResponse<ProjectItem[]> = await api.get('/projects');
   if (response) {
     return response.data.filter(({ role }) => role === 'owner');
   } else {
@@ -33,7 +33,7 @@ export async function loader() {
 
 export default function TeamCreate() {
   const { user } = useContext(AuthContext);
-  const projects = useLoaderData() as Project[];
+  const projects = useLoaderData() as ProjectItem[];
   const navigate = useNavigate();
   const revalidator = useRevalidator();
 


### PR DESCRIPTION
## Summary
Refactors TypeScript Project interfaces to clearly distinguish between detail view data (ProjectDetail) and list view data (ProjectItem). This resolves confusion from duplicate interface names and adds missing backend fields to ensure type safety across the application.

## Changes
**Frontend:**
 - Renamed `Project` → `ProjectDetail` in Project.d.ts for detail view endpoints
 - Added 6 missing fields to ProjectDetail: `created_at`, `updated_at`, `deactivated_at`, `is_active`, `data_product_count`, `most_recent_flight`
 - Created `ProjectItem` interface for list view endpoints with optimized fields: `centroid`, `liked`, `team`
 - Alphabetized all types/interfaces and their attributes in Project.d.ts (keeping `id` first)
 - Updated 25+ component files to use correct interface based on context:
   - Detail views: ProjectDetail (includes timestamps, created_by, is_published)
   - List/map views: ProjectItem (includes centroid, liked, team)
 - Fixed semantic errors where detail view files incorrectly used list types (ProjectContext, DataProductsTable)
 - Updated shared components (RasterSymbologyAccessControls, Buttons) to accept both types where only common fields (id, role) are used
 - Fixed GeoJSON type definition: `ProjectFeatureCollection` now correctly uses `FeatureCollection<Point, ProjectPointFeatureProperties>`

**Key files updated:**
 - Core types: `Project.d.ts`
 - Context files: `ProjectContext/*.tsx` (3 files)
 - List views: `ProjectList.tsx`, `Workspace.tsx`, `ProjectCard.tsx`, `MapContext.tsx`, `Maps.d.ts`, `Sort.tsx`, `utils.tsx`, `ProjectLoader.tsx`
 - Detail views: `ProjectDetail.tsx`, `ProjectDeleteModal.tsx`, `ProjectDetailEditForm.tsx`, all STAC publishing components (7 files)
 - Shared components: `Buttons.tsx`, `RasterSymbologyAccessControls.tsx`, `RasterSymbologySaveAndShare.tsx`

## Testing
 - TypeScript compilation passes with zero errors: `yarn tsc --noEmit`
 - All type references correctly align with backend API schemas:
   - `/projects` endpoint → `ProjectItem[]` (list schema)
   - `/projects/{id}` endpoint → `ProjectDetail` (detail schema)
 - Verified semantic correctness: detail view contexts use ProjectDetail, list/map contexts use ProjectItem

## Breaking Changes
None - This is a type-level refactoring with no runtime changes. Existing functionality remains identical.

## Related Issues
N/A