### PR TITLE
[Enhancement] Add user-defined no data value for single band raster symbology

### DIFF
--- a/frontend/src/components/maps/RasterSymbologyContext.tsx
+++ b/frontend/src/components/maps/RasterSymbologyContext.tsx
@@ -19,6 +19,7 @@ type ValueRange = {
 export interface SingleBandSymbology extends Symbology, ValueRange {
   background?: DataProduct;
   colorRamp: string;
+  nodata?: number | null;
 }
 
 export interface ColorBand extends ValueRange {

--- a/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandColorSettings.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandColorSettings.tsx
@@ -2,6 +2,7 @@ import { DataProduct } from '../../../pages/workspace/projects/Project';
 import RasterSymbologyFieldSet from '../RasterSymbologyFieldset';
 import RasterSymbologyOpacitySlider from '../RasterSymbologyOpacitySlider';
 import SingleBandColorRampSelect from './SingleBandColorRampSelect';
+import SingleBandNoDataInput from './SingleBandNoDataInput';
 
 export default function SingleBandColorSettings({
   dataProduct,
@@ -12,6 +13,7 @@ export default function SingleBandColorSettings({
     <RasterSymbologyFieldSet title="Color Properties">
       <SingleBandColorRampSelect dataProduct={dataProduct} />
       <RasterSymbologyOpacitySlider dataProduct={dataProduct} />
+      <SingleBandNoDataInput dataProduct={dataProduct} />
     </RasterSymbologyFieldSet>
   );
 }

--- a/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandNoDataInput.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandNoDataInput.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+
+import { DataProduct } from '../../../pages/workspace/projects/Project';
+import {
+  SingleBandSymbology,
+  useRasterSymbologyContext,
+} from '../../RasterSymbologyContext';
+
+export default function SingleBandNoDataInput({
+  dataProduct,
+}: {
+  dataProduct: DataProduct;
+}) {
+  const { state, dispatch } = useRasterSymbologyContext();
+  const symbology = state[dataProduct.id].symbology as SingleBandSymbology;
+
+  const [inputValue, setInputValue] = useState('');
+
+  // Sync local state when symbology nodata changes externally (e.g., loading saved settings)
+  useEffect(() => {
+    setInputValue(
+      symbology.nodata != null ? symbology.nodata.toString() : ''
+    );
+  }, [symbology.nodata]);
+
+  const handleSet = () => {
+    const parsed = parseFloat(inputValue);
+    if (isNaN(parsed)) return;
+
+    dispatch({
+      type: 'SET_SYMBOLOGY',
+      rasterId: dataProduct.id,
+      payload: { ...symbology, nodata: parsed },
+    });
+  };
+
+  const handleClear = () => {
+    setInputValue('');
+    dispatch({
+      type: 'SET_SYMBOLOGY',
+      rasterId: dataProduct.id,
+      payload: { ...symbology, nodata: null },
+    });
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSet();
+    }
+  };
+
+  const currentNodata = symbology.nodata;
+  const parsed = parseFloat(inputValue);
+  const isSetDisabled =
+    inputValue === '' || isNaN(parsed) || parsed === currentNodata;
+
+  return (
+    <div>
+      <label className="block font-semibold pt-2 pb-1" htmlFor="nodata">
+        No Data
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          className="focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-hidden border border-gray-400 rounded-sm py-1 px-4 block w-full appearance-none"
+          type="number"
+          id="nodata"
+          name="nodata"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="e.g. -9999"
+        />
+        <button
+          type="button"
+          className="px-3 py-1 text-sm font-medium rounded-sm border-2 bg-accent3 hover:bg-accent3-dark border-accent3 hover:border-accent3-dark text-white ease-in-out duration-300 disabled:bg-gray-200 disabled:border-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+          onClick={handleSet}
+          disabled={isSetDisabled}
+        >
+          Set
+        </button>
+        {currentNodata != null && (
+          <button
+            type="button"
+            className="px-3 py-1 text-sm font-medium rounded-sm border-2 text-gray-700 bg-gray-200 hover:bg-gray-300 border-gray-300 hover:border-gray-400 ease-in-out duration-300"
+            onClick={handleClear}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/maps/utils.tsx
+++ b/frontend/src/components/maps/utils.tsx
@@ -305,6 +305,7 @@ const createDefaultSingleBandSymbology = (
   colorRamp: 'rainbow',
   meanStdDev: 2,
   mode: 'minMax',
+  nodata: null,
   opacity: 100,
   min: stacProperties.raster[0].stats.minimum,
   max: stacProperties.raster[0].stats.maximum,
@@ -519,6 +520,9 @@ function getTitilerQueryParams(
       'rescale',
       getSingleBandMinMax(dataProduct.stac_properties, s).flat().join(',')
     );
+    if (s.nodata != null) {
+      queryParams.append('nodata', s.nodata.toString());
+    }
   } else {
     const s = symbology as MultibandSymbology;
     queryParams.append('bidx', s.red.idx.toString());


### PR DESCRIPTION
## Summary
Allows users to specify a custom no data value for single band rasters. When set, the value is passed as a nodata query parameter to TiTiler, causing those pixels to be treated as transparent. This allows raster datasets to exclude designated nodata values (e.g., -9999) from visualization.

## Changes
- Frontend: Added `nodata` field (`number | null`) to the `SingleBandSymbology` interface
- Frontend: Created `SingleBandNoDataInput` component with a numeric input, Set button, and conditional Clear button
- Frontend: Integrated the new component into `SingleBandColorSettings` under Color Properties
- Frontend: Updated `getTitilerQueryParams` to append `nodata` when a value is set
- Frontend: Initialized `nodata` as `null` in the default single band symbology

## Testing
- Navigate to a project with a single band raster data product
- Open the symbology settings panel
- Verify the "No Data" input appears under Color Properties
- Enter a value (e.g., `-9999`) and click Set or press Enter — pixels matching that value should become transparent
- Click Clear — the no data override is removed and all pixels render normally
- Verify that leaving the input empty or entering a non-numeric value disables the Set button