### PR TITLE
[Bug] Fix Turnstile retry loop by removing manual reset mechanism

### DIFF
--- a/frontend/src/components/pages/auth/RegistrationForm.tsx
+++ b/frontend/src/components/pages/auth/RegistrationForm.tsx
@@ -30,7 +30,6 @@ export default function RegistrationForm() {
   const [showPassword, toggleShowPassword] = useState(false);
   const [turnstileError, setTurnstileError] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
-  const [turnstileResetSignal, setTurnstileResetSignal] = useState(0);
   const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
 
   const methods = useForm<RegistrationFormData>({
@@ -48,16 +47,15 @@ export default function RegistrationForm() {
     setTurnstileError(false);
   };
 
-  const resetTurnstile = (showError = false) => {
+  const handleTurnstileError = () => {
     setTurnstileToken(null);
-    if (showError) {
-      setTurnstileError(true);
-    }
-    setTurnstileResetSignal((signal) => signal + 1);
+    setTurnstileError(true);
   };
 
-  const handleTurnstileError = () => resetTurnstile(true);
-  const handleTurnstileExpired = () => resetTurnstile(true);
+  const handleTurnstileExpired = () => {
+    setTurnstileToken(null);
+    setTurnstileError(true);
+  };
 
   const currentIntent = watch('registrationIntent') || '';
 
@@ -103,9 +101,7 @@ export default function RegistrationForm() {
       }
     } catch (err) {
       // Clear token on error so user can try again
-      if (turnstileSiteKey) {
-        resetTurnstile();
-      }
+      setTurnstileToken(null);
 
       if (isAxiosError(err)) {
         setStatus({
@@ -180,12 +176,12 @@ export default function RegistrationForm() {
               onSuccess={handleTurnstileSuccess}
               onError={handleTurnstileError}
               onExpire={handleTurnstileExpired}
-              resetSignal={turnstileResetSignal}
             />
           )}
           {turnstileError && (
             <Alert alertType="error">
-              Verification failed. Please refresh the page and try again.
+              erification failed. Turnstile will retry automatically; if it
+              still doesn't succeed, please reload the page and try again.
             </Alert>
           )}
           <Button type="submit" disabled={isSubmitting}>

--- a/frontend/src/components/pages/auth/TurnstileWidget.tsx
+++ b/frontend/src/components/pages/auth/TurnstileWidget.tsx
@@ -26,7 +26,6 @@ type TurnstileWidgetProps = {
   onSuccess: (token: string) => void;
   onError?: () => void;
   onExpire?: () => void;
-  resetSignal?: number;
 };
 
 export default function TurnstileWidget({
@@ -34,7 +33,6 @@ export default function TurnstileWidget({
   onSuccess,
   onError,
   onExpire,
-  resetSignal = 0,
 }: TurnstileWidgetProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const widgetIdRef = useRef<string | null>(null);
@@ -103,12 +101,6 @@ export default function TurnstileWidget({
       }
     };
   }, [apiReady, siteKey]);
-
-  // Reset the widget when requested by the parent
-  useEffect(() => {
-    if (!apiReady || !widgetIdRef.current || !window.turnstile) return;
-    window.turnstile.reset(widgetIdRef.current);
-  }, [apiReady, resetSignal]);
 
   return <div className="cf-turnstile" ref={containerRef} />;
 }


### PR DESCRIPTION
## Summary
Fixes an issue where manual Turnstile widget resets were causing a retry loop. The fix removes the manual reset mechanism and allows Turnstile to handle retries automatically, improving reliability and user experience during registration.

## Changes
- Frontend: Removed manual Turnstile reset logic that was causing retry loops
  - Eliminated `turnstileResetSignal` state and `resetTurnstile()` function from [RegistrationForm.tsx](frontend/src/components/pages/auth/RegistrationForm.tsx)
  - Removed `resetSignal` prop from [TurnstileWidget.tsx](frontend/src/components/pages/auth/TurnstileWidget.tsx)
  - Simplified error and expiry handlers to rely on Turnstile's automatic retry mechanism
  - Updated error messaging to clarify that Turnstile retries automatically

## Testing
Manual QA steps:
1. Navigate to `/auth/register`
2. Fill out the registration form with valid information
3. If Turnstile verification fails or expires, observe that it automatically retries without page refresh
4. Verify that form submission correctly validates Turnstile token presence
5. Test successful registration flow with valid Turnstile token

## Screenshots
N/A - Bug fix with no visible UI changes beyond error message text

## Breaking Changes
None

## Related Issues
N/A