### PR TITLE
[Enhancement] Mobile layout improvements for map viewer

### DIFF
--- a/backend/app/api/api_v1/endpoints/utils.py
+++ b/backend/app/api/api_v1/endpoints/utils.py
@@ -38,10 +38,10 @@ def get_colorbar_for_data_product_with_public_access(
     cmin: int | float,
     cmax: int | float,
     cmap: str,
-    refresh: bool,
     project_id: UUID,
     flight_id: UUID,
     data_product_id: UUID,
+    refresh: bool = False,
     db: Session = Depends(deps.get_db),
 ) -> Any:
     if os.environ.get("RUNNING_TESTS") == "1":
@@ -88,8 +88,8 @@ def get_colorbar_for_data_product_with_user_access(
     cmin: int | float,
     cmax: int | float,
     cmap: str,
-    refresh: bool,
     data_product_id: UUID,
+    refresh: bool = False,
     current_user: models.User = Depends(deps.get_current_approved_user),
     project: models.Project = Depends(deps.can_read_project),
     flight: models.Flight = Depends(deps.can_read_flight),

--- a/backend/app/utils/ColorBar.py
+++ b/backend/app/utils/ColorBar.py
@@ -71,6 +71,7 @@ class ColorBar:
             cax=ax,
             orientation=self.orientation,
         )
+        ax.tick_params(labelsize=mpl.rcParams['font.size'] + 2)
         plt.savefig(out_fullpath, format="png", transparent=True)
 
         return out_fullpath

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <title>%VITE_TITLE%</title>
 

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -27,7 +27,7 @@ export default function Modal({
     <Transition show={open} as={Fragment}>
       <Dialog
         as="div"
-        className="relative z-10"
+        className="relative z-[60]"
         initialFocus={cancelButtonRef}
         onClose={setOpen}
       >
@@ -43,8 +43,8 @@ export default function Modal({
           <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
         </TransitionChild>
 
-        <div className="fixed inset-0 z-10 overflow-y-auto">
-          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+        <div className="fixed inset-0 z-[60] overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
             <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -55,7 +55,7 @@ function PageNumberItems({
           return (
             <li
               key={`dots-${idx}`}
-              className="block size-8 rounded-sm text-center leading-8"
+              className="flex items-center justify-center size-11 md:size-8 rounded-sm"
             >
               &#8230;
             </li>
@@ -68,7 +68,7 @@ function PageNumberItems({
               <a
                 onClick={() => updateCurrentPage(pageNumber)}
                 className={clsx(
-                  'block size-8 rounded-sm text-center leading-8',
+                  'flex items-center justify-center size-11 md:size-8 rounded-sm',
                   {
                     'border border-gray-100 bg-white text-gray-900':
                       pageNumber !== currentPage,
@@ -114,7 +114,7 @@ export default function Pagination({
           <a
             onClick={() => updateCurrentPage(currentPage - 1)}
             className={clsx(
-              'inline-flex size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
+              'inline-flex size-11 md:size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
               {
                 'opacity-75 cursor-not-allowed': currentPage < 1,
                 'cursor-pointer': currentPage > 0,
@@ -147,7 +147,7 @@ export default function Pagination({
           <a
             onClick={() => updateCurrentPage(currentPage + 1)}
             className={clsx(
-              'inline-flex size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
+              'inline-flex size-11 md:size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
               {
                 'opacity-75 cursor-not-allowed': currentPage + 1 >= totalPages,
                 'cursor-pointer': currentPage + 1 < totalPages,

--- a/frontend/src/components/hooks/index.tsx
+++ b/frontend/src/components/hooks/index.tsx
@@ -1,2 +1,3 @@
 export { useInterval } from './useInterval';
+export { useIsMobile } from './useIsMobile';
 export { usePrevious } from './usePrevious';

--- a/frontend/src/components/hooks/useIsMobile.ts
+++ b/frontend/src/components/hooks/useIsMobile.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint = 768): boolean {
+  const query = `(max-width: ${breakpoint - 1}px)`;
+  const [isMobile, setIsMobile] = useState<boolean>(
+    () => window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [query]);
+
+  return isMobile;
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -231,7 +231,7 @@ export default function Navbar() {
           </div>
 
           {user ? (
-            <DisclosurePanel className="sm:hidden">
+            <DisclosurePanel className="md:hidden">
               <div className="space-y-1 px-2 pb-3 pt-2">
                 {navigation.map((item) => {
                   if (item.href) {

--- a/frontend/src/components/layout/RootExplore.tsx
+++ b/frontend/src/components/layout/RootExplore.tsx
@@ -18,7 +18,7 @@ export default function RootExplore() {
           {user ? (
             <Link
               to="/home"
-              className="hover:text-amber-300 transition-colors"
+              className="inline-flex items-center min-h-[44px] md:min-h-0 hover:text-amber-300 transition-colors"
             >
               My workspace
             </Link>
@@ -26,13 +26,13 @@ export default function RootExplore() {
             <>
               <Link
                 to="/auth/login"
-                className="hover:text-amber-300 transition-colors"
+                className="inline-flex items-center min-h-[44px] md:min-h-0 hover:text-amber-300 transition-colors"
               >
                 Sign in
               </Link>
               <Link
                 to="/auth/register"
-                className="rounded-md bg-amber-400 px-3 py-1.5 text-sm text-black hover:bg-amber-300 transition-colors"
+                className="inline-flex items-center min-h-[44px] md:min-h-0 rounded-md bg-amber-400 px-3 py-1.5 text-sm text-black hover:bg-amber-300 transition-colors"
               >
                 Sign up
               </Link>

--- a/frontend/src/components/maps/AnnotationToolsToggle.tsx
+++ b/frontend/src/components/maps/AnnotationToolsToggle.tsx
@@ -40,7 +40,7 @@ export default function AnnotationToolsToggle() {
   if (!activeDataProduct || !activeProject || !active) return null;
 
   return (
-    <div className="absolute bottom-9 right-2 m-2.5 z-10 pointer-events-none">
+    <div className="absolute bottom-9 max-md:bottom-20 right-2 m-2.5 z-10 pointer-events-none">
       <div className="flex items-center">
         {shouldRender && (
           <div className="annotation-tools-container pointer-events-auto mr-[-6px] pr-[8px]">

--- a/frontend/src/components/maps/ColorBarControl.tsx
+++ b/frontend/src/components/maps/ColorBarControl.tsx
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import clsx from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
-import { ArrowPathIcon } from '@heroicons/react/24/outline';
 
 import { DataProduct } from '../pages/workspace/projects/Project';
 import {
@@ -22,7 +21,6 @@ export default function ColorBarControl({
   position?: 'left' | 'right';
   projectId?: string;
 }) {
-  const [isRefreshing, toggleIsRefreshing] = useState(false);
   const [url, setURL] = useState('');
 
   const { state } = useRasterSymbologyContext();
@@ -31,7 +29,7 @@ export default function ColorBarControl({
   const symbology = state[dataProduct.id]?.symbology;
 
   const fetchColorBar = useCallback(
-    async (symbology: SingleBandSymbology, refresh = false) => {
+    async (symbology: SingleBandSymbology) => {
       const stats = dataProduct.stac_properties.raster[0].stats;
 
       try {
@@ -60,7 +58,6 @@ export default function ColorBarControl({
               ? (stats.mean + stats.stddev * symbology.meanStdDev).toFixed(2)
               : symbology.max.toFixed(2),
           cmap: symbology.colorRamp,
-          refresh: refresh,
         };
         // Use plain axios (no auth interceptor) for public-only projects so a
         // redirect to the auth-required endpoint doesn't trigger a login redirect.
@@ -71,15 +68,12 @@ export default function ColorBarControl({
             )
           : await api.get(colorbarPath, { params });
         if (response) {
-          // only set url if it responds with OK status
           axios
             .get(response.data.colorbar_url)
             .then(() => setURL(response.data.colorbar_url))
-            .catch(() => setURL(''))
-            .finally(() => setTimeout(() => toggleIsRefreshing(false), 2000));
+            .catch(() => setURL(''));
         }
       } catch (err) {
-        setTimeout(() => toggleIsRefreshing(false), 2000);
         throw err;
       }
     },
@@ -92,35 +86,16 @@ export default function ColorBarControl({
     }
   }, [fetchColorBar, symbology]);
 
-  if (!symbology) return null;
+  if (!symbology || !url) return null;
 
-  if (url) {
-    return (
-      <div
-        className={clsx(
-          'absolute bottom-8 bg-white/75 rounded-md shadow-md px-3 py-6 m-2.5 leading-3 text-slate-600 outline-hidden',
-          { 'start-0': position === 'left', 'end-0': position === 'right' }
-        )}
-      >
-        <img src={url} className="h-80" />
-        <button
-          type="button"
-          className="flex items-center text-sky-600"
-          onClick={async () => {
-            toggleIsRefreshing(true);
-            fetchColorBar(symbology as SingleBandSymbology, true);
-          }}
-        >
-          <ArrowPathIcon
-            className={clsx('h-4 w-4 inline mr-2', {
-              'animate-spin': isRefreshing,
-            })}
-          />
-          <span>Refresh</span>
-        </button>
-      </div>
-    );
-  } else {
-    return null;
-  }
+  return (
+    <div
+      className={clsx(
+        'absolute bottom-8 max-md:bottom-20 bg-white/75 rounded-md shadow-md px-3 py-2 m-2.5 leading-3 text-slate-600 outline-hidden',
+        { 'start-0': position === 'left', 'end-0': position === 'right' }
+      )}
+    >
+      <img src={url} className="h-80 max-md:max-h-40" />
+    </div>
+  );
 }

--- a/frontend/src/components/maps/CompareMap/CompareMapControl.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMapControl.tsx
@@ -70,17 +70,18 @@ export default function CompareMapControl({
   return (
     <div
       className={clsx(
-        'absolute top-2 bg-gray-200 rounded-md shadow-md px-3 py-3 min-w-80',
+        'absolute top-2 bg-gray-200 rounded-md shadow-md px-3 py-3 md:min-w-80',
+        'max-md:px-2 max-md:py-2 max-md:max-w-[calc(50%-0.75rem)]',
         {
-          'left-14': side === 'left',
-          'right-14': side === 'right',
+          'left-14 max-md:left-2': side === 'left',
+          'right-14 max-md:right-2': side === 'right',
         }
       )}
       style={{ zIndex: 1001 }}
     >
       <div className="w-full flex flex-col gap-2">
         <select
-          className="w-full px-8 font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
+          className="w-full px-8 max-md:px-2 max-md:text-xs font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
           aria-label="Select flight date"
           name={`${side}FlightSelection`}
           value={mapComparisonState[side].flightId}
@@ -114,7 +115,7 @@ export default function CompareMapControl({
         </select>
         {dataProductOptions && dataProductOptions.length > 0 && (
           <select
-            className="w-full px-8 font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
+            className="w-full px-8 max-md:px-2 max-md:text-xs font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
             aria-label="Select data product"
             name={`${side}DataProductSelection`}
             value={mapComparisonState[side].dataProductId}

--- a/frontend/src/components/maps/CompareMap/CompareMapControl.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMapControl.tsx
@@ -81,7 +81,7 @@ export default function CompareMapControl({
     >
       <div className="w-full flex flex-col gap-2">
         <select
-          className="w-full px-8 max-md:px-2 max-md:text-xs font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
+          className="w-full px-8 max-md:pl-2 max-md:pr-6 max-md:text-xs font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
           aria-label="Select flight date"
           name={`${side}FlightSelection`}
           value={mapComparisonState[side].flightId}
@@ -115,7 +115,7 @@ export default function CompareMapControl({
         </select>
         {dataProductOptions && dataProductOptions.length > 0 && (
           <select
-            className="w-full px-8 max-md:px-2 max-md:text-xs font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
+            className="w-full px-8 max-md:pl-2 max-md:pr-6 max-md:text-xs font-semibold text-gray-600 text-center truncate border-2 border-gray-300 rounded-md bg-white"
             aria-label="Select data product"
             name={`${side}DataProductSelection`}
             value={mapComparisonState[side].dataProductId}

--- a/frontend/src/components/maps/CompareMap/CompareModeControl.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareModeControl.tsx
@@ -17,7 +17,7 @@ export default function CompareModeControl({
   );
 
   return (
-    <div className="absolute bottom-2 left-32 font-semibold text-gray-600 border-2 border-gray-300 rounded-md">
+    <div className="absolute bottom-12 left-32 font-semibold text-gray-600 border-2 border-gray-300 rounded-md" style={{ zIndex: 1001 }}>
       <select className="rounded-md" value={mode} onChange={onModeChange}>
         <option value="side-by-side">Side by side</option>
         <option value="split-screen">Split screen</option>

--- a/frontend/src/components/maps/LCCQualitySettings.tsx
+++ b/frontend/src/components/maps/LCCQualitySettings.tsx
@@ -1,6 +1,16 @@
+type Quality = 'very-low' | 'low' | 'medium' | 'high' | 'very-high';
+
+const QUALITY_OPTIONS: { value: Quality; label: string; shortLabel: string }[] = [
+  { value: 'very-low', label: 'Very Low', shortLabel: 'V. Low' },
+  { value: 'low', label: 'Low', shortLabel: 'Low' },
+  { value: 'medium', label: 'Medium', shortLabel: 'Med' },
+  { value: 'high', label: 'High', shortLabel: 'High' },
+  { value: 'very-high', label: 'Very High', shortLabel: 'V. High' },
+];
+
 interface LCCQualitySettingsProps {
-  quality: 'very-low' | 'low' | 'medium' | 'high' | 'very-high';
-  setQuality: (quality: 'very-low' | 'low' | 'medium' | 'high' | 'very-high') => void;
+  quality: Quality;
+  setQuality: (quality: Quality) => void;
 }
 
 export default function LCCQualitySettings({
@@ -8,59 +18,24 @@ export default function LCCQualitySettings({
   setQuality,
 }: LCCQualitySettingsProps) {
   return (
-    <div className="flex items-center gap-2 rounded-sm border border-white/30 bg-black/70 px-3 py-2">
+    <div className="w-fit flex items-center gap-2 rounded-sm border border-white/30 bg-black/70 px-3 py-2">
       <span className="text-sm font-medium text-white">Quality:</span>
       <div className="flex overflow-hidden rounded-sm border border-white/30">
-        <button
-          onClick={() => setQuality('very-low')}
-          className={`px-2 py-1 text-xs font-medium transition-colors ${
-            quality === 'very-low'
-              ? 'bg-white/30 text-white'
-              : 'bg-black/40 text-white/70 hover:bg-white/10'
-          }`}
-        >
-          Very Low
-        </button>
-        <button
-          onClick={() => setQuality('low')}
-          className={`border-l border-white/30 px-2 py-1 text-xs font-medium transition-colors ${
-            quality === 'low'
-              ? 'bg-white/30 text-white'
-              : 'bg-black/40 text-white/70 hover:bg-white/10'
-          }`}
-        >
-          Low
-        </button>
-        <button
-          onClick={() => setQuality('medium')}
-          className={`border-l border-white/30 px-2 py-1 text-xs font-medium transition-colors ${
-            quality === 'medium'
-              ? 'bg-white/30 text-white'
-              : 'bg-black/40 text-white/70 hover:bg-white/10'
-          }`}
-        >
-          Medium
-        </button>
-        <button
-          onClick={() => setQuality('high')}
-          className={`border-l border-white/30 px-2 py-1 text-xs font-medium transition-colors ${
-            quality === 'high'
-              ? 'bg-white/30 text-white'
-              : 'bg-black/40 text-white/70 hover:bg-white/10'
-          }`}
-        >
-          High
-        </button>
-        <button
-          onClick={() => setQuality('very-high')}
-          className={`border-l border-white/30 px-2 py-1 text-xs font-medium transition-colors ${
-            quality === 'very-high'
-              ? 'bg-white/30 text-white'
-              : 'bg-black/40 text-white/70 hover:bg-white/10'
-          }`}
-        >
-          Very High
-        </button>
+        {QUALITY_OPTIONS.map((o, i) => (
+          <button
+            key={o.value}
+            onClick={() => setQuality(o.value)}
+            title={o.label}
+            className={`px-2 py-1 text-xs font-medium transition-colors${i > 0 ? ' border-l border-white/30' : ''} ${
+              quality === o.value
+                ? 'bg-white/30 text-white'
+                : 'bg-black/40 text-white/70 hover:bg-white/10'
+            }`}
+          >
+            <span className="md:hidden">{o.shortLabel}</span>
+            <span className="hidden md:inline">{o.label}</span>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/components/maps/LCCViewer.tsx
+++ b/frontend/src/components/maps/LCCViewer.tsx
@@ -426,13 +426,13 @@ export default function LCCViewer({ lccUrl }: { lccUrl: string }) {
         <div className="flex gap-2">
           <button
             onClick={() => setDroneVisible(!droneVisible)}
-            className="w-32 rounded-sm border border-white/30 bg-black/70 px-4 py-2 text-sm font-medium text-white"
+            className="md:w-32 rounded-sm border border-white/30 bg-black/70 px-2 py-2 md:px-4 text-sm font-medium text-white"
           >
             {droneVisible ? 'Hide Drone' : 'Show Drone'}
           </button>
           <button
             onClick={() => setShowControls(!showControls)}
-            className="w-36 rounded-sm border border-white/30 bg-black/70 px-4 py-2 text-sm font-medium text-white"
+            className="md:w-36 rounded-sm border border-white/30 bg-black/70 px-2 py-2 md:px-4 text-sm font-medium text-white"
           >
             {showControls ? 'Hide Controls' : 'Show Controls'}
           </button>
@@ -440,9 +440,9 @@ export default function LCCViewer({ lccUrl }: { lccUrl: string }) {
             onClick={() => setCollisionEnabled(!collisionEnabled)}
             disabled={!collisionAvailable}
             title={!collisionAvailable ? 'Collision detection not available for this scene' : ''}
-            className="w-44 rounded-sm border border-white/30 bg-black/70 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            className="md:w-44 rounded-sm border border-white/30 bg-black/70 px-2 py-2 md:px-4 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {collisionEnabled ? 'Disable Collision' : 'Enable Collision'}
+            {collisionEnabled ? 'Collision On' : 'Collision Off'}
           </button>
         </div>
         <LCCQualitySettings quality={quality} setQuality={setQuality} />

--- a/frontend/src/components/maps/LayerPane/ActiveProjectPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ActiveProjectPane.tsx
@@ -131,12 +131,12 @@ export default function ActiveProjectPane({ project }: ActiveProjectPaneProps) {
         className="flex-1 flex flex-col min-h-0"
       >
         <TabList className="flex gap-1 flex-none mt-3">
-          <Tab className="rounded-t-md border-2 border-slate-300 px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus:outline-hidden focus:ring-2 focus:ring-slate-500 bg-slate-300 data-hover:bg-slate-200 data-selected:bg-white data-selected:border-b-white data-selected:shadow-xs">
-            <div className="flex items-center gap-1.5">
+          <Tab className="max-md:flex-1 rounded-t-md border-2 border-slate-300 px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus:outline-hidden focus:ring-2 focus:ring-slate-500 bg-slate-300 data-hover:bg-slate-200 data-selected:bg-white data-selected:border-b-white data-selected:shadow-xs">
+            <div className="flex items-center justify-center gap-1.5">
               <img
                 src={uasIcon}
                 alt=""
-                className="h-3.5 w-3.5 data-selected:brightness-0"
+                className="h-3.5 w-3.5 max-md:hidden data-selected:brightness-0"
               />
               <span>Flights</span>
               <span className="text-slate-500 font-normal">
@@ -145,9 +145,9 @@ export default function ActiveProjectPane({ project }: ActiveProjectPaneProps) {
             </div>
           </Tab>
           {!publicOnly && (
-            <Tab className="rounded-t-md border-2 border-slate-300 px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus:outline-hidden focus:ring-2 focus:ring-slate-500 bg-slate-300 data-hover:bg-slate-200 data-selected:bg-white data-selected:border-b-white data-selected:shadow-xs">
-              <div className="flex items-center gap-1.5">
-                <FaLayerGroup className="h-3.5 w-3.5" />
+            <Tab className="max-md:flex-1 rounded-t-md border-2 border-slate-300 px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus:outline-hidden focus:ring-2 focus:ring-slate-500 bg-slate-300 data-hover:bg-slate-200 data-selected:bg-white data-selected:border-b-white data-selected:shadow-xs">
+              <div className="flex items-center justify-center gap-1.5">
+                <FaLayerGroup className="h-3.5 w-3.5 max-md:hidden" />
                 <span>Map Layers</span>
                 <span className="text-slate-500 font-normal">
                   ({layers.length})
@@ -158,10 +158,10 @@ export default function ActiveProjectPane({ project }: ActiveProjectPaneProps) {
           {!publicOnly && (
             <Tab
               disabled={!activeDataProduct}
-              className="rounded-t-md border-2 border-slate-300 px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus:outline-hidden focus:ring-2 focus:ring-slate-500 bg-slate-300 data-hover:bg-slate-200 data-selected:bg-white data-selected:border-b-white data-selected:shadow-xs data-disabled:opacity-50 data-disabled:cursor-not-allowed"
+              className="max-md:flex-1 rounded-t-md border-2 border-slate-300 px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus:outline-hidden focus:ring-2 focus:ring-slate-500 bg-slate-300 data-hover:bg-slate-200 data-selected:bg-white data-selected:border-b-white data-selected:shadow-xs data-disabled:opacity-50 data-disabled:cursor-not-allowed"
             >
-              <div className="flex items-center gap-1.5">
-                <MdEditNote className="h-3.5 w-3.5" />
+              <div className="flex items-center justify-center gap-1.5">
+                <MdEditNote className="h-3.5 w-3.5 max-md:hidden" />
                 <span>Annotations</span>
               </div>
             </Tab>

--- a/frontend/src/components/maps/LayerPane/ActiveProjectPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ActiveProjectPane.tsx
@@ -115,7 +115,7 @@ export default function ActiveProjectPane({ project }: ActiveProjectPaneProps) {
   }, [shouldScrollOnMount, activeDataProduct, scrollToActiveDataProduct]);
 
   return (
-    <article className="h-[calc(100%-44px)] p-4 flex flex-col">
+    <article className="h-[calc(100%-44px)] p-4 max-md:pb-20 flex flex-col">
       <header className="flex-none">
         <h1 className="truncate" title={project.title}>
           {project.title}

--- a/frontend/src/components/maps/LayerPane/DataProductCard.tsx
+++ b/frontend/src/components/maps/LayerPane/DataProductCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { useMapContext } from '../MapContext';
+import { useMobileView } from '../MobileViewContext';
 
 import LayerCard from './LayerCard';
 import Modal from '../../Modal';
@@ -26,6 +27,7 @@ export default function DataProductCard({
     pointCloudViewerDispatch,
   } = useMapContext();
 
+  const { setMobileView } = useMobileView();
   const [shareOpen, setShareOpen] = useState(false);
 
   const { dispatch } = useRasterSymbologyContext();
@@ -173,6 +175,13 @@ export default function DataProductCard({
           activeDataProduct.id === dataProduct.id &&
           isRasterType && (
             <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setMobileView('map')}
+                className="md:hidden mb-2 text-sm font-semibold text-accent2 hover:text-accent2-dark"
+              >
+                View on map →
+              </button>
               <RasterSymbologySettings />
             </div>
           )}

--- a/frontend/src/components/maps/LayerPane/FlightCard.tsx
+++ b/frontend/src/components/maps/LayerPane/FlightCard.tsx
@@ -40,7 +40,7 @@ export default function FlightCard({ flight }: { flight: Flight }) {
           className="mt-0.5 group [&_summary::-webkit-details-marker]:hidden overflow-visible"
           open={activeDataProduct?.flight_id === flight.id}
         >
-          <summary className="text-sm cursor-pointer text-slate-600 hover:text-slate-800 hover:bg-slate-50 transition-colors flex items-center gap-1.5 px-2 py-1 -mx-2 rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent2 focus-visible:ring-offset-1">
+          <summary className="text-sm cursor-pointer text-slate-600 hover:text-slate-800 hover:bg-slate-50 transition-colors flex items-center gap-1.5 px-2 py-1 -mx-2 rounded-sm max-md:min-h-[44px] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent2 focus-visible:ring-offset-1">
             <FaCircleChevronRight
               className="h-4 w-4 transition-transform group-open:rotate-90"
               aria-hidden="true"

--- a/frontend/src/components/maps/LayerPane/LayerPane.tsx
+++ b/frontend/src/components/maps/LayerPane/LayerPane.tsx
@@ -105,7 +105,7 @@ export default function LayerPane({
               <span />
             )}
             <XMarkIcon
-              className="h-6 w-6 cursor-pointer float-right"
+              className="h-6 w-6 cursor-pointer float-right max-md:hidden"
               onClick={handleToggleClick}
             />
           </div>

--- a/frontend/src/components/maps/LayerPane/LayerPane.tsx
+++ b/frontend/src/components/maps/LayerPane/LayerPane.tsx
@@ -98,7 +98,11 @@ export default function LayerPane({
         <div className="h-full text-slate-700">
           <div className="h-11 flex items-center justify-between p-2.5">
             {activeProject ? (
-              <button type="button" onClick={handleReturnClick}>
+              <button
+                type="button"
+                onClick={handleReturnClick}
+                className="inline-flex items-center justify-center max-md:h-11 max-md:w-11"
+              >
                 <ArrowUturnLeftIcon className="h-6 w-6" />
               </button>
             ) : (

--- a/frontend/src/components/maps/LayerPane/MapLayersPanel.tsx
+++ b/frontend/src/components/maps/LayerPane/MapLayersPanel.tsx
@@ -70,7 +70,7 @@ export default function MapLayersPanel() {
                     onChange={(event) =>
                       updateLayerProperty(layer.id, 'fill', event.target.value)
                     }
-                    className="h-7 w-10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+                    className="h-11 w-11 md:h-7 md:w-10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
                   />
                 </div>
                 <div className="flex flex-col items-center">
@@ -82,7 +82,7 @@ export default function MapLayersPanel() {
                     onChange={(event) =>
                       updateLayerProperty(layer.id, 'color', event.target.value)
                     }
-                    className="h-7 w-10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+                    className="h-11 w-11 md:h-7 md:w-10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
                   />
                 </div>
               </div>
@@ -94,7 +94,7 @@ export default function MapLayersPanel() {
                 onChange={(event) =>
                   updateLayerProperty(layer.id, 'color', event.target.value)
                 }
-                className="h-7 w-10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+                className="h-11 w-11 md:h-7 md:w-10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
               />
             )}
           </div>

--- a/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
@@ -190,7 +190,7 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
   }
 
   return (
-    <div className="h-[calc(100%-44px)] p-4 flex flex-col">
+    <div className="h-[calc(100%-44px)] p-4 max-md:pb-20 flex flex-col">
       <div className="h-36">
         <h1>Projects</h1>
         {hasAnyProjects && (

--- a/frontend/src/components/maps/LayerPane/RasterStats.tsx
+++ b/frontend/src/components/maps/LayerPane/RasterStats.tsx
@@ -6,7 +6,7 @@ export default function RasterStats({ stats }: { stats: Band['stats'] }) {
       <legend className="block text-sm text-gray-400 font-semibold pt-1 pb-1">
         Stats
       </legend>
-      <div className="flex flex-row flex-wrap justify-between gap-1.5">
+      <div className="grid grid-cols-2 gap-2 md:flex md:flex-row md:flex-wrap md:justify-between md:gap-1.5">
         <div className="flex flex-col">
           <span className="font-semibold">Mean</span>
           <span>{stats.mean.toFixed(2)}</span>

--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -124,7 +124,7 @@ function MapLayoutContent() {
           aria-label="Exit viewer and return to list"
           className={clsx(
             'fixed right-3 z-[60] h-11 w-11 flex items-center justify-center rounded-full bg-white shadow-lg text-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2',
-            activeDataProduct?.data_type === 'panoramic' ? 'bottom-20' : 'bottom-6',
+            activeDataProduct?.data_type === 'panoramic' ? 'bottom-20' : 'bottom-12',
           )}
           style={{ marginBottom: 'env(safe-area-inset-bottom)' }}
         >

--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -5,6 +5,7 @@ import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { useIsMobile } from '../hooks';
 import LayerPane from './LayerPane';
 import MapListToggle from './MapListToggle';
+import { MobileViewProvider } from './MobileViewContext';
 
 import { AnnotationProvider } from './contexts/AnnotationContext';
 import { MapApiKeysContextProvider } from './MapApiKeysContext';
@@ -49,6 +50,15 @@ function MapLayoutContent() {
     if (isFullScreenViewer) setMobileView('map');
   }, [isMobile, isFullScreenViewer]);
 
+  // Auto-switch when point cloud is activated in map mode (no in-list controls to stay for)
+  const isPointCloudMapMode =
+    activeDataProduct?.data_type === 'point_cloud' && pointCloudViewer === 'map';
+
+  useEffect(() => {
+    if (!isMobile) return;
+    if (isPointCloudMapMode) setMobileView('map');
+  }, [isMobile, isPointCloudMapMode]);
+
   const handleExitFullScreenViewer = () => {
     activeDataProductDispatch({ type: 'clear', payload: null });
     if (activeMapTool === 'compare') {
@@ -64,6 +74,7 @@ function MapLayoutContent() {
   const mapHidden = isMobile && mobileView !== 'map';
 
   return (
+    <MobileViewProvider value={{ setMobileView }}>
     <div className="relative h-full md:flex md:flex-row">
       {/* sidebar / list panel */}
       <div
@@ -118,6 +129,7 @@ function MapLayoutContent() {
         </button>
       )}
     </div>
+    </MobileViewProvider>
   );
 }
 

--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 
 import { useIsMobile } from '../hooks';
 import LayerPane from './LayerPane';
@@ -18,7 +19,9 @@ type MobileView = 'map' | 'list';
 function MapLayoutContent() {
   const {
     activeDataProduct,
+    activeDataProductDispatch,
     activeMapTool,
+    activeMapToolDispatch,
     activeProject,
     pointCloudViewer,
   } = useMapContext();
@@ -39,6 +42,20 @@ function MapLayoutContent() {
     (activeDataProduct?.data_type === 'point_cloud' &&
       pointCloudViewer === 'potree') ||
     activeMapTool === 'compare';
+
+  // Auto-switch to map panel when a full-screen viewer activates on mobile
+  useEffect(() => {
+    if (!isMobile) return;
+    if (isFullScreenViewer) setMobileView('map');
+  }, [isMobile, isFullScreenViewer]);
+
+  const handleExitFullScreenViewer = () => {
+    activeDataProductDispatch({ type: 'clear', payload: null });
+    if (activeMapTool === 'compare') {
+      activeMapToolDispatch({ type: 'set', payload: 'map' });
+    }
+    setMobileView('list');
+  };
 
   // Hide toggle for full-screen viewers that have no meaningful list to switch to
   const showToggle = isMobile && !isFullScreenViewer;
@@ -87,6 +104,18 @@ function MapLayoutContent() {
 
       {showToggle && (
         <MapListToggle view={mobileView} onChange={setMobileView} />
+      )}
+
+      {isMobile && isFullScreenViewer && (
+        <button
+          type="button"
+          onClick={handleExitFullScreenViewer}
+          aria-label="Exit viewer and return to list"
+          className="fixed bottom-6 right-3 z-[60] h-11 w-11 flex items-center justify-center rounded-full bg-white shadow-lg text-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2"
+          style={{ marginBottom: 'env(safe-area-inset-bottom)' }}
+        >
+          <ArrowLeftIcon className="h-5 w-5" />
+        </button>
       )}
     </div>
   );

--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -23,19 +23,12 @@ function MapLayoutContent() {
     activeDataProductDispatch,
     activeMapTool,
     activeMapToolDispatch,
-    activeProject,
     pointCloudViewer,
   } = useMapContext();
 
   const isMobile = useIsMobile();
   const [hidePane, toggleHidePane] = useState(false);
   const [mobileView, setMobileView] = useState<MobileView>('list');
-
-  // Default view based on whether a project is active
-  useEffect(() => {
-    if (!isMobile) return;
-    setMobileView(activeProject ? 'map' : 'list');
-  }, [isMobile, activeProject]);
 
   const isFullScreenViewer =
     activeDataProduct?.data_type === 'panoramic' ||

--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -1,48 +1,105 @@
-import { useState } from 'react';
+import clsx from 'clsx';
+import { useEffect, useState } from 'react';
 
+import { useIsMobile } from '../hooks';
 import LayerPane from './LayerPane';
+import MapListToggle from './MapListToggle';
 
 import { AnnotationProvider } from './contexts/AnnotationContext';
-import { MapContextProvider } from './MapContext';
 import { MapApiKeysContextProvider } from './MapApiKeysContext';
+import { MapContextProvider, useMapContext } from './MapContext';
 import { MapLayerProvider } from './MapLayersContext';
 import MapViewMode from './MapViewMode';
 import ProjectLoader from './ProjectLoader';
 import { RasterSymbologyProvider } from './RasterSymbologyContext';
 
-function classNames(...classes: [string, string]) {
-  return classes.filter(Boolean).join(' ');
+type MobileView = 'map' | 'list';
+
+function MapLayoutContent() {
+  const {
+    activeDataProduct,
+    activeMapTool,
+    activeProject,
+    pointCloudViewer,
+  } = useMapContext();
+
+  const isMobile = useIsMobile();
+  const [hidePane, toggleHidePane] = useState(false);
+  const [mobileView, setMobileView] = useState<MobileView>('list');
+
+  // Default view based on whether a project is active
+  useEffect(() => {
+    if (!isMobile) return;
+    setMobileView(activeProject ? 'map' : 'list');
+  }, [isMobile, activeProject]);
+
+  const isFullScreenViewer =
+    activeDataProduct?.data_type === 'panoramic' ||
+    activeDataProduct?.data_type === '3dgs' ||
+    (activeDataProduct?.data_type === 'point_cloud' &&
+      pointCloudViewer === 'potree') ||
+    activeMapTool === 'compare';
+
+  // Hide toggle for full-screen viewers that have no meaningful list to switch to
+  const showToggle = isMobile && !isFullScreenViewer;
+
+  const listHidden = isMobile && mobileView !== 'list';
+  const mapHidden = isMobile && mobileView !== 'map';
+
+  return (
+    <div className="relative h-full md:flex md:flex-row">
+      {/* sidebar / list panel */}
+      <div
+        id="panel-list"
+        role={isMobile ? 'tabpanel' : undefined}
+        aria-labelledby={isMobile ? 'tab-list' : undefined}
+        inert={listHidden ? true : undefined}
+        className={clsx(
+          'bg-slate-100',
+          'md:shrink-0',
+          hidePane ? 'md:w-[48px]' : 'md:w-[450px]',
+          'max-md:absolute max-md:inset-0 max-md:z-10 max-md:w-full',
+          listHidden && 'invisible',
+        )}
+      >
+        <LayerPane
+          hidePane={!isMobile && hidePane}
+          toggleHidePane={toggleHidePane}
+        />
+      </div>
+
+      {/* map panel */}
+      <div
+        id="panel-map"
+        role={isMobile ? 'tabpanel' : undefined}
+        aria-labelledby={isMobile ? 'tab-map' : undefined}
+        inert={mapHidden ? true : undefined}
+        className={clsx(
+          'md:w-full md:h-full',
+          'max-md:absolute max-md:inset-0',
+          mapHidden && 'invisible',
+        )}
+      >
+        <MapApiKeysContextProvider>
+          <MapViewMode />
+        </MapApiKeysContextProvider>
+      </div>
+
+      {showToggle && (
+        <MapListToggle view={mobileView} onChange={setMobileView} />
+      )}
+    </div>
+  );
 }
 
 export default function MapLayout() {
-  const [hidePane, toggleHidePane] = useState(false);
-
   return (
     <MapContextProvider>
       <ProjectLoader />
       <MapLayerProvider>
         <AnnotationProvider>
           <RasterSymbologyProvider>
-            {/* sidebar */}
-            <div className="flex flex-row h-full">
-              <div
-                className={classNames(
-                  hidePane ? 'w-[48px]' : 'w-[450px]',
-                  'shrink-0 bg-slate-100',
-                )}
-              >
-                <LayerPane
-                  hidePane={hidePane}
-                  toggleHidePane={toggleHidePane}
-                />
-              </div>
-              {/* page content */}
-              <div className="w-full h-full">
-                <MapApiKeysContextProvider>
-                  <MapViewMode />
-                </MapApiKeysContextProvider>
-              </div>
-            </div>
+            <MapLayoutContent />
           </RasterSymbologyProvider>
         </AnnotationProvider>
       </MapLayerProvider>

--- a/frontend/src/components/maps/MapLayout.tsx
+++ b/frontend/src/components/maps/MapLayout.tsx
@@ -122,7 +122,10 @@ function MapLayoutContent() {
           type="button"
           onClick={handleExitFullScreenViewer}
           aria-label="Exit viewer and return to list"
-          className="fixed bottom-6 right-3 z-[60] h-11 w-11 flex items-center justify-center rounded-full bg-white shadow-lg text-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2"
+          className={clsx(
+            'fixed right-3 z-[60] h-11 w-11 flex items-center justify-center rounded-full bg-white shadow-lg text-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2',
+            activeDataProduct?.data_type === 'panoramic' ? 'bottom-20' : 'bottom-6',
+          )}
           style={{ marginBottom: 'env(safe-area-inset-bottom)' }}
         >
           <ArrowLeftIcon className="h-5 w-5" />

--- a/frontend/src/components/maps/MapListToggle.tsx
+++ b/frontend/src/components/maps/MapListToggle.tsx
@@ -27,7 +27,7 @@ export default function MapListToggle({ view, onChange }: MapListToggleProps) {
       aria-label="View mode"
       onKeyDown={handleKeyDown}
       className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex rounded-full shadow-lg overflow-hidden"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      style={{ marginBottom: 'env(safe-area-inset-bottom)' }}
     >
       {tabs.map(({ value, label, Icon }) => {
         const isActive = view === value;

--- a/frontend/src/components/maps/MapListToggle.tsx
+++ b/frontend/src/components/maps/MapListToggle.tsx
@@ -1,0 +1,57 @@
+import { ListBulletIcon, MapIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+
+type View = 'map' | 'list';
+
+type MapListToggleProps = {
+  view: View;
+  onChange: (view: View) => void;
+};
+
+const tabs: { value: View; label: string; Icon: React.FC<React.SVGProps<SVGSVGElement>> }[] = [
+  { value: 'list', label: 'List', Icon: ListBulletIcon },
+  { value: 'map', label: 'Map', Icon: MapIcon },
+];
+
+export default function MapListToggle({ view, onChange }: MapListToggleProps) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      onChange(view === 'list' ? 'map' : 'list');
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label="View mode"
+      onKeyDown={handleKeyDown}
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex rounded-full shadow-lg overflow-hidden"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      {tabs.map(({ value, label, Icon }) => {
+        const isActive = view === value;
+        return (
+          <button
+            key={value}
+            id={`tab-${value}`}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`panel-${value}`}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onChange(value)}
+            className={clsx(
+              'flex items-center gap-2 px-5 h-11 text-sm font-semibold motion-safe:transition-colors motion-safe:duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2',
+              isActive
+                ? 'bg-accent2 text-white'
+                : 'bg-white text-slate-700 hover:bg-slate-50',
+            )}
+          >
+            <Icon className="h-5 w-5" aria-hidden="true" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/maps/MapToolbar.tsx
+++ b/frontend/src/components/maps/MapToolbar.tsx
@@ -22,27 +22,27 @@ export default function MapToolbar() {
         <div
           className={classNames(
             activeMapTool === 'map' ? 'bg-accent2' : '',
-            'h-8 w-8 cursor-pointer shadow-xs hover:shadow-xl rounded-sm border-2 border-solid border-slate-500 p-1.5'
+            'h-11 w-11 md:h-8 md:w-8 flex items-center justify-center cursor-pointer shadow-xs hover:shadow-xl rounded-sm border-2 border-solid border-slate-500 p-1.5'
           )}
           onClick={() => {
             activeDataProductDispatch({ type: 'clear', payload: null });
             activeMapToolDispatch({ type: 'set', payload: 'map' });
           }}
         >
-          <MapIcon className="h-4 w-4" />
+          <MapIcon className="h-5 w-5 md:h-4 md:w-4" />
           <span className="sr-only">Map Tool</span>
         </div>
         <div
           className={classNames(
             activeMapTool === 'compare' ? 'bg-accent2' : '',
-            'h-8 w-8 cursor-pointer shadow-xs hover:shadow-xl rounded-sm border-2 border-solid border-slate-500 p-1.5'
+            'h-11 w-11 md:h-8 md:w-8 flex items-center justify-center cursor-pointer shadow-xs hover:shadow-xl rounded-sm border-2 border-solid border-slate-500 p-1.5'
           )}
           onClick={() => {
             activeDataProductDispatch({ type: 'clear', payload: null });
             activeMapToolDispatch({ type: 'set', payload: 'compare' });
           }}
         >
-          <ScaleIcon className="h-4 w-4" />
+          <ScaleIcon className="h-5 w-5 md:h-4 md:w-4" />
           <span className="sr-only">Compare Tool</span>
         </div>
         <div className="mt-4">

--- a/frontend/src/components/maps/MeasureToolsToggle.tsx
+++ b/frontend/src/components/maps/MeasureToolsToggle.tsx
@@ -50,7 +50,7 @@ export default function MeasureToolsToggle() {
 
   return (
     <>
-      <div className="absolute bottom-9 right-2 m-2.5 flex flex-col items-end gap-2 z-10 pointer-events-none">
+      <div className="absolute bottom-9 max-md:bottom-20 right-2 m-2.5 flex flex-col items-end gap-2 z-10 pointer-events-none">
         {isExpanded && (
           <div className="bg-white rounded-md shadow-md px-3 py-2 flex items-center gap-2 relative z-10 pointer-events-auto">
             <span className="text-xs text-slate-500">Units:</span>

--- a/frontend/src/components/maps/MobileViewContext.tsx
+++ b/frontend/src/components/maps/MobileViewContext.tsx
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+
+type MobileView = 'map' | 'list';
+
+const MobileViewContext = createContext<{
+  setMobileView: (view: MobileView) => void;
+}>({ setMobileView: () => {} });
+
+export const MobileViewProvider = MobileViewContext.Provider;
+export const useMobileView = () => useContext(MobileViewContext);

--- a/frontend/src/components/maps/OpacitySlider.tsx
+++ b/frontend/src/components/maps/OpacitySlider.tsx
@@ -1,5 +1,7 @@
 import Slider from '@mui/material/Slider';
 
+import { useIsMobile } from '../hooks';
+
 const marks = [
   {
     value: 0,
@@ -32,6 +34,7 @@ export default function OpacitySlider({
   currentValue: number;
   onChange: (_: Event, newValue: number | number[]) => void;
 }) {
+  const isMobile = useIsMobile();
   const getAriaValueText = (newValue: number) => `${newValue}%`;
 
   return (
@@ -52,8 +55,8 @@ export default function OpacitySlider({
           onChange={onChange}
           sx={{
             '& .MuiSlider-thumb': {
-              width: '20px',
-              height: '14px',
+              width: isMobile ? '28px' : '20px',
+              height: isMobile ? '20px' : '14px',
               backgroundColor: 'white',
               border: !disabled ? '2px solid #ABABAB' : '2px solid #ebebeb',
               borderRadius: '4px',

--- a/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologyAccessControls.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologyAccessControls.tsx
@@ -84,11 +84,11 @@ export default function RasterSymbologyAccessControls({
   };
 
   return (
-    <div className="flex">
+    <div className="flex max-md:flex-col">
       <div
         className={`${
           qrCode ? 'flex-1' : 'w-full'
-        } grid grid-flow-row auto-rows-max py-8 px-4 gap-4`}
+        } grid grid-flow-row auto-rows-max py-8 px-4 max-md:py-4 max-md:px-3 gap-4`}
       >
         <div>
           <h1>Share Settings</h1>
@@ -108,9 +108,9 @@ export default function RasterSymbologyAccessControls({
             />
             <label
               htmlFor="accessRestricted"
-              className="flex items-center justify-between cursor-pointer peer-disabled:cursor-default rounded-lg border border-gray-50 bg-gray-100 p-4 text-sm font-medium shadow-xs hover:border-gray-200 peer-checked:border-accent3 peer-checked:ring-1 peer-checked:ring-accent3"
+              className="flex flex-col md:flex-row md:items-center md:justify-between cursor-pointer peer-disabled:cursor-default rounded-lg border border-gray-50 bg-gray-100 p-4 max-md:p-3 text-sm font-medium shadow-xs hover:border-gray-200 peer-checked:border-accent3 peer-checked:ring-1 peer-checked:ring-accent3 gap-1.5"
             >
-              <div className="flex-none flex items-center gap-2 w-48">
+              <div className="flex-none flex items-center gap-2 md:w-48">
                 <svg
                   className="hidden h-5 w-5 text-slate-600"
                   xmlns="http://www.w3.org/2000/svg"
@@ -126,7 +126,7 @@ export default function RasterSymbologyAccessControls({
 
                 <p className="text-gray-700">Restricted</p>
               </div>
-              <p className="text-gray-900">
+              <p className="text-gray-900 max-md:text-xs">
                 Only project members will be able to access shared links for
                 this data product. Must be signed in to platform to view shared
                 link.
@@ -147,9 +147,9 @@ export default function RasterSymbologyAccessControls({
               />
               <label
                 htmlFor="accessUnrestricted"
-                className="flex cursor-pointer items-center justify-between rounded-lg border border-gray-50 bg-gray-100 p-4 text-sm font-medium shadow-xs hover:border-gray-200 peer-checked:border-accent3 peer-checked:ring-1 peer-checked:ring-accent3"
+                className="flex flex-col md:flex-row md:items-center md:justify-between cursor-pointer rounded-lg border border-gray-50 bg-gray-100 p-4 max-md:p-3 text-sm font-medium shadow-xs hover:border-gray-200 peer-checked:border-accent3 peer-checked:ring-1 peer-checked:ring-accent3 gap-1.5"
               >
-                <div className="flex-none flex items-center gap-2 w-48">
+                <div className="flex-none flex items-center gap-2 md:w-48">
                   <svg
                     className="hidden h-5 w-5 text-slate-600"
                     xmlns="http://www.w3.org/2000/svg"
@@ -164,7 +164,7 @@ export default function RasterSymbologyAccessControls({
                   </svg>
                   <p className="text-gray-700">Anyone</p>
                 </div>
-                <p className="text-gray-900">
+                <p className="text-gray-900 max-md:text-xs">
                   Anyone can access this data product. It can be downloaded,
                   used outside of the platform, and shared links can be viewed
                   without signing in.
@@ -176,7 +176,7 @@ export default function RasterSymbologyAccessControls({
         <div className="grid grid-cols-6 gap-4">
           <div className="col-span-2">
             <CopyURLButton
-              copyText="Copy File URL"
+              copyText="Copy File"
               copiedText="Copied"
               url={dataProduct.url}
               title="Copy link that can be used to directly access the data product"
@@ -190,7 +190,7 @@ export default function RasterSymbologyAccessControls({
                   className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 whitespace-nowrap min-w-[180px]"
                   onClick={() => setIsOpen(!isOpen)}
                 >
-                  Share Current Map
+                  Share Map
                   <ChevronDownIcon
                     className="-mr-1 h-5 w-5 text-gray-400"
                     aria-hidden="true"
@@ -412,9 +412,9 @@ export default function RasterSymbologyAccessControls({
         {status ? <Alert alertType={status.type}>{status.msg}</Alert> : null}
       </div>
       {qrCode && (
-        <div className="flex flex-col items-center justify-center p-4 gap-4 w-48">
+        <div className="flex flex-col items-center justify-center p-4 gap-4 w-48 max-md:w-full">
           <img
-            className="w-full"
+            className="w-full max-md:max-w-[140px]"
             src={URL.createObjectURL(qrCode)}
             alt="QR Code"
           />

--- a/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologyModeRadioGroup.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologyModeRadioGroup.tsx
@@ -20,7 +20,7 @@ function ModeRadioInput({
   onChange,
 }: ModeRadioInputProps) {
   return (
-    <label className="block text-sm font-semibold pt-2 pb-1">
+    <label className="block text-sm font-semibold pt-2 pb-1 max-md:flex max-md:items-center max-md:min-h-[44px] max-md:pt-0 max-md:pb-0">
       <input
         type="radio"
         name="mode"
@@ -87,7 +87,7 @@ export default function RasterSymbologyModeRadioGroup({
 
   return (
     <div
-      className="flex flex-wrap justify-between gap-1.5"
+      className="flex flex-wrap justify-between gap-1.5 max-md:flex-col"
       role="group"
       aria-labelledby="modeGroup"
     >

--- a/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologySaveAndShare.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/RasterSymbologySaveAndShare.tsx
@@ -30,7 +30,7 @@ function RasterSymbologyShare({
 }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="w-36">
+    <div className="w-36 max-md:w-full">
       <Button
         type="button"
         size="sm"
@@ -101,7 +101,7 @@ function RasterSymbologySave({
   };
 
   return (
-    <div className="w-36">
+    <div className="w-36 max-md:w-full">
       <Button
         type="button"
         size="sm"
@@ -135,7 +135,7 @@ export default function RasterSymbologySaveAndShare({
   if (!activeProject || !symbology) return null;
 
   return (
-    <div className="mt-4 w-full flex items-center justify-between">
+    <div className="mt-4 w-full flex items-center justify-between max-md:flex-col max-md:items-stretch max-md:gap-2">
       {isPublicOnly(activeProject)
         ? stacBrowserUrl && (
             <div className="w-full">

--- a/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandColorRampSelect.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandColorRampSelect.tsx
@@ -50,6 +50,7 @@ export default function SingleBandColorRampSelect({
             boxShadow: 'none',
           },
         }),
+        menuPortal: (base) => ({ ...base, zIndex: 9999 }),
       }}
       theme={(theme) => ({
         ...theme,
@@ -60,6 +61,7 @@ export default function SingleBandColorRampSelect({
         },
       })}
       isSearchable
+      menuPortalTarget={document.body}
       defaultValue={
         symbology.colorRamp
           ? findMatchingColorOption(symbology.colorRamp)

--- a/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandNoDataInput.tsx
+++ b/frontend/src/components/maps/RasterSymbologySettings/SingleBandSymbologySettings/SingleBandNoDataInput.tsx
@@ -72,7 +72,7 @@ export default function SingleBandNoDataInput({
         />
         <button
           type="button"
-          className="px-3 py-1 text-sm font-medium rounded-sm border-2 bg-accent3 hover:bg-accent3-dark border-accent3 hover:border-accent3-dark text-white ease-in-out duration-300 disabled:bg-gray-200 disabled:border-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+          className="px-3 py-1 md:py-1 min-h-[44px] md:min-h-0 text-sm font-medium rounded-sm border-2 bg-accent3 hover:bg-accent3-dark border-accent3 hover:border-accent3-dark text-white ease-in-out duration-300 disabled:bg-gray-200 disabled:border-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
           onClick={handleSet}
           disabled={isSetDisabled}
         >
@@ -81,7 +81,7 @@ export default function SingleBandNoDataInput({
         {currentNodata != null && (
           <button
             type="button"
-            className="px-3 py-1 text-sm font-medium rounded-sm border-2 text-gray-700 bg-gray-200 hover:bg-gray-300 border-gray-300 hover:border-gray-400 ease-in-out duration-300"
+            className="px-3 py-1 min-h-[44px] md:min-h-0 text-sm font-medium rounded-sm border-2 text-gray-700 bg-gray-200 hover:bg-gray-300 border-gray-300 hover:border-gray-400 ease-in-out duration-300"
             onClick={handleClear}
           >
             Clear


### PR DESCRIPTION
## Summary

Overhauls the mobile layout of the map viewer to make the full feature set usable on phones. Adds a Map/List toggle pattern, enlarges touch targets throughout, adds escape hatches for full-screen viewers, and fixes several rendering bugs specific to devices with safe-area insets and narrow viewports.

## Changes

- **Frontend: Core layout**
  - Add `useIsMobile` hook (matchMedia-based, fires only on threshold crossing)
  - Add `MapListToggle` pill (List/Map tab switcher, fixed to viewport bottom)
  - Refactor `MapLayout` into a responsive two-panel layout: list panel and map panel are full-screen on mobile with the toggle switching between them
  - Add `MobileViewContext` so nested components can trigger a map-view switch without prop-drilling
  - Add `viewport-fit=cover` meta tag for edge-to-edge display on notched devices

- **Frontend: Touch targets & layout polish**
  - Enlarge map tool buttons, sidebar controls, and pagination controls for tap accuracy
  - Reflow layer-config form and fix Share modal sizing on mobile
  - Shift map overlays (color bar, opacity slider, annotation tools, measure tools) above the toggle pill
  - Clean up `ColorBarControl` to use Tailwind classes instead of inline styles
  - Polish `/explore` navbar touch targets

- **Frontend: Full-screen viewer handling**
  - Auto-switch to map view when a full-screen viewer activates (panoramic, 3DGS, point cloud Potree, compare mode)
  - Show a floating back button (bottom-right) to exit the viewer and return to the list; raised higher for panoramic to avoid overlapping the direction arrow
  - Add mobile-only "View on map →" link on active raster data products via `MobileViewContext`
  - Auto-switch to map when a point cloud is activated in map (non-Potree) mode
  - Keep list view after project selection (allows picking a flight/data product before jumping to the map)

- **Frontend: LCC viewer controls**
  - Compact button row for mobile (`md:`-gated fixed widths, tighter padding)
  - Abbreviated quality labels on mobile (V. Low / Med / V. High) using responsive span pattern; `w-fit` prevents the quality bar from stretching to the button row width

- **Frontend: CompareMap mobile fixes**
  - Constrain each `CompareMapControl` to its map half on mobile (`max-w-[calc(50%-0.75rem)]`, tighter insets)
  - Raise `CompareModeControl` to `bottom-12` and set `zIndex: 1001` to appear above the swipe divider bar
  - Reserve right-side padding on `<select>` elements so labels truncate cleanly before the native dropdown chevron

- **Frontend: Safe-area inset fixes**
  - Use `marginBottom` (not `paddingBottom`) for `env(safe-area-inset-bottom)` on the `MapListToggle` pill so the rounded background fills completely (fixes transparent strip on Android Pixel 8 / iOS)

- **Backend**
  - Minor fix in `utils.py` (related cleanup)

## Testing

- Manually tested on Android Pixel 8 (Chrome) and desktop Chrome DevTools mobile emulation (393×852)
- TypeScript: `docker compose exec frontend npx tsc --noEmit` — no errors
- All existing backend tests pass: `docker compose exec backend pytest`