### PR TITLE
[Bug] Show empty-state message when filters hide all projects

### DIFF
--- a/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
@@ -74,6 +74,27 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
     return filteredProjects;
   }, [projects, projectFilterSelection, selectedTeamIds]);
 
+  const hasAnyProjects = !!projects && projects.length > 0;
+
+  const emptyFilterMessage = useMemo(() => {
+    if (filteredProjects.length === 0) {
+      if (projectFilterSelection.includes('likedProjects')) {
+        return 'You have not favorited any projects yet.';
+      }
+      if (projectFilterSelection.includes('myProjects')) {
+        return "You have no projects of your own — try unchecking 'My projects' to also see shared projects.";
+      }
+      if (projectFilterSelection.includes('myTeams')) {
+        return 'No projects match the selected team(s).';
+      }
+      return 'No projects match the current filters.';
+    }
+    if (searchText) {
+      return 'No projects match your search.';
+    }
+    return 'No projects are visible in the current map view.';
+  }, [filteredProjects, projectFilterSelection, searchText]);
+
   const teamCategories = useMemo(() => {
     if (!projects) return [] as { label: string; value: string }[];
     const unique = new Map<string, string>();
@@ -159,7 +180,7 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
     <div className="h-[calc(100%-44px)] p-4 flex flex-col">
       <div className="h-36">
         <h1>Projects</h1>
-        {filteredProjects && filteredProjects.length > 0 && (
+        {hasAnyProjects && (
           <div className="flex flex-col gap-2 my-2">
             <ProjectSearch
               searchText={searchText}
@@ -204,7 +225,7 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
         )}
       </div>
       <div className="flex-1 min-h-0">
-        {filteredProjects && filteredProjects.length > 0 ? (
+        {currentPageProjects.length > 0 ? (
           <ul className="h-full space-y-2 overflow-y-auto">
             {currentPageProjects.map((project) => (
               <li key={project.id}>
@@ -268,6 +289,8 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
               </li>
             ))}
           </ul>
+        ) : hasAnyProjects ? (
+          <p className="text-sm text-gray-600">{emptyFilterMessage}</p>
         ) : (
           <div>
             <p className="mb-4">

--- a/frontend/src/components/pages/workspace/projects/ProjectList.tsx
+++ b/frontend/src/components/pages/workspace/projects/ProjectList.tsx
@@ -138,6 +138,24 @@ export default function ProjectList({
     return filteredProjects;
   }, [projects, projectFilterSelection, selectedTeamIds]);
 
+  const hasAnyProjects = !!projects && projects.length > 0;
+
+  const emptyFilterMessage = useMemo(() => {
+    if (filteredProjects.length === 0) {
+      if (projectFilterSelection.includes('likedProjects')) {
+        return 'You have not favorited any projects yet.';
+      }
+      if (projectFilterSelection.includes('myProjects')) {
+        return "You have no projects of your own — try unchecking 'My projects' to also see shared projects.";
+      }
+      if (projectFilterSelection.includes('myTeams')) {
+        return 'No projects match the selected team(s).';
+      }
+      return 'No projects match the current filters.';
+    }
+    return 'No projects match your search.';
+  }, [filteredProjects, projectFilterSelection]);
+
   useEffect(() => {
     if (!projects) return;
     const filteredCount = filterSearch(filteredProjects).length;
@@ -178,15 +196,14 @@ export default function ProjectList({
         {/* Project header and search */}
         <div className="flex flex-col gap-4">
           <ProjectListHeader />
-          {!filteredProjects ||
-            (filteredProjects.length === 0 && (
-              <p>
-                Use the above button to create your first project. Your projects
-                will appear in the space below.
-              </p>
-            ))}
+          {!hasAnyProjects && (
+            <p>
+              Use the above button to create your first project. Your projects
+              will appear in the space below.
+            </p>
+          )}
         </div>
-        {filteredProjects && filteredProjects.length > 0 && (
+        {hasAnyProjects && (
           <div>
             <div className="w-96 mb-4">
               <ProjectSearch
@@ -246,19 +263,23 @@ export default function ProjectList({
             </div>
           </div>
         )}
-        {filteredProjects && filteredProjects.length > 0 && (
+        {hasAnyProjects && (
           <div className="flex-1 min-h-0 flex flex-wrap gap-4 pb-24 overflow-y-auto">
-            {filteredAndSortedProjects.map((project) => (
-              <ProjectCard
-                key={project.id}
-                project={project}
-                revalidate={revalidate}
-              />
-            ))}
+            {filteredAndSortedProjects.length > 0 ? (
+              filteredAndSortedProjects.map((project) => (
+                <ProjectCard
+                  key={project.id}
+                  project={project}
+                  revalidate={revalidate}
+                />
+              ))
+            ) : (
+              <p className="text-gray-600">{emptyFilterMessage}</p>
+            )}
           </div>
         )}
         {/* Pagination */}
-        {filteredProjects && filteredProjects.length > 0 && (
+        {hasAnyProjects && filteredAndSortedProjects.length > 0 && (
           <div className="w-full bg-slate-200 fixed bottom-0 left-0 right-0 py-4 px-6 z-10">
             <div className="flex justify-center">
               <Pagination


### PR DESCRIPTION
## Summary
When the "Favorites" filter (or any other filter/search combination) returned zero results, the search and filter controls disappeared along with the project list, leaving the user with no obvious way to clear the filter. This change keeps the controls visible whenever the user has any projects at all, and renders a contextual message explaining why nothing is shown.

## Changes
- Frontend: In `ProjectList.tsx` (workspace projects page) and `ProjectsPane.tsx` (map layer pane), gate the search/filter UI on `hasAnyProjects` rather than on the filtered-and-searched result count.
- Frontend: Add a contextual empty-state message that varies by which filter is active (favorites, my projects, teams, search, map view) so the user understands why the list is empty and how to recover.
- Frontend: Only render the workspace pagination bar when there is at least one project to show on the current page.

## Testing
- `docker compose exec frontend npx tsc --noEmit` — no errors.
- Manual QA on the workspace projects page (`/projects`):
  - With at least one project, enable the "Favorites" filter while no projects are favorited → search/filter controls remain visible and "You have not favorited any projects yet." is displayed.
  - Type a search string that matches nothing → "No projects match your search." is displayed.
  - Toggle "My projects" with no owned projects → message suggests unchecking the filter.
- Manual QA on the map layer pane (`Projects` tab):
  - Same filter combinations produce equivalent contextual messages, including the map-view variant when no filter or search is active but no project overlaps the viewport.
- Verified the original "Use the above button to create your first project…" copy still appears for brand-new users with zero projects.