### PR TITLE
[Bug] Fix unreachable last page in project list pagination

### DIFF
--- a/frontend/src/components/pages/workspace/projects/ProjectList.tsx
+++ b/frontend/src/components/pages/workspace/projects/ProjectList.tsx
@@ -79,12 +79,6 @@ export default function ProjectList({
     projectDispatch({ type: 'clear', payload: null });
   }, [locationDispatch, project, projectDispatch]);
 
-  useEffect(() => {
-    if (projects && filterAndSlice(projects).length < MAX_ITEMS) {
-      setCurrentPage(0);
-    }
-  }, [filterAndSlice, projects]);
-
   /**
    * Updates the current search text.
    */
@@ -143,6 +137,15 @@ export default function ProjectList({
 
     return filteredProjects;
   }, [projects, projectFilterSelection, selectedTeamIds]);
+
+  useEffect(() => {
+    if (!projects) return;
+    const filteredCount = filterSearch(filteredProjects).length;
+    const maxPage = Math.max(0, Math.ceil(filteredCount / MAX_ITEMS) - 1);
+    if (currentPage > maxPage) {
+      setCurrentPage(maxPage);
+    }
+  }, [projects, filteredProjects, filterSearch, currentPage]);
 
   const filteredAndSortedProjects = useMemo(
     () =>


### PR DESCRIPTION
## Summary
The project list pagination silently bounced users back to page 0 whenever they tried to view the final page, hiding any projects that lived on a non-full last page (e.g., project no. 25 of 25). This PR replaces the offending effect with a correct page-bounds clamp.

## Changes
- Frontend: In `frontend/src/components/pages/workspace/projects/ProjectList.tsx`, removed the effect that reset `currentPage` to 0 whenever the current page slice contained fewer than `MAX_ITEMS` items — that condition is true for every non-full last page, so the user could never land there.
- Frontend: Added a replacement effect, placed after the `filteredProjects` memo, that resets `currentPage` only when it points past the last valid page. The bound is computed from `filterSearch(filteredProjects).length`, matching the logic already used to compute `TOTAL_PAGES`.

## Testing
- Type check: `docker compose exec frontend npx tsc --noEmit` — passes.
- Manual QA against a workspace with a non-multiple-of-12 project count (e.g., 25 projects, 3 pages):
  - Click the last-page number — the final page renders and project no. 25 is visible.
  - From page 1, repeatedly click `>` — advances to the last page and stops there instead of bouncing to page 1.
  - On the last page, toggle a filter that shrinks the result set below the current page — `currentPage` clamps to the new last page rather than resetting to 0 unconditionally.
  - On a later page, type a search query that narrows results to a single page — lands on page 1 instead of an empty page.

## Related Issues
N/A