### PR TITLE
[Enhancement] Add swipe slider for split-screen map comparison

### DIFF
--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -1,13 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Map, {
-  MapRef,
-  NavigationControl,
-  ScaleControl,
-} from 'react-map-gl/maplibre';
+import Map, { MapRef, ScaleControl } from 'react-map-gl/maplibre';
 
 import ColorBarControl from '../ColorBarControl';
 import CompareMapControl from './CompareMapControl';
-import CompareModeControl from './CompareModeControl';
+import SwipeSlider from './SwipeSlider';
+import CompareModeControl, { Mode } from './CompareModeControl';
 import ProjectBoundary from '../ProjectBoundary';
 import { useMapContext } from '../MapContext';
 import { useMapApiKeys } from '../MapApiKeysContext';
@@ -24,22 +21,6 @@ import {
   createDefaultSingleBandSymbology,
 } from '../utils';
 import { isSingleBand } from '../utils';
-
-const LeftMapStyle: React.CSSProperties = {
-  position: 'absolute',
-  width: '50%',
-  height: '100%',
-  borderRightWidth: 2,
-  borderRightColor: 'white',
-};
-const RightMapStyle: React.CSSProperties = {
-  position: 'absolute',
-  left: '50%',
-  width: '50%',
-  height: '100%',
-};
-
-type Mode = 'split-screen' | 'side-by-side';
 
 export type MapComparisonState = {
   left: {
@@ -64,47 +45,35 @@ const defaultMapComparisonState = {
 };
 
 export default function CompareMap() {
+  // State
   const [viewState, setViewState] = useState({
     longitude: -86.9138040788386,
     latitude: 40.428655143949925,
     zoom: 8,
   });
+  const [sliderPosition, setSliderPosition] = useState(50); // Percentage
+  const [mode, setMode] = useState<Mode>('split-screen');
   const [activeMap, setActiveMap] = useState<'left' | 'right'>('left');
   const [mapComparisonState, setMapComparisonState] =
     useState<MapComparisonState>(defaultMapComparisonState);
-  const [mode, setMode] = useState<Mode>('split-screen');
   const [activeProjectBBox, setActiveProjectBBox] = useState<BBox | null>(null);
 
+  // Refs
   const leftMapRef = useRef<MapRef>(null);
   const rightMapRef = useRef<MapRef>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
+  // Context
   const { activeProject, flights } = useMapContext();
   const { mapboxAccessToken, maptilerApiKey } = useMapApiKeys();
-
   const { state: symbologyState, dispatch } = useRasterSymbologyContext();
 
+  // Event handlers
   const onLeftMoveStart = useCallback(() => setActiveMap('left'), []);
   const onRightMoveStart = useCallback(() => setActiveMap('right'), []);
   const onMove = useCallback((evt) => setViewState(evt.viewState), []);
 
-  const width = typeof window === 'undefined' ? 100 : window.innerWidth;
-  const leftMapPadding = useMemo(() => {
-    return {
-      left: mode === 'split-screen' ? width / 2 : 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-    };
-  }, [width, mode]);
-  const rightMapPadding = useMemo(() => {
-    return {
-      right: mode === 'split-screen' ? width / 2 : 0,
-      top: 0,
-      left: 0,
-      bottom: 0,
-    };
-  }, [width, mode]);
-
+  // Selected data products
   const selectedLeftDataProduct = useMemo(
     () =>
       flights
@@ -125,6 +94,7 @@ export default function CompareMap() {
     [flights, mapComparisonState.right]
   );
 
+  // Symbology initialization for left data product
   useEffect(() => {
     if (selectedLeftDataProduct) {
       const { id, stac_properties, user_style } = selectedLeftDataProduct;
@@ -159,6 +129,7 @@ export default function CompareMap() {
     }
   }, [dispatch, selectedLeftDataProduct]);
 
+  // Symbology initialization for right data product
   useEffect(() => {
     if (selectedRightDataProduct) {
       const { id, stac_properties, user_style } = selectedRightDataProduct;
@@ -208,15 +179,48 @@ export default function CompareMap() {
     return () => clearTimeout(timer);
   }, []);
 
+  // Resize maps when mode changes
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      leftMapRef.current?.resize();
+      rightMapRef.current?.resize();
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [mode]);
+
+  // Styles with conditional rendering based on mode
+  const leftMapStyle: React.CSSProperties = useMemo(
+    () => ({
+      position: 'absolute',
+      width: mode === 'side-by-side' ? '50%' : '100%',
+      height: '100%',
+      clipPath: mode === 'split-screen' ? `inset(0 ${100 - sliderPosition}% 0 0)` : 'none',
+      borderRight: mode === 'side-by-side' ? '2px solid white' : 'none',
+    }),
+    [sliderPosition, mode]
+  );
+
+  const rightMapStyle: React.CSSProperties = useMemo(
+    () => ({
+      position: 'absolute',
+      left: mode === 'side-by-side' ? '50%' : 0,
+      width: mode === 'side-by-side' ? '50%' : '100%',
+      height: '100%',
+      clipPath: mode === 'split-screen' ? `inset(0 0 0 ${sliderPosition}%)` : 'none',
+    }),
+    [sliderPosition, mode]
+  );
+
   return (
-    <div className="relative h-full">
+    <div ref={containerRef} className="relative h-full overflow-x-hidden">
+      {/* Left Map - clipped from right */}
       <Map
         ref={leftMapRef}
         {...viewState}
-        padding={leftMapPadding}
         onMoveStart={onLeftMoveStart}
         onMove={activeMap === 'left' ? onMove : undefined}
-        style={LeftMapStyle}
+        style={leftMapStyle}
         mapboxAccessToken={mapboxAccessToken || undefined}
         mapStyle={mapStyle}
         maxZoom={25}
@@ -229,13 +233,6 @@ export default function CompareMap() {
             setViewState={setViewState}
           />
         )}
-
-        <CompareMapControl
-          flights={flights}
-          mapComparisonState={mapComparisonState}
-          setMapComparisonState={setMapComparisonState}
-          side="left"
-        />
 
         {activeProject &&
           selectedLeftDataProduct &&
@@ -258,20 +255,16 @@ export default function CompareMap() {
             />
           )}
 
-        {/* Toggle compare mode */}
-        <CompareModeControl mode={mode} onModeChange={setMode} />
-
-        {/* General controls */}
-        <NavigationControl position="top-left" />
         <ScaleControl />
       </Map>
+
+      {/* Right Map - clipped from left */}
       <Map
         ref={rightMapRef}
         {...viewState}
-        padding={rightMapPadding}
         onMoveStart={onRightMoveStart}
         onMove={activeMap === 'right' ? onMove : undefined}
-        style={RightMapStyle}
+        style={rightMapStyle}
         mapboxAccessToken={mapboxAccessToken}
         mapStyle={mapStyle}
         maxZoom={25}
@@ -279,13 +272,6 @@ export default function CompareMap() {
       >
         {/* Display project boundary when project activated */}
         {activeProject && <ProjectBoundary />}
-
-        <CompareMapControl
-          flights={flights}
-          mapComparisonState={mapComparisonState}
-          setMapComparisonState={setMapComparisonState}
-          side="right"
-        />
 
         {activeProject &&
           selectedRightDataProduct &&
@@ -309,10 +295,35 @@ export default function CompareMap() {
             />
           )}
 
-        {/* General controls */}
-        <NavigationControl />
         <ScaleControl />
       </Map>
+
+      {/* Draggable Swipe Slider - only in split-screen mode */}
+      {mode === 'split-screen' && (
+        <SwipeSlider
+          position={sliderPosition}
+          onPositionChange={setSliderPosition}
+          containerRef={containerRef}
+        />
+      )}
+
+      {/* Mode toggle control */}
+      <CompareModeControl mode={mode} onModeChange={setMode} />
+
+      {/* Data product selection controls (outside maps so they're never clipped) */}
+      <CompareMapControl
+        flights={flights}
+        mapComparisonState={mapComparisonState}
+        setMapComparisonState={setMapComparisonState}
+        side="left"
+      />
+
+      <CompareMapControl
+        flights={flights}
+        mapComparisonState={mapComparisonState}
+        setMapComparisonState={setMapComparisonState}
+        side="right"
+      />
     </div>
   );
 }

--- a/frontend/src/components/maps/CompareMap/CompareMapControl.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMapControl.tsx
@@ -6,7 +6,7 @@ import { Flight } from '../../pages/projects/Project';
 
 import { sorter } from '../../utils';
 
-type ComparisonMapControlProps = {
+type CompareMapControlProps = {
   flights: Flight[];
   mapComparisonState: MapComparisonState;
   setMapComparisonState: React.Dispatch<
@@ -20,7 +20,7 @@ export default function CompareMapControl({
   mapComparisonState,
   setMapComparisonState,
   side = 'left',
-}: ComparisonMapControlProps) {
+}: CompareMapControlProps) {
   // filter out flights with no data products or only point cloud data products
   const flightsWithRasters = useMemo(() => {
     return flights
@@ -76,6 +76,7 @@ export default function CompareMapControl({
           'right-14': side === 'right',
         }
       )}
+      style={{ zIndex: 1001 }}
     >
       <div className="w-full flex flex-col gap-2">
         <select

--- a/frontend/src/components/maps/CompareMap/SwipeSlider.tsx
+++ b/frontend/src/components/maps/CompareMap/SwipeSlider.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface SwipeSliderProps {
+  position: number; // 0-100
+  onPositionChange: (newPosition: number) => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export default function SwipeSlider({
+  position,
+  onPositionChange,
+  containerRef,
+}: SwipeSliderProps) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Mouse event handlers
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging || !containerRef.current) return;
+
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const percentage = (x / rect.width) * 100;
+      onPositionChange(Math.max(0, Math.min(100, percentage)));
+    },
+    [isDragging, containerRef, onPositionChange]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Touch event handlers for mobile
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!isDragging || !containerRef.current) return;
+      const touch = e.touches[0];
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = touch.clientX - rect.left;
+      const percentage = (x / rect.width) * 100;
+      onPositionChange(Math.max(0, Math.min(100, percentage)));
+    },
+    [isDragging, containerRef, onPositionChange]
+  );
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  // Effect for global event listeners
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.addEventListener('touchmove', handleTouchMove);
+      document.addEventListener('touchend', handleMouseUp);
+
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        document.removeEventListener('touchmove', handleTouchMove);
+        document.removeEventListener('touchend', handleMouseUp);
+      };
+    }
+  }, [isDragging, handleMouseMove, handleMouseUp, handleTouchMove]);
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: `${position}%`,
+        top: 0,
+        bottom: 0,
+        width: 4,
+        backgroundColor: 'white',
+        cursor: 'ew-resize',
+        zIndex: 1000,
+        boxShadow: '0 0 10px rgba(0,0,0,0.5)',
+      }}
+      onMouseDown={handleMouseDown}
+      onTouchStart={handleTouchStart}
+    >
+      {/* Slider handle/grip */}
+      <div
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: 40,
+          height: 40,
+          backgroundColor: 'white',
+          borderRadius: '50%',
+          border: '3px solid #ee6c4d',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+        }}
+      >
+        {/* Left/Right arrows icon */}
+        <svg width="20" height="20" viewBox="0 0 20 20">
+          <path d="M7 10l-4-4v8l4-4zm6 0l4-4v8l-4-4z" fill="#ee6c4d" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/maps/CompareMap/index.tsx
+++ b/frontend/src/components/maps/CompareMap/index.tsx
@@ -1,3 +1,1 @@
-import CompareMap from './CompareMap';
-
-export default CompareMap;
+export { default } from './CompareMap';


### PR DESCRIPTION
## Summary
Adds an interactive swipe slider to the map comparison feature, allowing users to drag a vertical divider to reveal more or less of each map. This replaces the previous map padding approach with a CSS clipping technique that significantly improves performance and user experience.

## Changes
- **Frontend:**
  - Added new `SwipeSlider` component with mouse and touch support for mobile devices
  - Refactored split-screen mode to use CSS `clipPath` instead of map padding for smoother performance
  - Both maps now render full viewport in split-screen mode, with visual clipping controlled by slider position
  - Moved data product selection controls outside map containers to prevent clipping
  - Added mode toggle between split-screen (with swipe slider) and side-by-side (traditional 50/50 split)
  - Removed redundant `NavigationControl` components from individual maps
  - Fixed z-index on `CompareMapControl` to ensure proper layering above maps

- **Performance:**
  - In split-screen mode, both maps load tiles for the full viewport once, eliminating tile re-fetching as slider moves
  - Swipe slider only changes visual clipping, not what's rendered underneath

## Testing
- **Manual QA:**
  1. Navigate to Compare Map view
  2. Select different data products for left and right maps
  3. Toggle between split-screen and side-by-side modes
  4. In split-screen mode, drag the swipe slider left and right
  5. Verify smooth dragging performance on desktop (mouse)
  6. Test on mobile device or browser dev tools to verify touch dragging works
  7. Pan/zoom maps and verify both maps stay synchronized
  8. Verify controls remain visible and unclipped in both modes

- **Expected behavior:**
  - Swipe slider appears only in split-screen mode
  - Slider is draggable with smooth performance
  - Both maps load tiles efficiently without constant re-fetching
  - Controls remain accessible and properly positioned