### PR TITLE
[Bug] Fix pagination overflow in mobile projects layer pane

### DIFF
--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -55,7 +55,7 @@ function PageNumberItems({
           return (
             <li
               key={`dots-${idx}`}
-              className="flex items-center justify-center size-11 md:size-8 rounded-sm"
+              className="flex items-center justify-center size-9 md:size-8 rounded-sm"
             >
               &#8230;
             </li>
@@ -68,7 +68,7 @@ function PageNumberItems({
               <a
                 onClick={() => updateCurrentPage(pageNumber)}
                 className={clsx(
-                  'flex items-center justify-center size-11 md:size-8 rounded-sm',
+                  'flex items-center justify-center size-9 md:size-8 rounded-sm',
                   {
                     'border border-gray-100 bg-white text-gray-900':
                       pageNumber !== currentPage,
@@ -98,7 +98,7 @@ export default function Pagination({
   updateCurrentPage: (page: number) => void;
   totalPages: number;
 }) {
-  const siblingCount = 2;
+  const siblingCount = 0;
   const totalCount = totalPages - 1;
 
   const paginationRange = usePagination({
@@ -114,7 +114,7 @@ export default function Pagination({
           <a
             onClick={() => updateCurrentPage(currentPage - 1)}
             className={clsx(
-              'inline-flex size-11 md:size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
+              'inline-flex size-9 md:size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
               {
                 'opacity-75 cursor-not-allowed': currentPage < 1,
                 'cursor-pointer': currentPage > 0,
@@ -147,7 +147,7 @@ export default function Pagination({
           <a
             onClick={() => updateCurrentPage(currentPage + 1)}
             className={clsx(
-              'inline-flex size-11 md:size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
+              'inline-flex size-9 md:size-8 items-center justify-center rounded-sm border border-gray-100 bg-white text-gray-900',
               {
                 'opacity-75 cursor-not-allowed': currentPage + 1 >= totalPages,
                 'cursor-pointer': currentPage + 1 < totalPages,

--- a/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
+++ b/frontend/src/components/maps/LayerPane/ProjectsPane.tsx
@@ -190,7 +190,7 @@ export default function ProjectsPane({ projects }: ProjectsPaneProps) {
   }
 
   return (
-    <div className="h-[calc(100%-44px)] p-4 max-md:pb-20 flex flex-col">
+    <div className="h-[calc(100%-44px)] p-4 max-md:pb-28 flex flex-col">
       <div className="h-36">
         <h1>Projects</h1>
         {hasAnyProjects && (


### PR DESCRIPTION
## Summary
The pagination control at the bottom of the projects layer pane overflowed its container on mobile, clipping buttons on the left and enabling unwanted horizontal scroll on the right. The Map/List toggle also overlapped the pagination on narrow screens.

## Changes
- Frontend: Reduced `siblingCount` from 2 to 0 in `Pagination.tsx` so fewer page buttons render, keeping the row within the panel width on narrow screens
- Frontend: Reduced mobile pagination button size from 44px (`size-11`) to 36px (`size-9`), matching desktop at 32px (`size-8`)
- Frontend: Increased `ProjectsPane` bottom padding on mobile (`pb-20` → `pb-28`) to prevent the fixed Map/List toggle from overlapping the pagination control

## Testing
- Tested on Pixel 8 (Chrome) — pagination row fits within pane with no clipping or horizontal scroll
- Navigation still works via prev/next arrows; middle page numbers show as `1 … [X] … N`
- Toggle no longer overlaps pagination when address bar is scrolled away