### PR TITLE
[Enhancement] Include user's last name and registration intent in admin notification emails

### DIFF
--- a/backend/app/api/api_v1/endpoints/users.py
+++ b/backend/app/api/api_v1/endpoints/users.py
@@ -118,8 +118,10 @@ async def create_user(
             )
             mail.send_admins_new_registree_notification(
                 background_tasks=background_tasks,
-                first_name=user.first_name,
                 email=user.email,
+                first_name=user.first_name,
+                last_name=user.last_name,
+                registration_intent=user.registration_intent,
                 approve_token=approve_token,
             )
     else:

--- a/backend/app/api/mail.py
+++ b/backend/app/api/mail.py
@@ -89,6 +89,8 @@ def send_admins_new_registree_notification(
     background_tasks: BackgroundTasks,
     email: EmailStr,
     first_name: str,
+    last_name: str,
+    registration_intent: Optional[str],
     approve_token: str,
 ) -> None:
     admin_emails = settings.MAIL_ADMINS.split(",")
@@ -105,9 +107,18 @@ def send_admins_new_registree_notification(
 
     content = (
         "<p>Data to Science Support Admins,</p>"
-        f"<p>A new account is awaiting approval. Please approve {first_name}'s "
+        f"<p>A new account is awaiting approval. Please approve {first_name} {last_name}'s "
         f"({email}) account within 24 hours of receiving this notification. "
         "No action is needed to deny the account.<br /><br />"
+    )
+
+    if registration_intent:
+        content += (
+            f"<p><strong>Registration Intent:</strong></p>"
+            f"<blockquote>{registration_intent}</blockquote><br />"
+        )
+
+    content += (
         f"<a href='{approve_url}' target='_blank'>{approve_btn}</a><br /><br />"
         "<p>-Data to Science Support</p>"
     )

--- a/frontend/src/components/pages/auth/RegistrationForm.tsx
+++ b/frontend/src/components/pages/auth/RegistrationForm.tsx
@@ -180,7 +180,7 @@ export default function RegistrationForm() {
           )}
           {turnstileError && (
             <Alert alertType="error">
-              erification failed. Turnstile will retry automatically; if it
+              Verification failed. Turnstile will retry automatically; if it
               still doesn't succeed, please reload the page and try again.
             </Alert>
           )}


### PR DESCRIPTION
## Summary
Improves admin account approval workflow by including the user's last name and registration intent in the new account notification email. This provides admins with more context when reviewing account approval requests.

## Changes
- Backend: Updated admin notification email to include additional user information
  - Modified [users.py:121-124](backend/app/api/api_v1/endpoints/users.py#L121-L124) to pass `last_name` and `registration_intent` to notification function
  - Updated [mail.py:92-119](backend/app/api/mail.py#L92-L119) to accept and display last name and registration intent in email body
  - Registration intent appears in a formatted blockquote when provided by the user
- Frontend: Fixed typo in Turnstile error message ([RegistrationForm.tsx:183](frontend/src/components/pages/auth/RegistrationForm.tsx#L183))
  - Changed "erification failed" to "Verification failed"

## Testing
Manual QA steps:
1. Start the full stack: `docker compose -f docker-compose.quickstart.yml up -d`
2. Navigate to `/auth/register`
3. Fill out registration form with all fields including the optional "How do you plan to use Data to Science?" field
4. Submit the form
5. Check admin email inbox for the notification email
6. Verify email includes:
   - User's full name (first and last)
   - Registration intent in a formatted blockquote (if provided)
   - Approval button

## Screenshots
N/A - Email template enhancement

## Breaking Changes
None - Backwards compatible change

## Related Issues
N/A