### PR TITLE
[Bug] Fix infinite API request loop in RawData tab

### DIFF
--- a/frontend/src/components/pages/projects/flights/RawData/RawData.tsx
+++ b/frontend/src/components/pages/projects/flights/RawData/RawData.tsx
@@ -70,10 +70,10 @@ export default function RawData({ rawData }: { rawData: RawDataProps[] }) {
     }
   }, [flightId, projectId, projectRole]);
 
-  useEffect(() => {
-    // check for new raw data when upload modal closes
-    if (!open) revalidator.revalidate();
-  }, [open, revalidator]);
+  function handleModalClose() {
+    setOpen(false);
+    revalidator.revalidate(); // Revalidate when modal closes
+  }
 
   // check for new raw data and initial processing progress on regular intervals
   useInterval(
@@ -247,7 +247,7 @@ export default function RawData({ rawData }: { rawData: RawDataProps[] }) {
             flightID={flightId}
             open={open}
             projectID={projectId}
-            setOpen={setOpen}
+            handleModalClose={handleModalClose}
           />
           <Button size="sm" onClick={() => setOpen(true)}>
             Upload Raw Data

--- a/frontend/src/components/pages/projects/flights/RawData/RawDataUploadModal.tsx
+++ b/frontend/src/components/pages/projects/flights/RawData/RawDataUploadModal.tsx
@@ -12,14 +12,14 @@ interface Props {
   flightID: string;
   projectID: string;
   open: boolean;
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  handleModalClose: () => void;
 }
 
 export default function RawDataUploadModal({
   flightID,
   projectID,
   open,
-  setOpen,
+  handleModalClose,
 }: Props) {
   const cancelButtonRef = useRef(null);
   const [uploadHistory, setUploadHistory] = useState<string[]>([]);
@@ -115,7 +115,7 @@ export default function RawDataUploadModal({
                     type="button"
                     className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
                     aria-label="Done button"
-                    onClick={() => setOpen(false)}
+                    onClick={() => handleModalClose()}
                   >
                     Done
                   </button>


### PR DESCRIPTION
## Summary
Fixed an infinite loop of API requests that occurred when switching to the RawData tab. The issue was caused by including the `revalidator` object in a useEffect dependency array, which created a feedback loop. Updated the component to match the DataProducts pattern for consistency.

## Changes
- Frontend: Removed problematic useEffect with `revalidator` in dependency array from RawData component
- Frontend: Added `handleModalClose` function to explicitly handle modal closing and revalidation
- Frontend: Updated RawDataUploadModal to accept `handleModalClose` callback instead of `setOpen` prop
- Frontend: Aligned RawData component with DataProducts component pattern for modal handling

## Testing
- Manual QA: Navigate to a project's flight page and switch to the RawData tab
- Verify: Network tab shows normal polling intervals (5s or 30s) instead of continuous requests
- Verify: Upload modal still functions correctly and triggers revalidation on close
- Verify: DataProducts tab continues to work as expected

## Related Issues
N/A