### PR TITLE
[Feature] Add S3 storage option for STAC published assets

### DIFF
--- a/backend.example.env
+++ b/backend.example.env
@@ -54,6 +54,15 @@ SECRET_KEY=CHANGEME-your-super-secret-key-32-chars-min
 #STAC_API_TEST_URL=
 #STAC_BROWSER_URL=
 
+# AWS S3 storage for STAC publishing
+# When configured, data products and raw data are uploaded to S3 during STAC publishing.
+# The S3 URLs are used as asset hrefs in published STAC items.
+# Leave empty to use local server URLs (default behavior).
+#AWS_S3_BUCKET_NAME=
+#AWS_S3_REGION=us-east-1
+#AWS_ACCESS_KEY_ID=
+#AWS_SECRET_ACCESS_KEY=
+
 # Cloudflare Turnstile secret key for bot protection on registration
 # Leave empty to disable Turnstile validation
 TURNSTILE_SECRET_KEY=

--- a/backend/alembic/versions/786003d898d7_add_s3_url_to_data_products_and_raw_data.py
+++ b/backend/alembic/versions/786003d898d7_add_s3_url_to_data_products_and_raw_data.py
@@ -1,0 +1,26 @@
+"""add s3_url to data_products and raw_data
+
+Revision ID: 786003d898d7
+Revises: a7f2c3d8e1b4
+Create Date: 2026-04-12 17:57:25.677328
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '786003d898d7'
+down_revision: str | None = 'a7f2c3d8e1b4'
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column('data_products', sa.Column('s3_url', sa.String(), nullable=True))
+    op.add_column('raw_data', sa.Column('s3_url', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('raw_data', 's3_url')
+    op.drop_column('data_products', 's3_url')

--- a/backend/app/api/api_v1/endpoints/stac.py
+++ b/backend/app/api/api_v1/endpoints/stac.py
@@ -20,13 +20,27 @@ from app.utils.s3 import delete_s3_objects, is_s3_configured, parse_s3_key_from_
 from app.utils.stac.STACCollectionManager import STACCollectionManager
 
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
+class S3CleanupError(Exception):
+    """Raised when the S3 cleanup step of unpublish does not fully succeed.
+
+    The endpoint converts this into a 503 with a generic message so the user
+    can retry once S3 connectivity is restored. The s3_url columns are left
+    intact so orphaned objects remain trackable.
+    """
+
+
 def _cleanup_s3_for_project(db: Session, project_id: UUID) -> None:
-    """Delete S3 copies of data products and raw data for a project, then clear s3_url columns."""
+    """Delete S3 copies of data products and raw data for a project, then clear s3_url columns.
+
+    Raises S3CleanupError if the S3 delete does not fully succeed. The s3_url
+    columns are preserved in that case so the orphaned objects can be cleaned
+    up on a future retry.
+    """
     s3_keys = []
 
     # Collect S3 keys from data products
@@ -49,9 +63,11 @@ def _cleanup_s3_for_project(db: Session, project_id: UUID) -> None:
         except ValueError:
             logger.warning(f"Could not parse S3 key from URL: {rd.s3_url}")
 
-    # Delete from S3
-    if s3_keys:
-        delete_s3_objects(s3_keys)
+    # Delete from S3; preserve s3_url columns if delete fails so we can retry
+    if s3_keys and not delete_s3_objects(s3_keys):
+        raise S3CleanupError(
+            f"S3 cleanup did not fully succeed for project {project_id}"
+        )
 
     # Clear s3_url columns in DB
     crud.data_product.clear_s3_urls_for_project(db, project_id=project_id)
@@ -259,6 +275,23 @@ def remove_project_from_stac_catalog(
             detail="Project not found in STAC catalog",
         )
 
+    # Delete S3 copies of published data BEFORE catalog removal so a failure
+    # leaves the project fully published and retriable rather than half-unpublished.
+    if is_s3_configured():
+        try:
+            _cleanup_s3_for_project(db, project_id)
+        except Exception:
+            logger.exception(
+                f"Failed to clean up S3 for project {project_id}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Could not clean up published data from the configured S3 "
+                    "bucket. Please try again later."
+                ),
+            )
+
     # Remove project from STAC catalog
     try:
         scm.remove_from_catalog()
@@ -270,15 +303,6 @@ def remove_project_from_stac_catalog(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to remove project from STAC catalog. Please try again later.",
         )
-
-    # Delete S3 copies of published data (best-effort, don't block unpublish)
-    if is_s3_configured():
-        try:
-            _cleanup_s3_for_project(db, project_id)
-        except Exception:
-            logger.exception(
-                f"Failed to clean up S3 for project {project_id}"
-            )
 
     # Delete STAC cache to prevent stale URLs on re-publish
     try:

--- a/backend/app/api/api_v1/endpoints/stac.py
+++ b/backend/app/api/api_v1/endpoints/stac.py
@@ -10,18 +10,52 @@ from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
 from app.api import deps
-from app.utils.stac.STACCollectionManager import STACCollectionManager
 from app.core.config import settings
 from app.tasks.stac_tasks import (
     generate_stac_preview,
     publish_stac_catalog,
     get_stac_cache_path,
 )
+from app.utils.s3 import delete_s3_objects, is_s3_configured, parse_s3_key_from_url
+from app.utils.stac.STACCollectionManager import STACCollectionManager
 
 
 logger = logging.getLogger("__name__")
 
 router = APIRouter()
+
+
+def _cleanup_s3_for_project(db: Session, project_id: UUID) -> None:
+    """Delete S3 copies of data products and raw data for a project, then clear s3_url columns."""
+    s3_keys = []
+
+    # Collect S3 keys from data products
+    data_products = crud.data_product.get_data_products_with_s3_urls_for_project(
+        db, project_id=project_id
+    )
+    for dp in data_products:
+        try:
+            s3_keys.append(parse_s3_key_from_url(dp.s3_url))
+        except ValueError:
+            logger.warning(f"Could not parse S3 key from URL: {dp.s3_url}")
+
+    # Collect S3 keys from raw data
+    raw_data_list = crud.raw_data.get_raw_data_with_s3_urls_for_project(
+        db, project_id=project_id
+    )
+    for rd in raw_data_list:
+        try:
+            s3_keys.append(parse_s3_key_from_url(rd.s3_url))
+        except ValueError:
+            logger.warning(f"Could not parse S3 key from URL: {rd.s3_url}")
+
+    # Delete from S3
+    if s3_keys:
+        delete_s3_objects(s3_keys)
+
+    # Clear s3_url columns in DB
+    crud.data_product.clear_s3_urls_for_project(db, project_id=project_id)
+    crud.raw_data.clear_s3_urls_for_project(db, project_id=project_id)
 
 
 @router.get(
@@ -236,6 +270,23 @@ def remove_project_from_stac_catalog(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to remove project from STAC catalog. Please try again later.",
         )
+
+    # Delete S3 copies of published data (best-effort, don't block unpublish)
+    if is_s3_configured():
+        try:
+            _cleanup_s3_for_project(db, project_id)
+        except Exception:
+            logger.exception(
+                f"Failed to clean up S3 for project {project_id}"
+            )
+
+    # Delete STAC cache to prevent stale URLs on re-publish
+    try:
+        cache_path = get_stac_cache_path(project_id)
+        if cache_path.exists():
+            cache_path.unlink()
+    except Exception:
+        logger.exception(f"Failed to delete STAC cache for project {project_id}")
 
     # Update the project to unpublished and change all data products to private
     updated_project = crud.project.update_project_visibility(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -144,7 +144,17 @@ class Settings(BaseSettings):
     STAC_BROWSER_URL: Optional[AnyHttpUrl] = None
     EXTERNAL_VIEWER_URL: Optional[AnyHttpUrl] = None
 
+    # AWS S3 storage for STAC publishing
+    AWS_S3_BUCKET_NAME: Optional[str] = None
+    AWS_S3_REGION: Optional[str] = None
+    AWS_ACCESS_KEY_ID: Optional[str] = None
+    AWS_SECRET_ACCESS_KEY: Optional[str] = None
+
     @field_validator(
+        "AWS_ACCESS_KEY_ID",
+        "AWS_S3_BUCKET_NAME",
+        "AWS_S3_REGION",
+        "AWS_SECRET_ACCESS_KEY",
         "EXTERNAL_VIEWER_URL",
         "MAPBOX_ACCESS_TOKEN",
         "STAC_API_URL",

--- a/backend/app/crud/crud_data_product.py
+++ b/backend/app/crud/crud_data_product.py
@@ -17,6 +17,7 @@ from app.crud.base import CRUDBase
 from app.db.session import SessionLocal
 from app.models.constants import NON_RASTER_TYPES, PROCESSING_JOB_NAMES
 from app.models.data_product import DataProduct
+from app.models.flight import Flight
 from app.models.job import Job
 from app.models.utils.utcnow import utcnow
 from app.schemas.data_product import (
@@ -219,6 +220,50 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
             session.commit()
 
         return crud.data_product.get(db, id=data_product_id)
+
+    def update_s3_url(
+        self, db: Session, data_product_id: UUID, s3_url: str
+    ) -> None:
+        """Set the s3_url for a single data product."""
+        stmt = (
+            update(DataProduct)
+            .where(DataProduct.id == data_product_id)
+            .values(s3_url=s3_url)
+        )
+        with db as session:
+            session.execute(stmt)
+            session.commit()
+
+    def clear_s3_urls_for_project(self, db: Session, project_id: UUID) -> int:
+        """Bulk clear s3_url for all data products in a project."""
+        stmt = (
+            update(DataProduct)
+            .where(
+                DataProduct.flight_id.in_(
+                    select(Flight.id).where(Flight.project_id == project_id)
+                ),
+                DataProduct.s3_url.isnot(None),
+            )
+            .values(s3_url=None)
+        )
+        with db as session:
+            result = session.execute(stmt)
+            session.commit()
+            return result.rowcount
+
+    def get_data_products_with_s3_urls_for_project(
+        self, db: Session, project_id: UUID
+    ) -> Sequence[DataProduct]:
+        """Return data products with non-null s3_url for a project."""
+        stmt = select(DataProduct).where(
+            DataProduct.flight_id.in_(
+                select(Flight.id).where(Flight.project_id == project_id)
+            ),
+            DataProduct.s3_url.isnot(None),
+            DataProduct.is_active,
+        )
+        with db as session:
+            return session.execute(stmt).scalars().all()
 
 
 def set_status_attr(data_product_obj: DataProduct, jobs: List[Job]) -> bool:

--- a/backend/app/crud/crud_raw_data.py
+++ b/backend/app/crud/crud_raw_data.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from app import crud
 from app.core.config import settings
 from app.crud.base import CRUDBase
+from app.models.flight import Flight
 from app.models.job import Job
 from app.models.raw_data import RawData
 from app.models.utils.utcnow import utcnow
@@ -85,6 +86,48 @@ class CRUDRawData(CRUDBase[RawData, RawDataCreate, RawDataUpdate]):
             session.commit()
 
         return crud.raw_data.get(db, id=raw_data_id)
+
+    def update_s3_url(self, db: Session, raw_data_id: UUID, s3_url: str) -> None:
+        """Set the s3_url for a single raw data record."""
+        stmt = (
+            update(RawData)
+            .where(RawData.id == raw_data_id)
+            .values(s3_url=s3_url)
+        )
+        with db as session:
+            session.execute(stmt)
+            session.commit()
+
+    def clear_s3_urls_for_project(self, db: Session, project_id: UUID) -> int:
+        """Bulk clear s3_url for all raw data in a project."""
+        stmt = (
+            update(RawData)
+            .where(
+                RawData.flight_id.in_(
+                    select(Flight.id).where(Flight.project_id == project_id)
+                ),
+                RawData.s3_url.isnot(None),
+            )
+            .values(s3_url=None)
+        )
+        with db as session:
+            result = session.execute(stmt)
+            session.commit()
+            return result.rowcount
+
+    def get_raw_data_with_s3_urls_for_project(
+        self, db: Session, project_id: UUID
+    ) -> Sequence[RawData]:
+        """Return raw data records with non-null s3_url for a project."""
+        stmt = select(RawData).where(
+            RawData.flight_id.in_(
+                select(Flight.id).where(Flight.project_id == project_id)
+            ),
+            RawData.s3_url.isnot(None),
+            RawData.is_active,
+        )
+        with db as session:
+            return session.execute(stmt).scalars().all()
 
 
 def set_status_attr(raw_data_obj: RawData, jobs: List[Job]) -> bool:

--- a/backend/app/models/data_product.py
+++ b/backend/app/models/data_product.py
@@ -36,6 +36,7 @@ class DataProduct(Base):
     bbox: Mapped[dict] = mapped_column(JSONB, nullable=True)
     crs: Mapped[dict] = mapped_column(JSONB, nullable=True)
     resolution: Mapped[dict] = mapped_column(JSONB, nullable=True)
+    s3_url: Mapped[str] = mapped_column(String, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_initial_processing_completed: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False

--- a/backend/app/models/raw_data.py
+++ b/backend/app/models/raw_data.py
@@ -23,6 +23,7 @@ class RawData(Base):
     )
     filepath: Mapped[str] = mapped_column(String, nullable=False)
     original_filename: Mapped[str] = mapped_column(String, nullable=False)
+    s3_url: Mapped[str] = mapped_column(String, nullable=True)
     flight_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("flights.id"), nullable=False
     )

--- a/backend/app/tasks/stac_tasks.py
+++ b/backend/app/tasks/stac_tasks.py
@@ -20,13 +20,23 @@ class UUIDEncoder(json.JSONEncoder):
 from celery.utils.log import get_task_logger
 from sqlalchemy.orm import Session
 
-from app import crud, schemas
+from pystac import Item
+
+from app import crud, models, schemas
 from app.api.deps import get_db
+from app.api.utils import get_static_dir
 from app.core.celery_app import celery_app
 from app.core.config import settings
 from app.models.job import Job as JobModel
 from app.schemas.job import Status
 from app.utils.job_manager import JobManager
+from app.utils.s3 import (
+    is_s3_configured,
+    build_s3_key,
+    upload_file_to_s3,
+    delete_s3_objects,
+    parse_s3_key_from_url,
+)
 
 # Import these at module level for testing/mocking purposes
 # They will be imported again inside functions to avoid circular imports during normal operation
@@ -61,6 +71,113 @@ def get_stac_timestamp(job: Optional[JobModel] = None) -> Optional[str]:
         return job.start_time.isoformat()
     else:
         return None
+
+
+def _upload_to_s3_and_rewrite_hrefs(
+    db: Session,
+    items: List[Item],
+    flights: List[models.Flight],
+    include_raw_data_links: Optional[List[str]],
+) -> List[str]:
+    """Upload successful data products (and raw data) to S3 and rewrite STAC item hrefs.
+
+    Called after STAC generation, only for items that succeeded.
+    Returns a list of S3 keys that were uploaded (for rollback on failure).
+
+    Raises on upload failure so the caller can handle rollback.
+    """
+    upload_dir = get_static_dir()
+    uploaded_s3_keys: List[str] = []
+
+    # Build a lookup from data_product_id -> data_product model
+    dp_lookup: Dict[str, models.DataProduct] = {}
+    for flight in flights:
+        for dp in flight.data_products:
+            dp_lookup[str(dp.id)] = dp
+
+    # Collect flight IDs that have items with derived_from links (for raw data upload)
+    include_raw_data_set = set(include_raw_data_links) if include_raw_data_links else set()
+    flights_needing_raw_data: set = set()
+
+    # Upload data product files and rewrite asset hrefs
+    for item in items:
+        dp = dp_lookup.get(item.id)
+        if not dp:
+            logger.warning(f"Data product not found for item {item.id}, skipping S3 upload")
+            continue
+
+        # Skip if already uploaded (idempotent for backfill)
+        if dp.s3_url:
+            s3_url = dp.s3_url
+        else:
+            # Upload the data product file
+            s3_key = build_s3_key(dp.filepath, upload_dir)
+            s3_url = upload_file_to_s3(dp.filepath, s3_key)
+            uploaded_s3_keys.append(s3_key)
+
+            # Update DB
+            crud.data_product.update_s3_url(db, data_product_id=dp.id, s3_url=s3_url)
+
+        # Rewrite the asset href
+        if item.id in item.assets:
+            item.assets[item.id].href = s3_url
+
+        # Rewrite external viewer link if present
+        for link in item.links:
+            if link.rel == "external" and hasattr(link, "href"):
+                # Replace the url= query parameter with the S3 URL
+                if settings.EXTERNAL_VIEWER_URL:
+                    link.target = f"{settings.EXTERNAL_VIEWER_URL}?url={s3_url}"
+
+        # Track if this item needs raw data uploaded
+        if item.id in include_raw_data_set:
+            flights_needing_raw_data.add(dp.flight_id)
+
+    # Upload raw data files for flights that have derived_from links
+    if flights_needing_raw_data:
+        for flight_id in flights_needing_raw_data:
+            # Query raw data for this flight
+            raw_data_list = crud.raw_data.get_multi_by_flight(
+                db=db, flight_id=flight_id, upload_dir=upload_dir,
+            )
+
+            for rd in raw_data_list:
+                local_url = getattr(rd, "url", None)
+                if not local_url:
+                    continue
+
+                # Skip if already uploaded (idempotent for backfill)
+                if rd.s3_url:
+                    s3_url = rd.s3_url
+                else:
+                    # Upload raw data file
+                    s3_key = build_s3_key(rd.filepath, upload_dir)
+                    s3_url = upload_file_to_s3(rd.filepath, s3_key)
+                    uploaded_s3_keys.append(s3_key)
+
+                    # Update DB
+                    crud.raw_data.update_s3_url(db, raw_data_id=rd.id, s3_url=s3_url)
+
+                # Rewrite derived_from links on items that reference this flight
+                for item in items:
+                    dp = dp_lookup.get(item.id)
+                    if dp and dp.flight_id == flight_id:
+                        for link in item.links:
+                            if link.rel == "derived_from" and link.href == local_url:
+                                link.target = s3_url
+
+    return uploaded_s3_keys
+
+
+def _rollback_s3_uploads(db: Session, project_id: UUID, uploaded_s3_keys: List[str]) -> None:
+    """Clean up S3 uploads and DB records on publish failure."""
+    try:
+        if uploaded_s3_keys:
+            delete_s3_objects(uploaded_s3_keys)
+        crud.data_product.clear_s3_urls_for_project(db, project_id=project_id)
+        crud.raw_data.clear_s3_urls_for_project(db, project_id=project_id)
+    except Exception:
+        logger.exception("Failed to rollback S3 uploads")
 
 
 @celery_app.task(name="generate_stac_preview_task", bind=True)
@@ -201,6 +318,13 @@ def publish_stac_catalog(
         items = sg.items
         failed_items = sg.failed_items
 
+        # Upload successful items to S3 and rewrite asset hrefs
+        uploaded_s3_keys: List[str] = []
+        if is_s3_configured() and len(items) > 0:
+            uploaded_s3_keys = _upload_to_s3_and_rewrite_hrefs(
+                db, items, sg.flights, include_raw_data_links,
+            )
+
         # Publish to catalog if we have successful items
         stac_report = None
         if len(items) > 0:
@@ -274,6 +398,13 @@ def publish_stac_catalog(
                 scm.remove_from_catalog()
         except Exception:
             logger.exception("Failed to rollback STAC publication")
+
+        # Rollback S3 uploads if any were made
+        if is_s3_configured():
+            _rollback_s3_uploads(
+                db, project_uuid,
+                uploaded_s3_keys if "uploaded_s3_keys" in locals() else [],
+            )
 
         # Cache error response
         error_response = {
@@ -442,6 +573,13 @@ def publish_stac_catalog_task(
         items = sg.items
         failed_items = sg.failed_items
 
+        # Upload successful items to S3 and rewrite asset hrefs
+        uploaded_s3_keys: List[str] = []
+        if is_s3_configured() and len(items) > 0:
+            uploaded_s3_keys = _upload_to_s3_and_rewrite_hrefs(
+                db, items, sg.flights, include_raw_data_links,
+            )
+
         # Publish to catalog if we have successful items
         stac_report = None
         if len(items) > 0:
@@ -515,6 +653,13 @@ def publish_stac_catalog_task(
                 scm.remove_from_catalog()
         except Exception:
             logger.exception("Failed to rollback STAC publication")
+
+        # Rollback S3 uploads if any were made
+        if is_s3_configured():
+            _rollback_s3_uploads(
+                db, project_uuid,
+                uploaded_s3_keys if "uploaded_s3_keys" in locals() else [],
+            )
 
         # Cache error response
         error_response = {

--- a/backend/app/tasks/stac_tasks.py
+++ b/backend/app/tasks/stac_tasks.py
@@ -170,10 +170,18 @@ def _upload_to_s3_and_rewrite_hrefs(
 
 
 def _rollback_s3_uploads(db: Session, project_id: UUID, uploaded_s3_keys: List[str]) -> None:
-    """Clean up S3 uploads and DB records on publish failure."""
+    """Clean up S3 uploads and DB records on publish failure.
+
+    Preserves s3_url columns when the S3 delete does not fully succeed so the
+    orphaned objects can be cleaned up on a future retry.
+    """
     try:
-        if uploaded_s3_keys:
-            delete_s3_objects(uploaded_s3_keys)
+        if uploaded_s3_keys and not delete_s3_objects(uploaded_s3_keys):
+            logger.error(
+                f"S3 rollback did not fully succeed for project {project_id}; "
+                f"preserving s3_url columns for retry"
+            )
+            return
         crud.data_product.clear_s3_urls_for_project(db, project_id=project_id)
         crud.raw_data.clear_s3_urls_for_project(db, project_id=project_id)
     except Exception:

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -27,6 +27,7 @@ from app.tests.utils.project import (
     random_harvest_date,
 )
 from app.tests.utils.project_member import create_project_member
+from app.tests.utils.raw_data import SampleRawData
 from app.tests.utils.team import create_team, random_team_name, random_team_description
 from app.tests.utils.team_member import create_team_member
 from app.tests.utils.user import create_user, update_regular_user_to_superuser
@@ -1840,7 +1841,7 @@ def test_unpublish_stac_cleans_up_s3_when_configured(
     with patch(
         "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=True
     ), patch(
-        "app.api.api_v1.endpoints.stac.delete_s3_objects"
+        "app.api.api_v1.endpoints.stac.delete_s3_objects", return_value=True
     ) as mock_delete:
         response = client.delete(f"{API_URL}/{project.id}/delete-stac")
 
@@ -1852,6 +1853,93 @@ def test_unpublish_stac_cleans_up_s3_when_configured(
     assert any(str(raw.obj.id) in key for key in deleted_keys)
     assert crud.data_product.get(db, id=dp.obj.id).s3_url is None
     assert crud.raw_data.get(db, id=raw.obj.id).s3_url is None
+
+
+@pytest_requires_stac
+def test_unpublish_stac_aborts_when_s3_delete_fails(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """If S3 delete fails, the unpublish must abort with 503: the catalog stays
+    intact, the project stays published, and s3_url columns are preserved so
+    the user can retry once S3 is reachable."""
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    raw = SampleRawData(db, project=project, flight=flight)
+
+    publish_stac_catalog_task(str(project.id), db=db)
+    _seed_s3_urls_after_publish(db, project, dp, raw)
+
+    seeded_dp_url = crud.data_product.get(db, id=dp.obj.id).s3_url
+    seeded_raw_url = crud.raw_data.get(db, id=raw.obj.id).s3_url
+
+    with patch(
+        "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=True
+    ), patch(
+        "app.api.api_v1.endpoints.stac.delete_s3_objects", return_value=False
+    ) as mock_delete, patch(
+        "app.api.api_v1.endpoints.stac.STACCollectionManager.remove_from_catalog"
+    ) as mock_remove:
+        response = client.delete(f"{API_URL}/{project.id}/delete-stac")
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert mock_delete.call_count == 1
+    # Catalog removal must NOT have run — we abort first so retry works
+    mock_remove.assert_not_called()
+    # s3_url columns must survive so the orphaned objects remain trackable
+    assert crud.data_product.get(db, id=dp.obj.id).s3_url == seeded_dp_url
+    assert crud.raw_data.get(db, id=raw.obj.id).s3_url == seeded_raw_url
+    # Project must still be marked published
+    refreshed_project = crud.project.get(db, id=project.id)
+    assert refreshed_project.is_published is True
+    # Generic message — no bucket/path/AWS detail
+    body = response.json()
+    assert "S3" in body["detail"] or "s3" in body["detail"]
+    assert "bucket" in body["detail"].lower()
+    # The detail must NOT include any keys, paths, or specific error codes
+    assert "NoSuchBucket" not in body["detail"]
+    for url in (seeded_dp_url, seeded_raw_url):
+        assert url not in body["detail"]
+
+
+@pytest_requires_stac
+def test_unpublish_stac_post_cleanup_state_unchanged_when_s3_fails(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """A failed unpublish must be retriable: the second attempt (with S3 working)
+    should clean up successfully and complete the unpublish."""
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    publish_stac_catalog_task(str(project.id), db=db)
+    _seed_s3_urls_after_publish(db, project, dp)
+
+    # First attempt: S3 broken — abort, leave state intact
+    with patch(
+        "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=True
+    ), patch(
+        "app.api.api_v1.endpoints.stac.delete_s3_objects", return_value=False
+    ):
+        first = client.delete(f"{API_URL}/{project.id}/delete-stac")
+    assert first.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert crud.project.get(db, id=project.id).is_published is True
+
+    # Second attempt: S3 fixed — full unpublish succeeds
+    with patch(
+        "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=True
+    ), patch(
+        "app.api.api_v1.endpoints.stac.delete_s3_objects", return_value=True
+    ):
+        second = client.delete(f"{API_URL}/{project.id}/delete-stac")
+    assert second.status_code == status.HTTP_200_OK
+    assert crud.project.get(db, id=project.id).is_published is False
+    assert crud.data_product.get(db, id=dp.obj.id).s3_url is None
 
 
 @pytest_requires_stac
@@ -1920,13 +2008,11 @@ def test_unpublish_stac_deletes_local_stac_cache(
 
 
 @pytest_requires_stac
-def test_unpublish_stac_succeeds_when_s3_cleanup_raises(
+def test_unpublish_stac_aborts_when_s3_cleanup_raises(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
-    """S3 cleanup is best-effort — a failure must not break unpublish."""
-    from unittest.mock import patch
-    from app.tasks.stac_tasks import publish_stac_catalog_task
-
+    """Any unexpected exception from S3 cleanup must abort the unpublish with a
+    503 — the project stays published so the user can retry."""
     current_user = get_current_approved_user(
         get_current_user(db, normal_user_access_token)
     )
@@ -1941,12 +2027,15 @@ def test_unpublish_stac_succeeds_when_s3_cleanup_raises(
     ), patch(
         "app.api.api_v1.endpoints.stac._cleanup_s3_for_project",
         side_effect=RuntimeError("s3 down"),
-    ):
+    ), patch(
+        "app.api.api_v1.endpoints.stac.STACCollectionManager.remove_from_catalog"
+    ) as mock_remove:
         response = client.delete(f"{API_URL}/{project.id}/delete-stac")
 
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    mock_remove.assert_not_called()
     refreshed_project = crud.project.get(db, id=project.id)
-    assert refreshed_project.is_published is False
+    assert refreshed_project.is_published is True
 
 
 @pytest_requires_stac

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -1796,3 +1796,201 @@ def test_stac_with_license_using_task(
 
     scm = STACCollectionManager(collection_id=str(project.id))
     scm.remove_from_catalog()
+
+
+def _seed_s3_urls_after_publish(db, project, dp, raw=None):
+    """Stamp s3_url on a project's data product (and optional raw data) so the
+    unpublish cleanup path has something to find."""
+    crud.data_product.update_s3_url(
+        db,
+        data_product_id=dp.obj.id,
+        s3_url=f"https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/dp/{dp.obj.id}.tif",
+    )
+    if raw is not None:
+        crud.raw_data.update_s3_url(
+            db,
+            raw_data_id=raw.obj.id,
+            s3_url=f"https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/raw/{raw.obj.id}.zip",
+        )
+
+
+@pytest_requires_stac
+def test_unpublish_stac_cleans_up_s3_when_configured(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """When S3 is configured, unpublishing should delete uploaded objects and clear s3_url columns."""
+    from unittest.mock import patch
+    from app.tasks.stac_tasks import publish_stac_catalog_task
+    from app.tests.utils.raw_data import SampleRawData
+
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    raw = SampleRawData(db, project=project, flight=flight)
+
+    publish_stac_catalog_task(str(project.id), db=db)
+    _seed_s3_urls_after_publish(db, project, dp, raw)
+
+    with patch(
+        "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=True
+    ), patch(
+        "app.api.api_v1.endpoints.stac.delete_s3_objects"
+    ) as mock_delete:
+        response = client.delete(f"{API_URL}/{project.id}/delete-stac")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert mock_delete.call_count == 1
+    deleted_keys = mock_delete.call_args[0][0]
+    assert len(deleted_keys) == 2
+    assert any(str(dp.obj.id) in key for key in deleted_keys)
+    assert any(str(raw.obj.id) in key for key in deleted_keys)
+    assert crud.data_product.get(db, id=dp.obj.id).s3_url is None
+    assert crud.raw_data.get(db, id=raw.obj.id).s3_url is None
+
+
+@pytest_requires_stac
+def test_unpublish_stac_skips_s3_cleanup_when_not_configured(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """When S3 is not configured, unpublish must not attempt S3 deletion."""
+    from unittest.mock import patch
+    from app.tasks.stac_tasks import publish_stac_catalog_task
+
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    SampleDataProduct(db, project=project, flight=flight)
+    publish_stac_catalog_task(str(project.id), db=db)
+
+    with patch(
+        "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=False
+    ), patch(
+        "app.api.api_v1.endpoints.stac.delete_s3_objects"
+    ) as mock_delete:
+        response = client.delete(f"{API_URL}/{project.id}/delete-stac")
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_delete.assert_not_called()
+
+
+@pytest_requires_stac
+def test_unpublish_stac_deletes_local_stac_cache(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """The local stac.json cache should be removed so re-publish doesn't see stale URLs."""
+    from unittest.mock import patch
+    from app.tasks.stac_tasks import get_stac_cache_path, publish_stac_catalog_task
+
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    SampleDataProduct(db, project=project, flight=flight)
+    publish_stac_catalog_task(str(project.id), db=db)
+
+    cache_path = get_stac_cache_path(project.id)
+    assert cache_path.exists()
+
+    with patch("app.api.api_v1.endpoints.stac.is_s3_configured", return_value=False):
+        response = client.delete(f"{API_URL}/{project.id}/delete-stac")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert not cache_path.exists()
+
+
+@pytest_requires_stac
+def test_unpublish_stac_succeeds_when_s3_cleanup_raises(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """S3 cleanup is best-effort — a failure must not break unpublish."""
+    from unittest.mock import patch
+    from app.tasks.stac_tasks import publish_stac_catalog_task
+
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    publish_stac_catalog_task(str(project.id), db=db)
+    _seed_s3_urls_after_publish(db, project, dp)
+
+    with patch(
+        "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=True
+    ), patch(
+        "app.api.api_v1.endpoints.stac._cleanup_s3_for_project",
+        side_effect=RuntimeError("s3 down"),
+    ):
+        response = client.delete(f"{API_URL}/{project.id}/delete-stac")
+
+    assert response.status_code == status.HTTP_200_OK
+    refreshed_project = crud.project.get(db, id=project.id)
+    assert refreshed_project.is_published is False
+
+
+@pytest_requires_stac
+def test_publish_does_not_call_s3_when_not_configured(
+    db: Session, normal_user_access_token: str
+) -> None:
+    """Publish must skip the S3 upload helper when S3 is not configured."""
+    from unittest.mock import patch
+    from app.tasks.stac_tasks import publish_stac_catalog_task
+
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    SampleDataProduct(db, project=project, flight=flight)
+
+    with patch(
+        "app.tasks.stac_tasks.is_s3_configured", return_value=False
+    ), patch(
+        "app.tasks.stac_tasks._upload_to_s3_and_rewrite_hrefs"
+    ) as mock_upload:
+        publish_stac_catalog_task(str(project.id), db=db)
+
+    mock_upload.assert_not_called()
+
+    # Clean up - remove from STAC catalog
+    from app.utils.stac.STACCollectionManager import STACCollectionManager
+
+    scm = STACCollectionManager(collection_id=str(project.id))
+    scm.remove_from_catalog()
+
+
+@pytest_requires_stac
+def test_publish_calls_s3_upload_helper_when_configured(
+    db: Session, normal_user_access_token: str
+) -> None:
+    """Publish must invoke the S3 upload helper when S3 is configured."""
+    from unittest.mock import patch
+    from app.tasks.stac_tasks import publish_stac_catalog_task
+
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    SampleDataProduct(db, project=project, flight=flight)
+
+    with patch(
+        "app.tasks.stac_tasks.is_s3_configured", return_value=True
+    ), patch(
+        "app.tasks.stac_tasks._upload_to_s3_and_rewrite_hrefs", return_value=[]
+    ) as mock_upload:
+        publish_stac_catalog_task(str(project.id), db=db)
+
+    mock_upload.assert_called_once()
+
+    # Clean up - remove from STAC catalog
+    from app.utils.stac.STACCollectionManager import STACCollectionManager
+
+    scm = STACCollectionManager(collection_id=str(project.id))
+    scm.remove_from_catalog()

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timezone
 from typing import Any, Dict
+from unittest.mock import patch
 
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
@@ -9,6 +10,7 @@ from sqlalchemy.orm import Session
 from app import crud
 from app.api.deps import get_current_user, get_current_approved_user
 from app.core.config import settings
+from app.tasks.stac_tasks import publish_stac_catalog_task
 from app.tests.conftest import pytest_requires_stac
 from app.schemas.data_product import DataProductCreate
 from app.schemas.project import ProjectUpdate
@@ -29,6 +31,7 @@ from app.tests.utils.team import create_team, random_team_name, random_team_desc
 from app.tests.utils.team_member import create_team_member
 from app.tests.utils.user import create_user, update_regular_user_to_superuser
 from app.tests.utils.utils import get_geojson_feature_collection
+from app.utils.stac.STACCollectionManager import STACCollectionManager
 
 API_URL = f"{settings.API_V1_STR}/projects"
 
@@ -1855,17 +1858,27 @@ def test_unpublish_stac_cleans_up_s3_when_configured(
 def test_unpublish_stac_skips_s3_cleanup_when_not_configured(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:
-    """When S3 is not configured, unpublish must not attempt S3 deletion."""
+    """When S3 is not configured, unpublish must not attempt S3 deletion
+    and must leave any persisted s3_url values untouched."""
     from unittest.mock import patch
     from app.tasks.stac_tasks import publish_stac_catalog_task
+    from app.tests.utils.raw_data import SampleRawData
 
     current_user = get_current_approved_user(
         get_current_user(db, normal_user_access_token)
     )
     project = create_project(db, owner_id=current_user.id)
     flight = create_flight(db, project_id=project.id)
-    SampleDataProduct(db, project=project, flight=flight)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    raw = SampleRawData(db, project=project, flight=flight)
+
     publish_stac_catalog_task(str(project.id), db=db)
+    _seed_s3_urls_after_publish(db, project, dp, raw)
+
+    seeded_dp_url = crud.data_product.get(db, id=dp.obj.id).s3_url
+    seeded_raw_url = crud.raw_data.get(db, id=raw.obj.id).s3_url
+    assert seeded_dp_url is not None
+    assert seeded_raw_url is not None
 
     with patch(
         "app.api.api_v1.endpoints.stac.is_s3_configured", return_value=False
@@ -1876,6 +1889,8 @@ def test_unpublish_stac_skips_s3_cleanup_when_not_configured(
 
     assert response.status_code == status.HTTP_200_OK
     mock_delete.assert_not_called()
+    assert crud.data_product.get(db, id=dp.obj.id).s3_url == seeded_dp_url
+    assert crud.raw_data.get(db, id=raw.obj.id).s3_url == seeded_raw_url
 
 
 @pytest_requires_stac
@@ -1991,6 +2006,51 @@ def test_publish_calls_s3_upload_helper_when_configured(
 
     # Clean up - remove from STAC catalog
     from app.utils.stac.STACCollectionManager import STACCollectionManager
+
+    scm = STACCollectionManager(collection_id=str(project.id))
+    scm.remove_from_catalog()
+
+
+@pytest_requires_stac
+def test_publish_writes_s3_hrefs_into_stac_cache(
+    client: TestClient, db: Session, normal_user_access_token: str, monkeypatch
+) -> None:
+    """End-to-end: when S3 is configured, the cached stac.json served via /stac-cache
+    contains S3 asset hrefs and the data product row has its s3_url persisted.
+    Mocks only at the upload boundary so the real rewrite helper runs."""
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    monkeypatch.setattr(settings, "AWS_S3_REGION", "us-east-1")
+
+    fake_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
+    with patch(
+        "app.tasks.stac_tasks.is_s3_configured", return_value=True
+    ), patch(
+        "app.tasks.stac_tasks.upload_file_to_s3", return_value=fake_url
+    ):
+        publish_stac_catalog_task(str(project.id), db=db)
+
+    response = client.get(f"{API_URL}/{project.id}/stac-cache")
+    assert response.status_code == status.HTTP_200_OK
+    cache_data = response.json()
+    asset_hrefs = [
+        asset["href"]
+        for item_dict in cache_data.get("items", [])
+        for asset in item_dict.get("assets", {}).values()
+        if isinstance(asset, dict) and "href" in asset
+    ]
+    assert fake_url in asset_hrefs, (
+        f"Expected S3 URL {fake_url} in cached asset hrefs, got: {asset_hrefs}"
+    )
+
+    refreshed_dp = crud.data_product.get(db, id=dp.obj.id)
+    assert refreshed_dp.s3_url == fake_url
 
     scm = STACCollectionManager(collection_id=str(project.id))
     scm.remove_from_catalog()

--- a/backend/app/tests/crud/test_crud_raw_data.py
+++ b/backend/app/tests/crud/test_crud_raw_data.py
@@ -131,3 +131,57 @@ def test_create_raw_data_creates_file_permission(db: Session) -> None:
     assert file_permission.raw_data_id == raw_data.id
     assert file_permission.file_id is None
     assert file_permission.is_public is False  # Should default to private
+
+
+def test_update_s3_url_sets_value(db: Session) -> None:
+    raw = SampleRawData(db)
+    assert raw.obj.s3_url is None
+
+    crud.raw_data.update_s3_url(
+        db,
+        raw_data_id=raw.obj.id,
+        s3_url="https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/raw.zip",
+    )
+
+    refreshed = crud.raw_data.get(db, id=raw.obj.id)
+    assert refreshed is not None
+    assert refreshed.s3_url == (
+        "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/raw.zip"
+    )
+
+
+def test_clear_s3_urls_for_project_only_clears_matching_project(db: Session) -> None:
+    raw_a = SampleRawData(db)
+    raw_b = SampleRawData(db)
+
+    crud.raw_data.update_s3_url(db, raw_data_id=raw_a.obj.id, s3_url="https://a")
+    crud.raw_data.update_s3_url(db, raw_data_id=raw_b.obj.id, s3_url="https://b")
+
+    rowcount = crud.raw_data.clear_s3_urls_for_project(
+        db, project_id=raw_a.project.id
+    )
+
+    assert rowcount == 1
+    assert crud.raw_data.get(db, id=raw_a.obj.id).s3_url is None
+    assert crud.raw_data.get(db, id=raw_b.obj.id).s3_url == "https://b"
+
+
+def test_get_raw_data_with_s3_urls_for_project(db: Session) -> None:
+    raw_uploaded = SampleRawData(db)
+    raw_not_uploaded = SampleRawData(
+        db, project=raw_uploaded.project, flight=raw_uploaded.flight
+    )
+
+    crud.raw_data.update_s3_url(
+        db,
+        raw_data_id=raw_uploaded.obj.id,
+        s3_url="https://my-bucket.s3.us-east-1.amazonaws.com/key",
+    )
+
+    results = crud.raw_data.get_raw_data_with_s3_urls_for_project(
+        db, project_id=raw_uploaded.project.id
+    )
+
+    result_ids = {rd.id for rd in results}
+    assert raw_uploaded.obj.id in result_ids
+    assert raw_not_uploaded.obj.id not in result_ids

--- a/backend/app/tests/crud/test_data_product.py
+++ b/backend/app/tests/crud/test_data_product.py
@@ -426,3 +426,85 @@ def test_lazy_migration_only_runs_once(db: Session) -> None:
     # Both requests should return the same bbox values
     # (In production, the second request uses the cached database value)
     assert first_bbox_value == second_bbox_value
+
+
+def test_update_s3_url_sets_value(db: Session) -> None:
+    dp = SampleDataProduct(db)
+    assert dp.obj.s3_url is None
+
+    crud.data_product.update_s3_url(
+        db,
+        data_product_id=dp.obj.id,
+        s3_url="https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif",
+    )
+
+    refreshed = crud.data_product.get(db, id=dp.obj.id)
+    assert refreshed is not None
+    assert refreshed.s3_url == (
+        "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
+    )
+
+
+def test_clear_s3_urls_for_project_only_clears_matching_project(db: Session) -> None:
+    project_a = SampleDataProduct(db)
+    project_b = SampleDataProduct(db)
+
+    crud.data_product.update_s3_url(
+        db, data_product_id=project_a.obj.id, s3_url="https://a"
+    )
+    crud.data_product.update_s3_url(
+        db, data_product_id=project_b.obj.id, s3_url="https://b"
+    )
+
+    rowcount = crud.data_product.clear_s3_urls_for_project(
+        db, project_id=project_a.project.id
+    )
+
+    assert rowcount == 1
+    assert crud.data_product.get(db, id=project_a.obj.id).s3_url is None
+    # Other project untouched
+    assert crud.data_product.get(db, id=project_b.obj.id).s3_url == "https://b"
+
+
+def test_clear_s3_urls_for_project_zero_when_nothing_to_clear(db: Session) -> None:
+    dp = SampleDataProduct(db)
+    rowcount = crud.data_product.clear_s3_urls_for_project(
+        db, project_id=dp.project.id
+    )
+    assert rowcount == 0
+
+
+def test_get_data_products_with_s3_urls_for_project(db: Session) -> None:
+    dp_uploaded = SampleDataProduct(db)
+    flight = create_flight(db, project_id=dp_uploaded.project.id)
+    dp_not_uploaded = SampleDataProduct(
+        db, project=dp_uploaded.project, flight=flight
+    )
+
+    crud.data_product.update_s3_url(
+        db,
+        data_product_id=dp_uploaded.obj.id,
+        s3_url="https://my-bucket.s3.us-east-1.amazonaws.com/key",
+    )
+
+    results = crud.data_product.get_data_products_with_s3_urls_for_project(
+        db, project_id=dp_uploaded.project.id
+    )
+
+    result_ids = {dp.id for dp in results}
+    assert dp_uploaded.obj.id in result_ids
+    assert dp_not_uploaded.obj.id not in result_ids
+
+
+def test_get_data_products_with_s3_urls_excludes_inactive(db: Session) -> None:
+    dp = SampleDataProduct(db)
+    crud.data_product.update_s3_url(
+        db, data_product_id=dp.obj.id, s3_url="https://x"
+    )
+    crud.data_product.deactivate(db, data_product_id=dp.obj.id)
+
+    results = crud.data_product.get_data_products_with_s3_urls_for_project(
+        db, project_id=dp.project.id
+    )
+
+    assert dp.obj.id not in {row.id for row in results}

--- a/backend/app/tests/tasks/test_stac_s3_upload.py
+++ b/backend/app/tests/tasks/test_stac_s3_upload.py
@@ -210,7 +210,9 @@ def test_rollback_deletes_uploaded_keys_and_clears_columns(db: Session):
     )
     crud.raw_data.update_s3_url(db, raw_data_id=raw.obj.id, s3_url="https://x/raw")
 
-    with patch("app.tasks.stac_tasks.delete_s3_objects") as mock_delete:
+    with patch(
+        "app.tasks.stac_tasks.delete_s3_objects", return_value=True
+    ) as mock_delete:
         _rollback_s3_uploads(db, project.id, ["k1", "k2"])
 
     mock_delete.assert_called_once_with(["k1", "k2"])

--- a/backend/app/tests/tasks/test_stac_s3_upload.py
+++ b/backend/app/tests/tasks/test_stac_s3_upload.py
@@ -2,7 +2,6 @@ import os
 from uuid import uuid4
 from unittest.mock import patch
 
-import pytest
 from sqlalchemy.orm import Session
 
 from app import crud
@@ -101,10 +100,11 @@ def test_upload_to_s3_rewrites_external_viewer_link(db: Session, monkeypatch):
 
     items, flights = _generate_items(db, project.id)
     item = items[0]
-    # STACGenerator should have added an external link if EXTERNAL_VIEWER_URL is set
     external_links = [link for link in item.links if link.rel == "external"]
-    if not external_links:
-        pytest.skip("STACGenerator did not add an external link for this item")
+    assert external_links, (
+        "STACGenerator must add an external link when EXTERNAL_VIEWER_URL is set; "
+        "without one, the rewrite branch under test is dead code."
+    )
 
     fake_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
     with patch("app.tasks.stac_tasks.upload_file_to_s3", return_value=fake_url):

--- a/backend/app/tests/tasks/test_stac_s3_upload.py
+++ b/backend/app/tests/tasks/test_stac_s3_upload.py
@@ -1,0 +1,248 @@
+import os
+from uuid import uuid4
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.core.config import settings
+from app.tasks.stac_tasks import (
+    _rollback_s3_uploads,
+    _upload_to_s3_and_rewrite_hrefs,
+)
+from app.tests.conftest import pytest_requires_stac
+from app.tests.utils.data_product import SampleDataProduct
+from app.tests.utils.flight import create_flight
+from app.tests.utils.project import create_project
+from app.tests.utils.raw_data import SampleRawData
+
+
+def _generate_items(db: Session, project_id, include_raw_data_links=None):
+    """Helper that runs STACGenerator and returns (items, flights)."""
+    from app.utils.stac.STACGenerator import STACGenerator
+
+    sg = STACGenerator(
+        db,
+        project_id=project_id,
+        include_raw_data_links=include_raw_data_links,
+    )
+    return sg.items, sg.flights
+
+
+@pytest_requires_stac
+def test_upload_to_s3_uploads_new_files_and_rewrites_asset_hrefs(
+    db: Session, monkeypatch
+):
+    """Happy path: untouched data products get uploaded, s3_url persisted, asset href rewritten."""
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    monkeypatch.setattr(settings, "AWS_S3_REGION", "us-east-1")
+
+    items, flights = _generate_items(db, project.id)
+    assert len(items) == 1
+
+    fake_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
+    with patch(
+        "app.tasks.stac_tasks.upload_file_to_s3", return_value=fake_url
+    ) as mock_upload:
+        uploaded_keys = _upload_to_s3_and_rewrite_hrefs(
+            db, items, flights, include_raw_data_links=None
+        )
+
+    # One upload happened, one key returned
+    assert mock_upload.call_count == 1
+    assert len(uploaded_keys) == 1
+
+    # Asset href rewritten on the item
+    item = items[0]
+    assert item.assets[item.id].href == fake_url
+
+    # s3_url persisted to DB
+    refreshed = crud.data_product.get(db, id=dp.obj.id)
+    assert refreshed is not None
+    assert refreshed.s3_url == fake_url
+
+
+@pytest_requires_stac
+def test_upload_to_s3_is_idempotent_when_already_uploaded(db: Session, monkeypatch):
+    """If dp.s3_url is already set, skip the upload but still rewrite the href."""
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+
+    existing_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/already.tif"
+    crud.data_product.update_s3_url(db, data_product_id=dp.obj.id, s3_url=existing_url)
+
+    items, flights = _generate_items(db, project.id)
+
+    with patch("app.tasks.stac_tasks.upload_file_to_s3") as mock_upload:
+        uploaded_keys = _upload_to_s3_and_rewrite_hrefs(
+            db, items, flights, include_raw_data_links=None
+        )
+
+    mock_upload.assert_not_called()
+    assert uploaded_keys == []
+    item = items[0]
+    assert item.assets[item.id].href == existing_url
+
+
+@pytest_requires_stac
+def test_upload_to_s3_rewrites_external_viewer_link(db: Session, monkeypatch):
+    """When EXTERNAL_VIEWER_URL is set, the 'external' link target is rewritten with the S3 URL."""
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    SampleDataProduct(db, project=project, flight=flight)
+
+    monkeypatch.setattr(settings, "EXTERNAL_VIEWER_URL", "https://viewer.example.com")
+
+    items, flights = _generate_items(db, project.id)
+    item = items[0]
+    # STACGenerator should have added an external link if EXTERNAL_VIEWER_URL is set
+    external_links = [link for link in item.links if link.rel == "external"]
+    if not external_links:
+        pytest.skip("STACGenerator did not add an external link for this item")
+
+    fake_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
+    with patch("app.tasks.stac_tasks.upload_file_to_s3", return_value=fake_url):
+        _upload_to_s3_and_rewrite_hrefs(
+            db, items, flights, include_raw_data_links=None
+        )
+
+    rewritten = [link for link in item.links if link.rel == "external"][0]
+    assert rewritten.target == f"https://viewer.example.com?url={fake_url}"
+
+
+@pytest_requires_stac
+def test_upload_to_s3_uploads_raw_data_when_derived_from_present(
+    db: Session, monkeypatch
+):
+    """When include_raw_data_links names an item, raw data for its flight gets uploaded
+    and derived_from links rewritten."""
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    raw = SampleRawData(db, project=project, flight=flight)
+
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+
+    items, flights = _generate_items(
+        db, project.id, include_raw_data_links=[str(dp.obj.id)]
+    )
+
+    fake_dp_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/dp.tif"
+    fake_raw_url = "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/raw.zip"
+
+    # Return the data product URL on the first call, raw data URL on the second
+    with patch(
+        "app.tasks.stac_tasks.upload_file_to_s3",
+        side_effect=[fake_dp_url, fake_raw_url],
+    ) as mock_upload:
+        uploaded_keys = _upload_to_s3_and_rewrite_hrefs(
+            db, items, flights, include_raw_data_links=[str(dp.obj.id)]
+        )
+
+    assert mock_upload.call_count == 2
+    assert len(uploaded_keys) == 2
+
+    # Raw data row got s3_url set
+    refreshed_raw = crud.raw_data.get(db, id=raw.obj.id)
+    assert refreshed_raw is not None
+    assert refreshed_raw.s3_url == fake_raw_url
+
+    # derived_from link on the item now points at the S3 URL
+    item = items[0]
+    derived_links = [link for link in item.links if link.rel == "derived_from"]
+    assert any(link.target == fake_raw_url for link in derived_links)
+
+
+@pytest_requires_stac
+def test_upload_to_s3_skips_items_with_no_matching_data_product(
+    db: Session, monkeypatch, caplog
+):
+    """Synthetic items whose id does not match any data product are skipped, not crashed."""
+    from pystac import Item
+    from datetime import datetime, timezone
+
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    SampleDataProduct(db, project=project, flight=flight)
+
+    items, flights = _generate_items(db, project.id)
+    # Inject a stray item with a bogus id
+    items.append(
+        Item(
+            id="not-a-real-data-product",
+            geometry={"type": "Point", "coordinates": [0, 0]},
+            bbox=[0, 0, 0, 0],
+            datetime=datetime.now(tz=timezone.utc),
+            properties={},
+        )
+    )
+
+    with patch(
+        "app.tasks.stac_tasks.upload_file_to_s3", return_value="https://x"
+    ) as mock_upload:
+        with caplog.at_level("WARNING"):
+            uploaded_keys = _upload_to_s3_and_rewrite_hrefs(
+                db, items, flights, include_raw_data_links=None
+            )
+
+    # Only the real data product gets uploaded; the stray item triggers a warning
+    assert mock_upload.call_count == 1
+    assert len(uploaded_keys) == 1
+    assert any("not-a-real-data-product" in rec.message for rec in caplog.records)
+
+
+@pytest_requires_stac
+def test_rollback_deletes_uploaded_keys_and_clears_columns(db: Session):
+    """Rollback removes uploaded S3 objects and nulls s3_url on data products and raw data."""
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    raw = SampleRawData(db, project=project, flight=flight)
+
+    crud.data_product.update_s3_url(
+        db, data_product_id=dp.obj.id, s3_url="https://x/dp"
+    )
+    crud.raw_data.update_s3_url(db, raw_data_id=raw.obj.id, s3_url="https://x/raw")
+
+    with patch("app.tasks.stac_tasks.delete_s3_objects") as mock_delete:
+        _rollback_s3_uploads(db, project.id, ["k1", "k2"])
+
+    mock_delete.assert_called_once_with(["k1", "k2"])
+
+    refreshed_dp = crud.data_product.get(db, id=dp.obj.id)
+    refreshed_raw = crud.raw_data.get(db, id=raw.obj.id)
+    assert refreshed_dp.s3_url is None
+    assert refreshed_raw.s3_url is None
+
+
+@pytest_requires_stac
+def test_rollback_with_empty_key_list_skips_s3_call_but_clears_db(db: Session):
+    """If no uploads happened, the rollback still clears any stale s3_url columns."""
+    project = create_project(db)
+    flight = create_flight(db, project_id=project.id)
+    dp = SampleDataProduct(db, project=project, flight=flight)
+    crud.data_product.update_s3_url(
+        db, data_product_id=dp.obj.id, s3_url="https://stale"
+    )
+
+    with patch("app.tasks.stac_tasks.delete_s3_objects") as mock_delete:
+        _rollback_s3_uploads(db, project.id, [])
+
+    mock_delete.assert_not_called()
+    assert crud.data_product.get(db, id=dp.obj.id).s3_url is None
+
+
+def test_rollback_swallows_exceptions(db: Session):
+    """Rollback must never raise — failures only log."""
+    with patch(
+        "app.tasks.stac_tasks.crud.data_product.clear_s3_urls_for_project",
+        side_effect=RuntimeError("boom"),
+    ), patch("app.tasks.stac_tasks.delete_s3_objects"):
+        # Should not raise even though clear_s3_urls_for_project blew up
+        _rollback_s3_uploads(db, uuid4(), ["k1"])

--- a/backend/app/tests/utils/test_s3.py
+++ b/backend/app/tests/utils/test_s3.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
 
 from app.core.config import settings
 from app.utils import s3 as s3_utils
@@ -97,25 +97,64 @@ def test_upload_file_to_s3_uploads_and_returns_url(monkeypatch):
         assert url == "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
 
 
+def test_upload_file_to_s3_raises_sanitized_error_on_client_error(monkeypatch):
+    """Boto ClientError (e.g. NoSuchBucket) must be re-raised as a generic
+    S3UploadError so the bucket name / key / AWS error code don't leak to the
+    user-facing job error response."""
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "secret-bucket")
+    fake_client = MagicMock()
+    fake_client.upload_file.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchBucket", "Message": "bucket does not exist"}},
+        "CreateMultipartUpload",
+    )
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    with pytest.raises(s3_utils.S3UploadError) as exc_info:
+        s3_utils.upload_file_to_s3("/static/some/file.tif", "d2s/host/file.tif")
+
+    msg = str(exc_info.value)
+    assert "secret-bucket" not in msg
+    assert "/static/some/file.tif" not in msg
+    assert "NoSuchBucket" not in msg
+
+
+def test_upload_file_to_s3_raises_sanitized_error_on_botocore_error(monkeypatch):
+    """Connection-level BotoCoreError must also be sanitized."""
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "secret-bucket")
+    fake_client = MagicMock()
+    fake_client.upload_file.side_effect = EndpointConnectionError(
+        endpoint_url="https://s3.example.com"
+    )
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    with pytest.raises(s3_utils.S3UploadError) as exc_info:
+        s3_utils.upload_file_to_s3("/static/some/file.tif", "d2s/host/file.tif")
+
+    msg = str(exc_info.value)
+    assert "secret-bucket" not in msg
+    assert "s3.example.com" not in msg
+
+
 def test_delete_s3_objects_noop_on_empty(monkeypatch):
     """Empty input must short-circuit BEFORE creating the S3 client to avoid
     unnecessary credential resolution / network access."""
     fake_get_client = MagicMock()
     monkeypatch.setattr(s3_utils, "get_s3_client", fake_get_client)
 
-    s3_utils.delete_s3_objects([])
+    assert s3_utils.delete_s3_objects([]) is True
 
     fake_get_client.assert_not_called()
 
 
-def test_delete_s3_objects_batches_over_1000(monkeypatch):
+def test_delete_s3_objects_returns_true_on_full_success(monkeypatch):
+    """When every batch comes back with no errors, the helper reports success."""
     monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
     fake_client = MagicMock()
     fake_client.delete_objects.return_value = {"Errors": []}
     monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
 
     keys = [f"k{i}" for i in range(2500)]
-    s3_utils.delete_s3_objects(keys)
+    assert s3_utils.delete_s3_objects(keys) is True
 
     # Expect 3 batches: 1000, 1000, 500
     assert fake_client.delete_objects.call_count == 3
@@ -126,18 +165,33 @@ def test_delete_s3_objects_batches_over_1000(monkeypatch):
     assert batch_sizes == [1000, 1000, 500]
 
 
-def test_delete_s3_objects_swallows_client_error(monkeypatch, caplog):
+def test_delete_s3_objects_returns_false_on_client_error(monkeypatch, caplog):
+    """ClientError (e.g. auth failure) must be logged and reported as failure
+    so callers can preserve the s3_url columns for retry."""
     fake_client = MagicMock()
     fake_client.delete_objects.side_effect = ClientError(
         {"Error": {"Code": "Boom", "Message": "nope"}}, "DeleteObjects"
     )
     monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
 
-    # Should not raise
-    s3_utils.delete_s3_objects(["k1", "k2"])
+    assert s3_utils.delete_s3_objects(["k1", "k2"]) is False
 
 
-def test_delete_s3_objects_logs_per_key_errors(monkeypatch, caplog):
+def test_delete_s3_objects_returns_false_on_botocore_error(monkeypatch, caplog):
+    """Connection-level BotoCoreError (no endpoint, network down, etc.) must
+    not propagate, but must be reported as failure to preserve s3_url columns."""
+    fake_client = MagicMock()
+    fake_client.delete_objects.side_effect = EndpointConnectionError(
+        endpoint_url="https://s3.example.com"
+    )
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    assert s3_utils.delete_s3_objects(["k1", "k2"]) is False
+
+
+def test_delete_s3_objects_returns_false_on_per_key_errors(monkeypatch, caplog):
+    """Per-key errors in the response must be logged and downgrade the overall
+    return value to False."""
     fake_client = MagicMock()
     fake_client.delete_objects.return_value = {
         "Errors": [{"Key": "k1", "Code": "AccessDenied", "Message": "no perms"}]
@@ -145,6 +199,6 @@ def test_delete_s3_objects_logs_per_key_errors(monkeypatch, caplog):
     monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
 
     with caplog.at_level("WARNING", logger="app.utils.s3"):
-        s3_utils.delete_s3_objects(["k1", "k2"])
+        assert s3_utils.delete_s3_objects(["k1", "k2"]) is False
 
     assert any("k1" in rec.message and "AccessDenied" in rec.message for rec in caplog.records)

--- a/backend/app/tests/utils/test_s3.py
+++ b/backend/app/tests/utils/test_s3.py
@@ -1,0 +1,148 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from app.core.config import settings
+from app.utils import s3 as s3_utils
+
+
+def test_is_s3_configured_returns_false_during_tests(monkeypatch):
+    """The conftest sets RUNNING_TESTS=1, so is_s3_configured must always be False."""
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "some-bucket")
+    assert os.environ.get("RUNNING_TESTS") == "1"
+    assert s3_utils.is_s3_configured() is False
+
+
+def test_is_s3_configured_true_when_bucket_set_and_not_testing(monkeypatch):
+    monkeypatch.delenv("RUNNING_TESTS", raising=False)
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "some-bucket")
+    assert s3_utils.is_s3_configured() is True
+
+
+def test_is_s3_configured_false_when_bucket_unset(monkeypatch):
+    monkeypatch.delenv("RUNNING_TESTS", raising=False)
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", None)
+    assert s3_utils.is_s3_configured() is False
+
+
+def test_build_s3_key_uses_hostname_prefix(monkeypatch):
+    monkeypatch.setattr(settings, "API_DOMAIN", "https://ps2.d2s.org")
+    upload_dir = "/static"
+    filepath = "/static/projects/abc/flights/def/data_products/ghi/file.tif"
+
+    key = s3_utils.build_s3_key(filepath, upload_dir)
+
+    assert key == "d2s/ps2.d2s.org/projects/abc/flights/def/data_products/ghi/file.tif"
+
+
+def test_build_s3_key_localhost_hostname(monkeypatch):
+    monkeypatch.setattr(settings, "API_DOMAIN", "http://localhost:8000")
+    key = s3_utils.build_s3_key("/static/foo/bar.tif", "/static")
+    assert key == "d2s/localhost/foo/bar.tif"
+
+
+def test_build_s3_key_falls_back_to_unknown_when_no_hostname(monkeypatch):
+    monkeypatch.setattr(settings, "API_DOMAIN", "")
+    key = s3_utils.build_s3_key("/static/x.tif", "/static")
+    assert key.startswith("d2s/unknown/")
+
+
+def test_build_s3_url_uses_region_and_bucket(monkeypatch):
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    monkeypatch.setattr(settings, "AWS_S3_REGION", "us-west-2")
+
+    url = s3_utils.build_s3_url("d2s/host/path/file.tif")
+
+    assert url == "https://my-bucket.s3.us-west-2.amazonaws.com/d2s/host/path/file.tif"
+
+
+def test_build_s3_url_defaults_region_to_us_east_1(monkeypatch):
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    monkeypatch.setattr(settings, "AWS_S3_REGION", None)
+    url = s3_utils.build_s3_url("k")
+    assert "s3.us-east-1.amazonaws.com" in url
+
+
+def test_parse_s3_key_round_trips_with_build_s3_url(monkeypatch):
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    monkeypatch.setattr(settings, "AWS_S3_REGION", "us-east-1")
+    key = "d2s/host.example.com/projects/p/file.tif"
+
+    url = s3_utils.build_s3_url(key)
+
+    assert s3_utils.parse_s3_key_from_url(url) == key
+
+
+def test_parse_s3_key_raises_on_malformed_url():
+    with pytest.raises(ValueError):
+        s3_utils.parse_s3_key_from_url("https://example.com/not-an-s3-url")
+
+
+def test_upload_file_to_s3_uploads_and_returns_url(monkeypatch):
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    monkeypatch.setattr(settings, "AWS_S3_REGION", "us-east-1")
+    fake_client = MagicMock()
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    with tempfile.NamedTemporaryFile(suffix=".tif") as tmp:
+        url = s3_utils.upload_file_to_s3(tmp.name, "d2s/host/file.tif")
+
+        fake_client.upload_file.assert_called_once_with(
+            tmp.name, "my-bucket", "d2s/host/file.tif"
+        )
+        assert url == "https://my-bucket.s3.us-east-1.amazonaws.com/d2s/host/file.tif"
+
+
+def test_delete_s3_objects_noop_on_empty(monkeypatch):
+    fake_client = MagicMock()
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    s3_utils.delete_s3_objects([])
+
+    fake_client.delete_objects.assert_not_called()
+
+
+def test_delete_s3_objects_batches_over_1000(monkeypatch):
+    monkeypatch.setattr(settings, "AWS_S3_BUCKET_NAME", "my-bucket")
+    fake_client = MagicMock()
+    fake_client.delete_objects.return_value = {"Errors": []}
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    keys = [f"k{i}" for i in range(2500)]
+    s3_utils.delete_s3_objects(keys)
+
+    # Expect 3 batches: 1000, 1000, 500
+    assert fake_client.delete_objects.call_count == 3
+    batch_sizes = [
+        len(call.kwargs["Delete"]["Objects"])
+        for call in fake_client.delete_objects.call_args_list
+    ]
+    assert batch_sizes == [1000, 1000, 500]
+
+
+def test_delete_s3_objects_swallows_client_error(monkeypatch, caplog):
+    fake_client = MagicMock()
+    fake_client.delete_objects.side_effect = ClientError(
+        {"Error": {"Code": "Boom", "Message": "nope"}}, "DeleteObjects"
+    )
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    # Should not raise
+    s3_utils.delete_s3_objects(["k1", "k2"])
+
+
+def test_delete_s3_objects_logs_per_key_errors(monkeypatch, caplog):
+    fake_client = MagicMock()
+    fake_client.delete_objects.return_value = {
+        "Errors": [{"Key": "k1", "Code": "AccessDenied", "Message": "no perms"}]
+    }
+    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+
+    with caplog.at_level("WARNING", logger="app.utils.s3"):
+        s3_utils.delete_s3_objects(["k1", "k2"])
+
+    assert any("k1" in rec.message and "AccessDenied" in rec.message for rec in caplog.records)

--- a/backend/app/tests/utils/test_s3.py
+++ b/backend/app/tests/utils/test_s3.py
@@ -98,12 +98,14 @@ def test_upload_file_to_s3_uploads_and_returns_url(monkeypatch):
 
 
 def test_delete_s3_objects_noop_on_empty(monkeypatch):
-    fake_client = MagicMock()
-    monkeypatch.setattr(s3_utils, "get_s3_client", lambda: fake_client)
+    """Empty input must short-circuit BEFORE creating the S3 client to avoid
+    unnecessary credential resolution / network access."""
+    fake_get_client = MagicMock()
+    monkeypatch.setattr(s3_utils, "get_s3_client", fake_get_client)
 
     s3_utils.delete_s3_objects([])
 
-    fake_client.delete_objects.assert_not_called()
+    fake_get_client.assert_not_called()
 
 
 def test_delete_s3_objects_batches_over_1000(monkeypatch):

--- a/backend/app/utils/backfill_s3_stac.py
+++ b/backend/app/utils/backfill_s3_stac.py
@@ -1,0 +1,237 @@
+"""Backfill S3 uploads for already-published STAC projects.
+
+Uploads data product and raw data files to S3, updates s3_url in the database,
+re-generates STAC items with S3 URLs, and re-publishes to the STAC API.
+
+Usage:
+    # Backfill all published projects
+    docker compose exec backend python app/utils/backfill_s3_stac.py
+
+    # Backfill a single project
+    docker compose exec backend python app/utils/backfill_s3_stac.py --project-id <uuid>
+
+    # Dry run (show what would be uploaded, no actual changes)
+    docker compose exec backend python app/utils/backfill_s3_stac.py --dry-run
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+# Add parent directory to path
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from app import crud
+from app.core.config import settings
+from app.db.session import SessionLocal
+from app.models.data_product import DataProduct
+from app.models.flight import Flight
+from app.models.project import Project
+from app.models.raw_data import RawData
+from app.tasks.stac_tasks import (
+    UUIDEncoder,
+    _upload_to_s3_and_rewrite_hrefs,
+    get_stac_cache_path,
+)
+from app.utils.s3 import is_s3_configured
+from app.utils.stac.CachedSTACMetadata import CachedSTACMetadata
+from app.utils.stac.STACCollectionManager import STACCollectionManager
+from app.utils.stac.STACGenerator import STACGenerator
+
+
+def get_cached_raw_data_link_ids(project_id: UUID) -> list:
+    """Read the STAC cache file to detect which items had raw data links."""
+    cache_path = get_stac_cache_path(project_id)
+    if not cache_path.exists():
+        return []
+
+    try:
+        with open(cache_path, "r") as f:
+            cached_data = json.load(f)
+        cache = CachedSTACMetadata(cached_data)
+        return cache.get_raw_data_link_ids()
+    except Exception:
+        return []
+
+
+def backfill_project(db, project: Project, dry_run: bool = False) -> bool:
+    """Backfill S3 uploads for a single published project.
+
+    Returns True on success, False on failure.
+    """
+    project_id = project.id
+    print(f"\nProcessing project {project_id} ({project.title})...")
+
+    # Check how many data products need uploading
+    query = (
+        select(DataProduct)
+        .where(
+            DataProduct.flight_id.in_(
+                select(Flight.id).where(Flight.project_id == project_id)
+            ),
+            DataProduct.is_active == True,
+            DataProduct.s3_url.is_(None),
+        )
+    )
+    pending_dps = db.execute(query).scalars().all()
+
+    query_done = (
+        select(DataProduct)
+        .where(
+            DataProduct.flight_id.in_(
+                select(Flight.id).where(Flight.project_id == project_id)
+            ),
+            DataProduct.is_active == True,
+            DataProduct.s3_url.isnot(None),
+        )
+    )
+    done_dps = db.execute(query_done).scalars().all()
+
+    print(f"  Data products: {len(pending_dps)} to upload, {len(done_dps)} already in S3")
+
+    # Detect raw data links from cache
+    include_raw_data_links = get_cached_raw_data_link_ids(project_id)
+    if include_raw_data_links:
+        print(f"  Raw data links detected for {len(include_raw_data_links)} items")
+
+    if dry_run:
+        for dp in pending_dps:
+            print(f"    [dry-run] Would upload: {dp.filepath}")
+        return True
+
+    # Load cached STAC metadata for re-generation
+    cached_stac_metadata = None
+    cache_path = get_stac_cache_path(project_id)
+    if cache_path.exists():
+        try:
+            with open(cache_path, "r") as f:
+                cached_stac_metadata = json.load(f)
+        except Exception:
+            print("  Warning: Could not read cached STAC metadata")
+
+    # Re-generate STAC items (with local URLs initially)
+    sg = STACGenerator(
+        db,
+        project_id=project_id,
+        cached_stac_metadata=cached_stac_metadata,
+        include_raw_data_links=include_raw_data_links,
+    )
+    collection = sg.collection
+    items = sg.items
+    failed_items = sg.failed_items
+
+    if not items:
+        print("  No valid STAC items generated, skipping")
+        return True
+
+    print(f"  Generated {len(items)} STAC items ({len(failed_items)} failed)")
+
+    # Upload to S3 and rewrite hrefs (skips files where s3_url is already set)
+    uploaded_keys = _upload_to_s3_and_rewrite_hrefs(
+        db, items, sg.flights, include_raw_data_links,
+    )
+    print(f"  Uploaded {len(uploaded_keys)} files to S3")
+
+    # Re-publish to STAC API (PUT updates existing items)
+    scm = STACCollectionManager(
+        collection_id=str(project_id), collection=collection, items=items
+    )
+    report = scm.publish_to_catalog()
+
+    published_count = sum(1 for item in report.items if item.is_published)
+    failed_count = sum(1 for item in report.items if not item.is_published)
+    print(f"  STAC API: {published_count} published, {failed_count} failed")
+
+    # Update the local STAC cache
+    try:
+        items_dicts = [item.to_dict() for item in items]
+        response_data = {
+            "collection_id": str(project_id),
+            "collection": collection.to_dict(),
+            "items": items_dicts,
+            "is_published": True,
+        }
+        if failed_items:
+            response_data["failed_items"] = [
+                item.model_dump() for item in failed_items
+            ]
+        with open(cache_path, "w") as f:
+            json.dump(response_data, f, indent=2, cls=UUIDEncoder)
+    except Exception as e:
+        print(f"  Warning: Could not update STAC cache: {e}")
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill S3 uploads for published STAC projects"
+    )
+    parser.add_argument(
+        "--project-id",
+        type=str,
+        default=None,
+        help="Backfill a single project by UUID",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be uploaded without making changes",
+    )
+    args = parser.parse_args()
+
+    if not is_s3_configured():
+        print("Error: S3 is not configured. Set AWS_S3_BUCKET_NAME in backend.env.")
+        sys.exit(1)
+
+    db = SessionLocal()
+
+    try:
+        # Query published projects
+        query = select(Project).where(
+            Project.is_published == True,
+            Project.is_active == True,
+        )
+        if args.project_id:
+            query = query.where(Project.id == UUID(args.project_id))
+
+        projects = db.execute(query).scalars().all()
+
+        if not projects:
+            print("No published projects found to backfill.")
+            return
+
+        print(f"Found {len(projects)} published project(s) to process")
+        if args.dry_run:
+            print("[DRY RUN MODE - no changes will be made]\n")
+
+        success_count = 0
+        error_count = 0
+
+        for project in projects:
+            try:
+                ok = backfill_project(db, project, dry_run=args.dry_run)
+                if ok:
+                    success_count += 1
+                else:
+                    error_count += 1
+            except Exception as e:
+                error_count += 1
+                print(f"  Error: {e}")
+                db.rollback()
+
+        print(f"\nBackfill complete:")
+        print(f"  Success: {success_count}")
+        print(f"  Errors: {error_count}")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/utils/s3.py
+++ b/backend/app/utils/s3.py
@@ -1,0 +1,122 @@
+import logging
+import os
+from pathlib import Path
+from typing import List
+from urllib.parse import urlparse
+
+import boto3
+from botocore.exceptions import ClientError
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def is_s3_configured() -> bool:
+    """Check if S3 storage is configured for STAC publishing.
+
+    Always returns False during tests to prevent accidental S3 uploads.
+    """
+    if os.environ.get("RUNNING_TESTS") == "1":
+        return False
+    return settings.AWS_S3_BUCKET_NAME is not None
+
+
+def get_s3_client():
+    """Create a boto3 S3 client.
+
+    Uses explicit credentials from settings if configured, otherwise
+    falls back to boto3's default credential chain (IAM roles, etc.).
+    """
+    kwargs = {}
+    if settings.AWS_S3_REGION:
+        kwargs["region_name"] = settings.AWS_S3_REGION
+    if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
+        kwargs["aws_access_key_id"] = settings.AWS_ACCESS_KEY_ID
+        kwargs["aws_secret_access_key"] = settings.AWS_SECRET_ACCESS_KEY
+    return boto3.client("s3", **kwargs)
+
+
+def _get_s3_key_prefix() -> str:
+    """Build the S3 key prefix from the API domain.
+
+    Produces: d2s/{hostname}/
+    E.g., https://ps2.d2s.org -> d2s/ps2.d2s.org
+          http://localhost:8000 -> d2s/localhost
+    """
+    hostname = urlparse(settings.API_DOMAIN).hostname or "unknown"
+    return f"d2s/{hostname}"
+
+
+def build_s3_key(filepath: str, upload_dir: str) -> str:
+    """Convert a local filepath to an S3 key by extracting the relative path.
+
+    Prefixes with d2s/{hostname}/ to namespace within the bucket.
+    E.g., d2s/ps2.d2s.org/projects/{project_id}/flights/.../file.tif
+    """
+    relative_path = str(Path(filepath).relative_to(upload_dir))
+    return f"{_get_s3_key_prefix()}/{relative_path}"
+
+
+def build_s3_url(s3_key: str) -> str:
+    """Build the public S3 URL for an object."""
+    region = settings.AWS_S3_REGION or "us-east-1"
+    bucket = settings.AWS_S3_BUCKET_NAME
+    return f"https://{bucket}.s3.{region}.amazonaws.com/{s3_key}"
+
+
+def upload_file_to_s3(filepath: str, s3_key: str) -> str:
+    """Upload a file to S3 and return the S3 URL.
+
+    Uses boto3's upload_file which handles multipart uploads automatically
+    for files larger than 8MB.
+
+    Raises on failure so the caller can handle rollback.
+    """
+    client = get_s3_client()
+    client.upload_file(filepath, settings.AWS_S3_BUCKET_NAME, s3_key)
+    return build_s3_url(s3_key)
+
+
+def delete_s3_objects(s3_keys: List[str]) -> None:
+    """Delete multiple objects from the S3 bucket.
+
+    Best-effort: logs warnings on failures but does not raise.
+    Handles batching (S3 delete_objects supports up to 1000 keys per call).
+    """
+    if not s3_keys:
+        return
+
+    client = get_s3_client()
+    bucket = settings.AWS_S3_BUCKET_NAME
+
+    # Process in batches of 1000 (S3 API limit)
+    for i in range(0, len(s3_keys), 1000):
+        batch = s3_keys[i : i + 1000]
+        try:
+            response = client.delete_objects(
+                Bucket=bucket,
+                Delete={"Objects": [{"Key": key} for key in batch]},
+            )
+            errors = response.get("Errors", [])
+            if errors:
+                for error in errors:
+                    logger.warning(
+                        f"Failed to delete S3 object {error['Key']}: "
+                        f"{error['Code']} - {error['Message']}"
+                    )
+        except ClientError:
+            logger.exception(f"Failed to delete S3 objects batch starting at index {i}")
+
+
+def parse_s3_key_from_url(s3_url: str) -> str:
+    """Extract the S3 key from an S3 URL.
+
+    Expects URL format: https://{bucket}.s3.{region}.amazonaws.com/{key}
+    """
+    # Remove the scheme and host portion to get the key
+    # Format: https://{bucket}.s3.{region}.amazonaws.com/{key}
+    parts = s3_url.split(".amazonaws.com/", 1)
+    if len(parts) == 2:
+        return parts[1]
+    raise ValueError(f"Cannot parse S3 key from URL: {s3_url}")

--- a/backend/app/utils/s3.py
+++ b/backend/app/utils/s3.py
@@ -5,7 +5,7 @@ from typing import List
 from urllib.parse import urlparse
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from app.core.config import settings
 
@@ -65,31 +65,50 @@ def build_s3_url(s3_key: str) -> str:
     return f"https://{bucket}.s3.{region}.amazonaws.com/{s3_key}"
 
 
+class S3UploadError(Exception):
+    """Raised when an S3 upload fails. The message is safe to surface to users
+    (no bucket names, file paths, or AWS error codes); the original exception
+    is still logged server-side via logger.exception."""
+
+
 def upload_file_to_s3(filepath: str, s3_key: str) -> str:
     """Upload a file to S3 and return the S3 URL.
 
     Uses boto3's upload_file which handles multipart uploads automatically
     for files larger than 8MB.
 
-    Raises on failure so the caller can handle rollback.
+    Raises S3UploadError with a generic message on boto3 failure so the
+    caller can handle rollback without leaking AWS details to users.
     """
     client = get_s3_client()
-    client.upload_file(filepath, settings.AWS_S3_BUCKET_NAME, s3_key)
+    try:
+        client.upload_file(filepath, settings.AWS_S3_BUCKET_NAME, s3_key)
+    except (ClientError, BotoCoreError):
+        logger.exception(
+            f"Failed to upload {filepath} to s3://{settings.AWS_S3_BUCKET_NAME}/{s3_key}"
+        )
+        raise S3UploadError(
+            "Could not upload data to the configured S3 bucket. "
+            "Please contact an administrator."
+        )
     return build_s3_url(s3_key)
 
 
-def delete_s3_objects(s3_keys: List[str]) -> None:
+def delete_s3_objects(s3_keys: List[str]) -> bool:
     """Delete multiple objects from the S3 bucket.
 
-    Best-effort: logs warnings on failures but does not raise.
+    Returns True if every key in every batch was deleted successfully, False
+    otherwise. Failures are logged; the function does not raise so callers can
+    decide whether to preserve database state for retry.
     Handles batching (S3 delete_objects supports up to 1000 keys per call).
     """
     if not s3_keys:
-        return
+        return True
 
     client = get_s3_client()
     bucket = settings.AWS_S3_BUCKET_NAME
 
+    all_succeeded = True
     # Process in batches of 1000 (S3 API limit)
     for i in range(0, len(s3_keys), 1000):
         batch = s3_keys[i : i + 1000]
@@ -100,13 +119,17 @@ def delete_s3_objects(s3_keys: List[str]) -> None:
             )
             errors = response.get("Errors", [])
             if errors:
+                all_succeeded = False
                 for error in errors:
                     logger.warning(
                         f"Failed to delete S3 object {error['Key']}: "
                         f"{error['Code']} - {error['Message']}"
                     )
-        except ClientError:
+        except (ClientError, BotoCoreError):
+            all_succeeded = False
             logger.exception(f"Failed to delete S3 objects batch starting at index {i}")
+
+    return all_succeeded
 
 
 def parse_s3_key_from_url(s3_url: str) -> str:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -27,6 +27,10 @@ You must provide a value for `SECRET_KEY` in your `backend.env` file. Use a cryp
 |----------|-------------|
 | `API_PROJECT_NAME` | Name that will appear in the FastAPI docs. |
 | `API_DOMAIN` | Domain used for accessing the application (e.g., `http://localhost` or `https://customdomain`). |
+| `AWS_S3_BUCKET_NAME` | S3 bucket name for STAC asset storage (optional). When set, data products and raw data are uploaded to S3 during STAC publishing and the S3 URLs are used as asset hrefs in published items. Leave empty to use local server URLs. |
+| `AWS_S3_REGION` | AWS region for the S3 bucket (e.g., `us-east-1`). Defaults to `us-east-1` when unset. |
+| `AWS_ACCESS_KEY_ID` | AWS access key ID for the S3 bucket (optional). Leave empty to fall back to the boto3 default credential chain (e.g., IAM role). |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key for the S3 bucket (optional). Pair with `AWS_ACCESS_KEY_ID`. |
 | `CELERY_BROKER_URL` | Address for local redis service. |
 | `CELERY_RESULT_BACKEND` | Address for local redis service. |
 | `BREEDBASE_ALLOWED_HOSTS` | Comma-separated list of allowed BreedBase hostnames for the BrAPI proxy (optional). When empty, any public host with a `/brapi/` path is allowed. Set to restrict which servers the proxy can reach. |

--- a/frontend/src/components/pages/workspace/projects/stac/ScientificCitationForm.tsx
+++ b/frontend/src/components/pages/workspace/projects/stac/ScientificCitationForm.tsx
@@ -53,13 +53,13 @@ export default function ScientificCitationForm({
           >
             License <span className="text-red-500">*</span>
           </label>
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center flex-wrap gap-2">
             <select
               id="license"
               value={license}
               onChange={(e) => setLicense(e.target.value)}
               required
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-xs focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="flex-1 min-w-0 pl-3 pr-8 py-2 border border-gray-300 rounded-md shadow-xs focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             >
               <option value="">Select a license...</option>
               {availableLicenses.map((licenseOption) => (


### PR DESCRIPTION
## Summary

Adds optional S3 storage for assets attached to published STAC items. When `AWS_S3_BUCKET_NAME` is configured, data products and raw data are uploaded to S3 during STAC publishing and the public S3 URLs are used as asset hrefs in the published catalog. When unset, behavior is unchanged (local server URLs continue to be used).

The change also hardens the publish/unpublish flow against partial S3 failures so transient AWS errors no longer leave the database in a state that's out of sync with S3, and adds a one-time backfill script for projects that were already published before this feature shipped.

## Changes

**Backend**

- New `app/utils/s3.py` helper: `is_s3_configured`, `upload_file_to_s3`, `delete_s3_objects`, `build_s3_key`/`build_s3_url`/`parse_s3_key_from_url`. boto3 errors are wrapped in a generic `S3UploadError` so AWS internals (bucket names, file paths, error codes) never leak to the client.
- `data_products` and `raw_data` gain an `s3_url` column (alembic migration `786003d898d7`); CRUD modules expose `update_s3_url` and `clear_s3_urls_for_project`.
- `app/tasks/stac_tasks.py`: publish path now uploads files to S3 (idempotent — skips when `s3_url` is already set), rewrites STAC item asset hrefs / external viewer links / `derived_from` raw-data links to the S3 URLs, and rolls back uploaded objects on failure while preserving `s3_url` columns when the rollback delete itself fails (so a retry can reuse them).
- `app/api/api_v1/endpoints/stac.py`: unpublish reordered to clean up S3 **before** removing the catalog. If S3 cleanup fails it raises `S3CleanupError` and returns a generic 503, preserving `is_published=true` and the `s3_url` columns so the operation is retriable. The user-facing message contains no AWS details; full context is logged server-side.
- New `app/utils/backfill_s3_stac.py` admin script to upload assets and re-publish STAC items for already-published projects (`--project-id`, `--dry-run`).
- New `AWS_S3_BUCKET_NAME`, `AWS_S3_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` settings in `app/core/config.py`. Credentials fall back to the boto3 default credential chain (e.g., IAM role) when not set.

**Frontend**

- `ScientificCitationForm.tsx`: wrap the license row and prevent the select from overflowing on narrow widths.

**Database**

- Migration `786003d898d7_add_s3_url_to_data_products_and_raw_data.py` adds nullable `s3_url` columns to `data_products` and `raw_data`.

**Config**

- `backend.example.env` documents the new `AWS_S3_*` block.
- `docs/reference/configuration.md` documents the four `AWS_S3_*` env vars in the `backend.env` table.

**Tests**

- `app/tests/utils/test_s3.py` (new) — S3 helpers, error sanitization, batched delete behavior, per-key error handling.
- `app/tests/tasks/test_stac_s3_upload.py` (new) — happy path, idempotent re-publish, external-viewer link rewrite, raw-data `derived_from` rewrite, stray-item warning, rollback paths (including swallowed exceptions).
- `app/tests/api/api_v1/test_projects.py` — adds publish/unpublish integration tests covering: clean publish-with-S3, S3 cleanup runs on unpublish when configured, unpublish aborts with 503 (and preserves DB state) when S3 delete fails or raises, and post-cleanup retry succeeds once S3 is healthy again.
- `app/tests/crud/test_crud_raw_data.py` and `test_data_product.py` — coverage for `update_s3_url` / `clear_s3_urls_for_project`.

## Testing

- Commands run: `docker compose exec backend pytest` — full backend suite passing locally.
- Manual QA on staging:
  - Publish a project with S3 misconfigured → generic error is shown, no AWS details leaked, `s3_url` columns are not flipped.
  - Publish a project with S3 configured correctly → assets land in `s3://{bucket}/d2s/{hostname}/...`, STAC item asset hrefs and external viewer link point at the S3 URLs.
  - Unpublish with a misconfigured bucket → request fails with 503, project remains published, `s3_url` columns preserved for retry.
  - Unpublish after fixing S3 → completes cleanly, S3 objects removed, `s3_url` columns cleared.
  - `python app/utils/backfill_s3_stac.py` (and `--dry-run`, `--project-id <uuid>`) verified end-to-end against an already-published project.

## Breaking Changes

- Migration required: `docker compose exec backend alembic upgrade head` (adds `s3_url` columns to `data_products` and `raw_data`).
- New optional environment variables in `backend.env`: `AWS_S3_BUCKET_NAME`, `AWS_S3_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. Defaults preserve existing local-URL behavior.
- After deploy, run `docker compose exec backend python app/utils/backfill_s3_stac.py` once to upload assets and re-publish STAC items for projects that were already published prior to this change.

## Follow-ups (deferred)

- Return a structured cleanup result and upgrade log levels for `_rollback_s3_uploads` / `_cleanup_s3_for_project`.
- Surface S3 cleanup failure detail in the unpublish API/UI response (currently a generic 503).