### PR TITLE
[Feature] Add depth map filter mode to Metashape advanced settings

### DIFF
--- a/backend/app/schemas/raw_data.py
+++ b/backend/app/schemas/raw_data.py
@@ -76,6 +76,9 @@ class MetashapeQueryParams(BaseModel):
     alignQuality: Literal["low", "medium", "high"]
     backend: Literal["metashape"]
     blendingMode: Literal["average", "disabled", "min", "max", "mosaic"]
+    buildDepthFilterMode: Literal[
+        "no_filtering", "mild_filtering", "moderate_filtering", "aggressive_filtering"
+    ]
     buildDepthQuality: Literal["low", "medium", "high"]
     camera: Literal["single", "multi"]
     cullFaces: bool

--- a/frontend/src/components/RHFInputs.tsx
+++ b/frontend/src/components/RHFInputs.tsx
@@ -14,6 +14,17 @@ interface RadioInput extends Input {
   value: string;
 }
 
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectInput {
+  fieldName: string;
+  label: string;
+  options: SelectOption[];
+}
+
 interface TextInput extends Input {
   placeholder?: string;
 }
@@ -99,6 +110,29 @@ function RadioInput({
   );
 }
 
+function SelectInput({ fieldName, label, options }: SelectInput) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
+
+  const error = errors && errors[fieldName];
+
+  return (
+    <label htmlFor={fieldName}>
+      <span className="text-sm font-medium inline-block mr-2">{label}:</span>
+      <select id={fieldName} {...register(fieldName)}>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {error && <p className="text-sm text-red-500">{`${error.message}`}</p>}
+    </label>
+  );
+}
+
 function TextInput({ fieldName, label, placeholder, ...props }: TextInput) {
   const {
     register,
@@ -123,4 +157,4 @@ function TextInput({ fieldName, label, placeholder, ...props }: TextInput) {
     </label>
   );
 }
-export { CheckboxInput, NumberInput, RadioInput, TextInput };
+export { CheckboxInput, NumberInput, RadioInput, SelectInput, TextInput };

--- a/frontend/src/components/pages/workspace/projects/flights/RawData/RawData.types.ts
+++ b/frontend/src/components/pages/workspace/projects/flights/RawData/RawData.types.ts
@@ -1,5 +1,10 @@
 type BlendingModeType = 'average' | 'disabled' | 'min' | 'max' | 'mosaic';
 type CameraType = 'single' | 'multi';
+type FilterMode =
+  | 'no_filtering'
+  | 'mild_filtering'
+  | 'moderate_filtering'
+  | 'aggressive_filtering';
 type QualityType = 'low' | 'medium' | 'high';
 
 export interface MetashapeSettings {
@@ -7,6 +12,7 @@ export interface MetashapeSettings {
   backend: 'metashape';
   blendingMode: BlendingModeType;
   buildDepthQuality: QualityType;
+  buildDepthFilterMode: FilterMode;
   camera: CameraType;
   cullFaces: boolean;
   disclaimer: boolean;

--- a/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/MetashapeForm.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/MetashapeForm.tsx
@@ -7,6 +7,7 @@ import {
   CheckboxInput,
   NumberInput,
   RadioInput,
+  SelectInput,
 } from '../../../../../../../RHFInputs';
 
 import {
@@ -174,6 +175,26 @@ export default function MetashapeForm({
                       </p>
                     )}
                 </div>
+                {showAdvancedSettings && (
+                  <div className="mt-4">
+                    <SelectInput
+                      fieldName="buildDepthFilterMode"
+                      label="Filter Mode"
+                      options={[
+                        { value: 'no_filtering', label: 'No Filtering' },
+                        { value: 'mild_filtering', label: 'Mild Filtering' },
+                        {
+                          value: 'moderate_filtering',
+                          label: 'Moderate Filtering',
+                        },
+                        {
+                          value: 'aggressive_filtering',
+                          label: 'Aggressive Filtering',
+                        },
+                      ]}
+                    />
+                  </div>
+                )}
               </fieldset>
 
               {/* Advanced Settings - Conditionally Rendered */}

--- a/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/defaultValues.ts
+++ b/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/defaultValues.ts
@@ -5,6 +5,7 @@ const defaultValues: MetashapeSettings = {
   backend: 'metashape',
   blendingMode: 'mosaic',
   buildDepthQuality: 'medium',
+  buildDepthFilterMode: 'mild_filtering',
   camera: 'single',
   disclaimer: false,
   exportDEM: true,

--- a/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/validationSchema.ts
+++ b/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataImageProcessingForm/MetashapeForm/validationSchema.ts
@@ -5,7 +5,7 @@ const schema = yup.object({
     .string()
     .oneOf(
       ['low', 'medium', 'high'],
-      'Alignment accuracy must be "low", "medium", or "high"'
+      'Alignment accuracy must be "low", "medium", or "high"',
     )
     .required('Alignment accuracy is required'),
   backend: yup
@@ -16,16 +16,28 @@ const schema = yup.object({
     .string()
     .oneOf(
       ['average', 'disabled', 'min', 'max', 'mosaic'],
-      'Blending mode must be "average", "disabled", "min", "max", or "mosaic"'
+      'Blending mode must be "average", "disabled", "min", "max", or "mosaic"',
     )
     .required('Blending mode is required'),
   buildDepthQuality: yup
     .string()
     .oneOf(
       ['low', 'medium', 'high'],
-      'Build depth quality must be "low", "medium", or "high"'
+      'Build depth quality must be "low", "medium", or "high"',
     )
     .required('Build depth quality is required'),
+  buildDepthFilterMode: yup
+    .string()
+    .oneOf(
+      [
+        'no_filtering',
+        'mild_filtering',
+        'moderate_filtering',
+        'aggressive_filtering',
+      ],
+      'Build depth filter mode must be "No Filtering", "Mild Filtering", "Moderate Filtering", or "Aggressive Filtering"',
+    )
+    .required('Build depth filter mode is required'),
   camera: yup
     .string()
     .oneOf(['single', 'multi'], 'Camera sensors must be single or multi')


### PR DESCRIPTION
## Summary
Adds a new `buildDepthFilterMode` option to the Metashape image processing form, exposed under advanced settings, so users can control depth map filtering aggressiveness when processing raw flight imagery.

## Changes
- Backend: Added `buildDepthFilterMode` literal field (`no_filtering` | `mild_filtering` | `moderate_filtering` | `aggressive_filtering`) to `MetashapeQueryParams` in `backend/app/schemas/raw_data.py`.
- Frontend: New reusable `SelectInput` component in `frontend/src/components/RHFInputs.tsx` wired to react-hook-form.
- Frontend: Added Filter Mode dropdown to `MetashapeForm.tsx`, rendered only when advanced settings are toggled on.
- Frontend: Extended `MetashapeSettings` type, default values (`mild_filtering`), and yup validation schema for the new field.

## Testing
- `docker compose exec frontend npx tsc --noEmit`
- `docker compose exec backend pytest`
- Manual QA: Navigate to a project flight → Raw Data → Process Images (Metashape) → toggle Advanced Settings → verify the Filter Mode dropdown appears with four options and submits successfully.

## Related Issues
N/A