### PR TITLE
[Enhancement] Add collision toggle and improve LCC viewer UI controls

### DIFF
--- a/frontend/src/components/maps/LCCControlsOverlay.tsx
+++ b/frontend/src/components/maps/LCCControlsOverlay.tsx
@@ -1,6 +1,6 @@
 export default function LCCControlsOverlay() {
   return (
-    <div className="absolute top-[60px] left-3 z-10 max-w-[300px] rounded-sm border border-white/30 bg-black/85 p-4 text-[13px] leading-relaxed text-white">
+    <div className="absolute top-[110px] left-3 z-10 max-w-[300px] rounded-sm border border-white/30 bg-black/85 p-4 text-[13px] leading-relaxed text-white">
       <div className="mb-3 text-[15px] font-semibold">Controls</div>
       <div className="flex flex-col gap-2">
         <div>


### PR DESCRIPTION
## Summary
Adds a collision detection toggle button to the LCC viewer, allowing users to enable/disable collision. Also improves UI consistency by fixing button width changes on toggle and preventing the controls overlay from overlapping with the quality settings bar.

## Changes
- Frontend: Added collision toggle button with enable/disable functionality, disabled by default
- Frontend: Fixed toggle button widths to remain consistent across state changes
- Frontend: Adjusted controls overlay position to prevent overlap with quality settings

## Testing
- Manual QA steps: Load LCC scene with collision support, verify "Enable Collision" button is clickable, click to enable/disable collision and verify collision detection activates/deactivates accordingly
- Manual QA steps: Load LCC scene without collision support, verify button is disabled with tooltip message
- Manual QA steps: Toggle Hide Drone, Show Controls, and Enable Collision buttons, verify widths remain consistent
- Manual QA steps: Open controls overlay, verify it appears below quality settings without overlap

## Related Issues
None