### PR TITLE
[Bug] Fix project creation with MultiPolygon GeoJSON boundary uploads

### DIFF
--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -1,8 +1,8 @@
-from typing import Dict
+from typing import Any, Dict
 from uuid import UUID
 
 from geojson_pydantic import Feature, Polygon
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 # shared properties
@@ -12,7 +12,27 @@ class LocationBase(BaseModel):
 
 # properties to receive via API on creation
 class LocationCreate(Feature[Polygon, Dict]):
-    pass
+    @field_validator("geometry", mode="before")
+    @classmethod
+    def geometry_must_be_polygon(cls, v: Any) -> Any:
+        # Short-circuit Pydantic's union resolution against Feature[Polygon, Dict]
+        # so non-Polygon geometries return one clear domain message instead of
+        # an 11-item Position2D/Position3D coordinate-coercion dump.
+        geom_type = (
+            v.get("type") if isinstance(v, dict) else getattr(v, "type", None)
+        )
+        if geom_type is None or geom_type == "Polygon":
+            return v
+        if geom_type == "MultiPolygon":
+            raise ValueError(
+                "Field boundary must be a single Polygon. MultiPolygon is not "
+                "supported — dissolve the feature into a single Polygon before "
+                "uploading."
+            )
+        raise ValueError(
+            f"Field boundary must be a Polygon. Received geometry type: "
+            f"{geom_type}."
+        )
 
 
 # properties to receive via API on update

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -148,6 +148,64 @@ def test_create_project_with_demo_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
+def test_create_project_rejects_multipolygon(
+    client: TestClient, normal_user_access_token: str, db: Session
+) -> None:
+    create_location(db)
+    polygon_coords = get_geojson_feature_collection("polygon")["geojson"][
+        "features"
+    ][0]["geometry"]["coordinates"]
+    multipolygon_feature = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [polygon_coords],
+        },
+    }
+    data = jsonable_encoder(
+        {
+            "title": random_team_name(),
+            "description": random_team_description(),
+            "location": multipolygon_feature,
+        }
+    )
+    response = client.post(API_URL, json=data)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    detail = response.json()["detail"]
+    assert isinstance(detail, list)
+    assert len(detail) == 1, f"Expected single-message detail, got: {detail}"
+    msg = detail[0]["msg"]
+    assert "MultiPolygon" in msg
+    assert "Polygon" in msg
+
+
+def test_create_project_rejects_point_geometry(
+    client: TestClient, normal_user_access_token: str, db: Session
+) -> None:
+    create_location(db)
+    point_feature = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {"type": "Point", "coordinates": [-86.94, 41.44]},
+    }
+    data = jsonable_encoder(
+        {
+            "title": random_team_name(),
+            "description": random_team_description(),
+            "location": point_feature,
+        }
+    )
+    response = client.post(API_URL, json=data)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    detail = response.json()["detail"]
+    assert isinstance(detail, list)
+    assert len(detail) == 1, f"Expected single-message detail, got: {detail}"
+    msg = detail[0]["msg"]
+    assert "Polygon" in msg
+    assert "Point" in msg
+
+
 def test_create_project_date_validation(
     client: TestClient, normal_user_access_token: str, db: Session
 ) -> None:

--- a/frontend/src/components/maps/DrawFieldMap/DrawFieldMap.tsx
+++ b/frontend/src/components/maps/DrawFieldMap/DrawFieldMap.tsx
@@ -18,6 +18,7 @@ import { GeoJsonShapeFeature } from '@geoman-io/maplibre-geoman-free';
 import GeomanControl from '../GeomanControl';
 import { GeoJSONFeature } from '../../pages/workspace/projects/Project';
 import { useProjectContext } from '../../pages/workspace/projects/ProjectContext';
+import { normalizeToPolygon } from './normalizeToPolygon';
 
 import {
   getMapboxSatelliteBasemapStyle,
@@ -58,18 +59,6 @@ export default function DrawFieldMap({
   const mapRef = useRef<MapRef>(null);
   const { setFieldValue, setFieldTouched } = useFormikContext();
   const { locationDispatch } = useProjectContext();
-
-  // Utility: ensure a feature is a Polygon (convert first polygon of MultiPolygon)
-  const normalizeToPolygon = (feature: GeoJSONFeature): GeoJSONFeature => {
-    if (feature?.geometry?.type !== 'MultiPolygon') return feature;
-    return {
-      ...feature,
-      geometry: {
-        type: 'Polygon',
-        coordinates: (feature.geometry.coordinates as number[][][][])[0],
-      },
-    };
-  };
 
   // Load config for osmLabelFilter
   useEffect(() => {
@@ -126,7 +115,7 @@ export default function DrawFieldMap({
   // Handle draw end - update formik location field with drawn feature
   const handleDrawEnd = (feature: GeoJsonShapeFeature) => {
     const geoJsonFeature = feature as unknown as GeoJSONFeature;
-    const convertedFeature = normalizeToPolygon(geoJsonFeature);
+    const { feature: convertedFeature } = normalizeToPolygon(geoJsonFeature);
 
     // Update formik location field
     setFieldValue('location', convertedFeature);
@@ -144,7 +133,7 @@ export default function DrawFieldMap({
   // Handle edit - update formik location field with edited feature
   const handleEdit = (feature: GeoJsonShapeFeature) => {
     const geoJsonFeature = feature as unknown as GeoJSONFeature;
-    const convertedFeature = normalizeToPolygon(geoJsonFeature);
+    const { feature: convertedFeature } = normalizeToPolygon(geoJsonFeature);
 
     // Update formik location field only - don't update context until user clicks Update Field
     setFieldValue('location', convertedFeature);

--- a/frontend/src/components/maps/DrawFieldMap/normalizeToPolygon.ts
+++ b/frontend/src/components/maps/DrawFieldMap/normalizeToPolygon.ts
@@ -1,0 +1,50 @@
+import area from '@turf/area';
+import { Polygon } from 'geojson';
+
+import { GeoJSONFeature } from '../../pages/workspace/projects/Project';
+
+export type NormalizeResult = {
+  feature: GeoJSONFeature;
+  pickedLargestOf?: number;
+};
+
+// Convert a (possibly MultiPolygon) feature into a single-Polygon feature.
+// Trivial single-component MultiPolygons (common in shapefile-derived GeoJSON)
+// are unwrapped silently. Multi-component MultiPolygons keep the largest
+// component by area, with the original component count returned so callers
+// can surface a notice.
+export function normalizeToPolygon(feature: GeoJSONFeature): NormalizeResult {
+  if (feature?.geometry?.type !== 'MultiPolygon') {
+    return { feature };
+  }
+
+  const components = feature.geometry.coordinates as number[][][][];
+  if (components.length === 0) {
+    return { feature };
+  }
+
+  let largestIdx = 0;
+  if (components.length > 1) {
+    let largestArea = -Infinity;
+    components.forEach((coords, idx) => {
+      const polygon: Polygon = { type: 'Polygon', coordinates: coords };
+      const a = area(polygon);
+      if (a > largestArea) {
+        largestArea = a;
+        largestIdx = idx;
+      }
+    });
+  }
+
+  const normalized: GeoJSONFeature = {
+    ...feature,
+    geometry: {
+      type: 'Polygon',
+      coordinates: components[largestIdx],
+    },
+  };
+
+  return components.length > 1
+    ? { feature: normalized, pickedLargestOf: components.length }
+    : { feature: normalized };
+}

--- a/frontend/src/components/pages/workspace/projects/ProjectForm.tsx
+++ b/frontend/src/components/pages/workspace/projects/ProjectForm.tsx
@@ -1,4 +1,3 @@
-import { isAxiosError } from 'axios';
 import { Formik, Form } from 'formik';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -14,6 +13,7 @@ import { projectCreateValidationSchema } from './validationSchema';
 import { useProjectContext } from './ProjectContext';
 
 import api from '../../../../api';
+import { formatApiError } from '../../../../utils/formatApiError';
 
 export async function loader() {
   const response = await api.get('/teams', { params: { owner_only: true } });
@@ -81,17 +81,13 @@ export default function ProjectForm({
               });
             }
           } catch (err) {
-            if (isAxiosError(err) && err.response && err.response.data.detail) {
-              setStatus({
-                type: 'error',
-                msg: err.response.data.detail,
-              });
-            } else {
-              setStatus({
-                type: 'error',
-                msg: 'Unexpected error occurred. Unable to create project.',
-              });
-            }
+            setStatus({
+              type: 'error',
+              msg: formatApiError(
+                err,
+                'Unexpected error occurred. Unable to create project.'
+              ),
+            });
           }
           setSubmitting(false);
         }}

--- a/frontend/src/components/pages/workspace/projects/ProjectFormMap.tsx
+++ b/frontend/src/components/pages/workspace/projects/ProjectFormMap.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { Button, OutlineButton } from '../../../Buttons';
 import DrawFieldMap from '../../../maps/DrawFieldMap/DrawFieldMap';
+import { normalizeToPolygon } from '../../../maps/DrawFieldMap/normalizeToPolygon';
 import { GeoJSONFeature } from './Project';
 import HintText from '../../../HintText';
 import { useProjectContext } from './ProjectContext';
@@ -69,15 +70,28 @@ export default function ProjectFormMap({
 
   useEffect(() => {
     if (featureCollection && featureCollection.features.length === 1) {
-      setFieldValue('location', featureCollection.features[0]);
+      const raw = featureCollection.features[0] as unknown as GeoJSONFeature;
+      const { feature, pickedLargestOf } = normalizeToPolygon(raw);
+
+      setFieldValue('location', feature);
       setFieldTouched('location', true);
 
-      locationDispatch({
-        type: 'set',
-        payload: featureCollection.features[0] as unknown as GeoJSONFeature,
-      });
+      locationDispatch({ type: 'set', payload: feature });
+
+      if (pickedLargestOf) {
+        setStatus({
+          type: 'info',
+          msg: `This file contained ${pickedLargestOf} polygons in one feature. We kept the largest. Redraw or re-upload if you want a different one.`,
+        });
+      }
     }
-  }, [featureCollection, setFieldValue, setFieldTouched, locationDispatch]);
+  }, [
+    featureCollection,
+    setFieldValue,
+    setFieldTouched,
+    setStatus,
+    locationDispatch,
+  ]);
 
   // Handle draw start callback
   const handleDrawStart = () => {

--- a/frontend/src/utils/formatApiError.ts
+++ b/frontend/src/utils/formatApiError.ts
@@ -1,0 +1,39 @@
+import { isAxiosError } from 'axios';
+
+import { ErrorResponseBody, ValidationError } from '../types/uppy';
+
+const DEFAULT_FALLBACK = 'Unexpected error occurred. Please try again.';
+
+// Convert an axios error into a safe, user-displayable string.
+// Handles FastAPI's two response shapes: { detail: string } and the 422
+// validation-error case where detail is an array of {loc, msg, type}.
+// The array case must be flattened — passing it as a React child throws
+// "Objects are not valid as a React child" and bubbles to error boundaries.
+export function formatApiError(
+  err: unknown,
+  fallback: string = DEFAULT_FALLBACK
+): string {
+  if (!isAxiosError(err) || !err.response) return fallback;
+
+  const body = err.response.data as ErrorResponseBody | undefined;
+  const detail = body?.detail;
+  if (!detail) return fallback;
+
+  if (typeof detail === 'string') return detail;
+
+  if (Array.isArray(detail)) {
+    const errors = detail as ValidationError[];
+    if (errors.length === 0) return fallback;
+
+    return errors
+      .map((e) => {
+        const path = e.loc
+          .filter((p, i) => !(i === 0 && p === 'body'))
+          .join('.');
+        return path ? `${path}: ${e.msg}` : e.msg;
+      })
+      .join('; ');
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
Uploading a MultiPolygon GeoJSON (common output from GIS tools that wrap a single polygon as MultiPolygon) on the New Project form caused a 422 backend rejection that crashed the form into the generic 404 error page. This PR makes uploaded MultiPolygons succeed end-to-end, renders any future validation errors inline in the form, and replaces the noisy Pydantic union-resolution dump with a single user-meaningful message for non-Polygon geometry.

## Changes

- **Frontend:**
  - New `normalizeToPolygon` helper extracted from `DrawFieldMap` and reused in `ProjectFormMap`. Single-component MultiPolygons are unwrapped silently; multi-component MultiPolygons keep the largest by area (via `@turf/area`) and surface a non-blocking info notice.
  - New `formatApiError` utility that safely flattens FastAPI's array-shaped 422 `detail` into a display string. Replaces the unsafe `setStatus({ msg: err.response.data.detail })` in `ProjectForm` that rendered an object array as a React child, crashing into the route's `errorElement`.
  - `ProjectForm` submit handler now uses `formatApiError`; `isAxiosError` import dropped (encapsulated).
- **Backend:**
  - `LocationCreate` (`backend/app/schemas/location.py`) gains a `mode="before"` `field_validator` on `geometry` that fast-rejects non-Polygon types with a single domain message ("Field boundary must be a single Polygon. MultiPolygon is not supported — dissolve the feature into a single Polygon before uploading.") instead of an 11-item Position2D/Position3D coordinate-coercion dump.
  - Schema and PostGIS column type unchanged — the contract stays "Polygon only", but rejection messages are now actionable for non-browser API clients.

## Testing

- Backend: added `test_create_project_rejects_multipolygon` and `test_create_project_rejects_point_geometry` in `app/tests/api/api_v1/test_projects.py`. Both assert a single-element 422 `detail` with a domain message.
  - `docker compose exec backend pytest app/tests/api/api_v1/test_projects.py` — **62 passed** (60 pre-existing + 2 new).
- Frontend type check: `docker compose exec frontend npx tsc --noEmit` — clean.
- Manual QA (running stack):
  1. Upload `test_boundary.geojson` (single-component MultiPolygon) on the New Project form, fill title/description, click **Create** — project is created, no error page, stored geometry is `ST_Polygon`.
  2. Upload a hand-crafted two-component MultiPolygon — non-blocking info Alert renders ("This file contained 2 polygons in one feature. We kept the largest…"), Create succeeds, the larger component is persisted (verifiable via `ST_Area(geom::geography)`).
  3. Force a 422 once by temporarily commenting out the `normalizeToPolygon` call in `ProjectFormMap.tsx` and re-uploading the MultiPolygon: inline red Alert renders a single line such as `location.geometry: Field boundary must be a single Polygon. MultiPolygon is not supported — dissolve the feature into a single Polygon before uploading.` The generic error page no longer appears.
  4. Drawn-polygon path (regression check): draw a polygon with the map controls and create a project — still works as before.

## Breaking Changes
None. Schema and DB column type unchanged. The 422 contract is unchanged in shape (still array-of-detail); only the message text and length changed for non-Polygon geometry.

## Related Issues
N/A
