### PR TITLE
[Enhancement] Add name sort control to map layers panel

### DIFF
--- a/frontend/src/components/maps/LayerPane/MapLayerSort.tsx
+++ b/frontend/src/components/maps/LayerPane/MapLayerSort.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef } from 'react';
+
+import { MapLayerProps } from '../MapLayersContext';
+import { sorter } from '../../utils';
+
+export type MapLayerSortSelection = 'atoz' | 'ztoa';
+
+const STORAGE_KEY = 'mapLayerSortPreference';
+
+const categories = [
+  { key: 'atoz', label: 'Name A-Z', title: 'Sort by layer name ascending' },
+  { key: 'ztoa', label: 'Name Z-A', title: 'Sort by layer name descending' },
+];
+
+export function sortMapLayers(
+  layers: MapLayerProps[],
+  selection: MapLayerSortSelection
+): MapLayerProps[] {
+  return [...layers].sort((a, b) => {
+    if (selection === 'ztoa') {
+      return sorter(a.name.toLowerCase(), b.name.toLowerCase(), 'desc');
+    }
+    return sorter(a.name.toLowerCase(), b.name.toLowerCase());
+  });
+}
+
+export function getMapLayerSortPreference(): MapLayerSortSelection {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'atoz' || stored === 'ztoa') {
+    return stored;
+  }
+  return 'atoz';
+}
+
+function setMapLayerSortPreference(value: MapLayerSortSelection) {
+  localStorage.setItem(STORAGE_KEY, value);
+}
+
+function getSortOptionLabel(selection: MapLayerSortSelection): string {
+  return categories.find(({ key }) => key === selection)?.label ?? 'Unknown';
+}
+
+export default function MapLayerSort({
+  sortSelection,
+  setSortSelection,
+  isOpen,
+  onOpen,
+  onClose,
+}: {
+  sortSelection: MapLayerSortSelection;
+  setSortSelection: React.Dispatch<React.SetStateAction<MapLayerSortSelection>>;
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}) {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (detailsRef.current?.open && event.target) {
+        if (!detailsRef.current.contains(event.target as HTMLElement)) {
+          detailsRef.current.removeAttribute('open');
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [onClose]);
+
+  function onChange(event: React.ChangeEvent<HTMLInputElement>) {
+    if (event.target.checked) {
+      const value = event.target.value as MapLayerSortSelection;
+      setSortSelection(value);
+      setMapLayerSortPreference(value);
+    }
+  }
+
+  return (
+    <div className="flex gap-8">
+      <div className="relative">
+        <details
+          ref={detailsRef}
+          className="group [&_summary::-webkit-details-marker]:hidden"
+          open={isOpen}
+          onToggle={(e) => {
+            if (e.currentTarget.open) {
+              onOpen();
+            } else {
+              onClose();
+            }
+          }}
+        >
+          <summary className="flex cursor-pointer items-center gap-2 border-b border-gray-400 pb-1 text-gray-900 transition hover:border-gray-600">
+            <span className="w-36 text-sm font-medium">
+              Sort by: {getSortOptionLabel(sortSelection)}
+            </span>
+            <span className="transition group-open:-rotate-180">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+                className="h-4 w-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                />
+              </svg>
+            </span>
+          </summary>
+
+          <div className="z-50 group-open:absolute group-open:start-0 group-open:top-auto group-open:mt-2">
+            <div className="rounded-sm border border-gray-200 bg-white">
+              <ul className="space-y-1 border-t border-gray-200 p-4">
+                {categories.map(({ key, label, title }) => (
+                  <li key={key}>
+                    <label
+                      htmlFor={`layer-sort-${key}`}
+                      className="inline-flex items-center gap-2"
+                      title={title}
+                    >
+                      <input
+                        type="radio"
+                        name="layerSortOption"
+                        id={`layer-sort-${key}`}
+                        className="size-5 text-accent2 border-gray-300"
+                        value={key}
+                        checked={sortSelection === key}
+                        onChange={onChange}
+                      />
+                      <span className="text-sm font-medium text-gray-700">
+                        {label}
+                      </span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/maps/LayerPane/MapLayersPanel.tsx
+++ b/frontend/src/components/maps/LayerPane/MapLayersPanel.tsx
@@ -1,6 +1,13 @@
+import { useMemo, useState } from 'react';
+
 import Checkbox from '../../Checkbox';
 import { useMapLayerContext } from '../MapLayersContext';
 import OpacitySlider from '../OpacitySlider';
+import MapLayerSort, {
+  getMapLayerSortPreference,
+  MapLayerSortSelection,
+  sortMapLayers,
+} from './MapLayerSort';
 import { getGeomTypeIcon } from './utils';
 
 export default function MapLayersPanel() {
@@ -8,6 +15,16 @@ export default function MapLayersPanel() {
     state: { layers },
     dispatch,
   } = useMapLayerContext();
+
+  const [sortSelection, setSortSelection] = useState<MapLayerSortSelection>(
+    getMapLayerSortPreference()
+  );
+  const [sortOpen, setSortOpen] = useState(false);
+
+  const sortedLayers = useMemo(
+    () => sortMapLayers(layers, sortSelection),
+    [layers, sortSelection]
+  );
 
   const updateLayerProperty = (
     layerId: string,
@@ -20,18 +37,24 @@ export default function MapLayersPanel() {
     dispatch({ type: 'SET_LAYERS', payload: updatedLayers });
   };
 
-  if (layers.length === 0) {
-    return (
-      <div className="text-sm text-slate-500 italic p-2">
-        No map layers found for this project. Add map layers from the project
-        page.
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-3">
-      {layers.map((layer) => (
+      <div className="flex justify-end">
+        <MapLayerSort
+          sortSelection={sortSelection}
+          setSortSelection={setSortSelection}
+          isOpen={sortOpen}
+          onOpen={() => setSortOpen(true)}
+          onClose={() => setSortOpen(false)}
+        />
+      </div>
+      {sortedLayers.length === 0 && (
+        <div className="text-sm text-slate-500 italic p-2">
+          No map layers found for this project. Add map layers from the project
+          page.
+        </div>
+      )}
+      {sortedLayers.map((layer) => (
         <div
           key={layer.id}
           className="flex flex-col p-2 bg-slate-50 rounded-sm"

--- a/frontend/src/components/pages/workspace/projects/mapLayers/MapLayersTable.tsx
+++ b/frontend/src/components/pages/workspace/projects/mapLayers/MapLayersTable.tsx
@@ -16,6 +16,7 @@ import { useProjectContext } from '../ProjectContext';
 import { AlertBar, Status } from '../../../../Alert';
 
 import api from '../../../../../api';
+import { sorter } from '../../../../utils';
 
 import pointIcon from '../../../../../assets/point-icon.svg';
 import lineIcon from '../../../../../assets/line-icon.svg';
@@ -67,6 +68,7 @@ export default function ProjectLayersTable() {
   const { projectId } = useParams();
 
   const [status, setStatus] = useState<Status | null>(null);
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState<string>('');
   const [previewModalOpen, setPreviewModalOpen] = useState<boolean>(false);
@@ -77,9 +79,9 @@ export default function ProjectLayersTable() {
 
   const sortedMapLayers = useMemo(() => {
     return [...mapLayers].sort((a, b) =>
-      a.layer_name.localeCompare(b.layer_name)
+      sorter(a.layer_name.toLowerCase(), b.layer_name.toLowerCase(), sortOrder)
     );
-  }, [mapLayers]);
+  }, [mapLayers, sortOrder]);
 
   const handleEdit = (layer: MapLayer) => {
     setEditingLayerId(layer.layer_id);
@@ -162,7 +164,25 @@ export default function ProjectLayersTable() {
   };
 
   return (
-    <div className="max-h-96 overflow-auto">
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-row items-center gap-2">
+        <label
+          htmlFor="mapLayerSortOrder"
+          className="text-sm font-medium text-gray-900 w-20"
+        >
+          Sort by
+        </label>
+        <select
+          id="mapLayerSortOrder"
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
+          className="w-36 px-1.5 font-semibold rounded-md border-2 border-zinc-300 text-gray-700 sm:text-sm"
+        >
+          <option value="asc">Name (A-Z)</option>
+          <option value="desc">Name (Z-A)</option>
+        </select>
+      </div>
+      <div className="max-h-96 overflow-auto">
       <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
         <thead>
           <tr className="h-12 sticky top-0 text-white bg-slate-300">
@@ -347,6 +367,7 @@ export default function ProjectLayersTable() {
           layerName={selectedPreview.name}
         />
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a sort dropdown to the Map Layers panel so users can organize their project's vector layers alphabetically. Layers previously displayed in API-return order with no way to reorder them.

## Changes

- Frontend: New `MapLayerSort` component (`LayerPane/MapLayerSort.tsx`) — a `<details>`-based dropdown matching the style of the existing Sort control in the Projects pane. Supports Name A–Z and Name Z–A. Selection persists to `localStorage` under `mapLayerSortPreference`.
- Frontend: Updated `MapLayersPanel.tsx` to render the sort control at the top of the panel and display layers in the selected order via a memoized sort.

## Testing

- `docker compose exec frontend npx tsc --noEmit` — passes with zero errors
- Manual QA: Navigate to a project with multiple map layers → open the Map Layers tab → confirm the "Sort by" dropdown appears top-right → toggle A–Z and Z–A and verify layers reorder → refresh and confirm selection persists