### PR TITLE
[Bug] Fix type errors from dependency type definition changes

### DIFF
--- a/frontend/src/components/maps/MeasureTerraDrawControl.tsx
+++ b/frontend/src/components/maps/MeasureTerraDrawControl.tsx
@@ -42,7 +42,8 @@ export default function MeasureTerraDrawControl({
       forceAreaUnit: unitType === 'metric' ? 'square meters' : 'acres',
       forceDistanceUnit: unitType === 'metric' ? 'meter' : 'foot',
       computeElevation: false,
-    });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
 
     // Set font glyphs to use fonts available in OpenMapTiles
     draw.fontGlyphs = ['Open Sans Regular'];

--- a/frontend/src/components/pages/workspace/projects/fieldCampaigns/FieldCampaignTable.tsx
+++ b/frontend/src/components/pages/workspace/projects/fieldCampaigns/FieldCampaignTable.tsx
@@ -100,11 +100,11 @@ function FieldTimepoints({
                   if (response.status === 200) {
                     // get blob from response data
                     const blob = new Blob([response.data], {
-                      type: response.headers['content-type'],
+                      type: response.headers['content-type'] as string,
                     });
                     // get filename from content-disposition header
                     const filename = getFilenameFromContentDisposition(
-                      response.headers['content-disposition']
+                      response.headers['content-disposition'] as string
                     );
                     // download file
                     downloadFile(blob, filename ? filename : 'template.csv');
@@ -326,11 +326,11 @@ export default function FieldCampaignTable() {
                     if (response.status === 200) {
                       // get blob from response data
                       const blob = new Blob([response.data], {
-                        type: response.headers['content-type'],
+                        type: response.headers['content-type'] as string,
                       });
                       // get filename from content-disposition header
                       const filename = getFilenameFromContentDisposition(
-                        response.headers['content-disposition']
+                        response.headers['content-disposition'] as string
                       );
                       // download file
                       downloadFile(


### PR DESCRIPTION
## Summary
Adds type casts to fix build-breaking TypeScript errors introduced by upstream dependency type changes — no logic changes.

## Changes
- Frontend: Cast `MaplibreMeasureControl` constructor options as `any` in `MeasureTerraDrawControl.tsx` to work around `forceAreaUnit` being dropped from the `MeasureControlOptions` type in `@watergis/maplibre-gl-terradraw`
- Frontend: Cast `response.headers['content-type']` and `response.headers['content-disposition']` as `string` in `FieldCampaignTable.tsx` to account for Axios widening `AxiosHeaderValue` to include `null`

## Testing
- `docker compose exec frontend npx tsc --noEmit` — passes with no errors

## Related Issues
N/A
