### PR TITLE
[Enhancement] Zoom map to data product extent when activating a raster layer

### DIFF
--- a/frontend/src/components/maps/DataProductZoom.tsx
+++ b/frontend/src/components/maps/DataProductZoom.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+
+import { useMapContext } from './MapContext';
+import { NON_MAP_DATA_TYPES } from './LayerPane/utils';
+
+export default function DataProductZoom() {
+  const { current: map } = useMap();
+  const { activeDataProduct } = useMapContext();
+
+  useEffect(() => {
+    if (!map || !activeDataProduct?.bbox) return;
+    if ((NON_MAP_DATA_TYPES as readonly string[]).includes(activeDataProduct.data_type)) return;
+
+    map.fitBounds(activeDataProduct.bbox, {
+      padding: 20,
+      duration: 1000,
+    });
+  }, [map, activeDataProduct]);
+
+  return null;
+}

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -15,6 +15,7 @@ import AnnotationLayers from './AnnotationLayers';
 import AnnotationPopup from './AnnotationPopup';
 import AnnotationToolsToggle from './AnnotationToolsToggle';
 import ColorBarControl from './ColorBarControl';
+import DataProductZoom from './DataProductZoom';
 import GeocoderControl from './GeocoderControl';
 import ProjectCluster from './ProjectCluster';
 import FeaturePopup from './FeaturePopup';
@@ -278,6 +279,9 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       {activeProject && (
         <ProjectBoundary setActiveProjectBBox={setActiveProjectBBox} />
       )}
+
+      {/* Zoom to data product extent when a raster data product is activated */}
+      {activeProject && <DataProductZoom />}
 
       {/* Annotation tool toggle (renders drawing tools when annotation mode active) */}
       {activeProject && <AnnotationToolsToggle />}

--- a/frontend/src/components/maps/LayerPane/DataProductCard.tsx
+++ b/frontend/src/components/maps/LayerPane/DataProductCard.tsx
@@ -6,6 +6,7 @@ import RasterSymbologySettings from '../RasterSymbologySettings';
 import { DataProduct } from '../../pages/workspace/projects/Project';
 import { getDataProductName } from '../../pages/workspace/projects/flights/DataProducts/DataProductsTable';
 import { useRasterSymbologyContext } from '../RasterSymbologyContext';
+import { NON_MAP_DATA_TYPES } from './utils';
 
 export default function DataProductCard({
   dataProduct,
@@ -16,8 +17,7 @@ export default function DataProductCard({
 
   const { dispatch } = useRasterSymbologyContext();
 
-  // Check if this is a raster data type (not point cloud, panoramic, or 3dgs)
-  const isRasterType = !['point_cloud', 'panoramic', '3dgs'].includes(
+  const isRasterType = !(NON_MAP_DATA_TYPES as readonly string[]).includes(
     dataProduct.data_type
   );
 

--- a/frontend/src/components/maps/LayerPane/utils.ts
+++ b/frontend/src/components/maps/LayerPane/utils.ts
@@ -88,10 +88,13 @@ function formatArea(feature: Feature): string {
   return `${acres.toFixed(1)} ac`;
 }
 
+const NON_MAP_DATA_TYPES = ['point_cloud', 'panoramic', '3dgs'] as const;
+
 export {
   formatArea,
   formatDate,
   formatLength,
   getGeomTypeIcon,
+  NON_MAP_DATA_TYPES,
   sortedFlightsByDateAndId,
 };


### PR DESCRIPTION
## Summary
When a raster data product is activated in the LayerPane, the map now animates to fit
the data product's bounding box — giving users an immediate view of where the layer
sits on the map. The behavior mirrors the existing project-boundary zoom and reuses
the `bbox` already returned by the API for all raster data products.

## Changes
- Frontend: Added `DataProductZoom.tsx`, a null-rendering component mounted inside
  `<Map>` that watches `activeDataProduct` and calls `map.fitBounds(bbox, { padding: 20, duration: 1000 })`
  on activation transitions
- Frontend: Mounted `<DataProductZoom>` in `HomeMap.tsx` alongside `<ProjectBoundary>`
- Frontend: Extracted `NON_MAP_DATA_TYPES` constant into `LayerPane/utils.ts` and
  replaced the inline array literal in `DataProductCard.tsx` with the shared constant

## Testing
- Navigate to a project with multiple raster data products whose extents are smaller
  than the project boundary; activate the project, then click each `DataProductCard`
  — map should animate to each product's extent in turn
- Re-clicking the already-active card should not move the camera
- Activating a `point_cloud`, `panoramic`, or `3dgs` data product should not trigger
  a camera move (those types render in dedicated viewers outside MapLibre)
- Navigating directly via the workspace "View" button: project extent zooms first,
  then camera tightens to the data product bbox