### PR TITLE
[Feature] Add identify tool and sync point pixel value labels for raster data products

### DIFF
--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import RedirectResponse, StreamingResponse
 from geojson_pydantic import FeatureCollection
 from pydantic import UUID4
-from rasterio.warp import transform_bounds
+from rasterio.warp import transform, transform_bounds
 from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
@@ -17,6 +17,7 @@ from app.api import deps
 from app.api.utils import get_signature_for_data_product
 from app.core.config import settings
 from app.core.limiter import limiter
+from app.models.constants import NON_RASTER_TYPES
 
 
 router = APIRouter()
@@ -217,6 +218,61 @@ def read_data_product_bounds(
 
     # return bounds
     return {"bounds": list(wgs84_bounds)}
+
+
+@router.get("/point", response_model=schemas.data_product.DataProductPointValue)
+@limiter.limit("60/minute")
+def read_data_product_point_value(
+    request: Request,
+    data_product_id: UUID4,
+    lon: float,
+    lat: float,
+    current_user: Optional[models.User] = Depends(deps.get_optional_current_user),
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    if os.environ.get("RUNNING_TESTS") == "1":
+        upload_dir = settings.TEST_STATIC_DIR
+    else:
+        upload_dir = settings.STATIC_DIR
+
+    # get user id if available
+    user_id = None
+    if current_user:
+        user_id = current_user.id
+
+    # check if file is public or if user has access through project member role
+    data_product = crud.data_product.get_public_data_product_by_id(
+        db, file_id=data_product_id, upload_dir=upload_dir, user_id=user_id
+    )
+    if not data_product:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        )
+
+    # reject non-raster products
+    if data_product.data_type in NON_RASTER_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Point value sampling is only available for raster data products",
+        )
+
+    # sample raster at the given coordinates
+    try:
+        with rasterio.open(data_product.filepath) as dataset:
+            xs, ys = transform("EPSG:4326", dataset.crs, [lon], [lat])
+            sample = next(dataset.sample([(xs[0], ys[0])]))
+            nodata = dataset.nodata
+        values = [
+            None if (nodata is not None and float(v) == nodata) else float(v)
+            for v in sample
+        ]
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Unable to sample data product at the given coordinates",
+        )
+
+    return {"coordinates": [lon, lat], "values": values}
 
 
 @router.get(

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -17,6 +17,7 @@ from .data_product import (
     DataProduct,
     DataProductBands,
     DataProductCreate,
+    DataProductPointValue,
     DataProductUpdate,
     DataProductUpdateDataType,
     ProcessingRequest,

--- a/backend/app/schemas/data_product.py
+++ b/backend/app/schemas/data_product.py
@@ -83,6 +83,11 @@ class DataProductBoundingBox(BaseModel):
     bounds: List[float]
 
 
+class DataProductPointValue(BaseModel):
+    coordinates: List[float]
+    values: List[Optional[float]]
+
+
 class DataProductBand(BaseModel):
     name: str
     description: str

--- a/backend/app/tests/api/api_v1/test_public.py
+++ b/backend/app/tests/api/api_v1/test_public.py
@@ -8,6 +8,13 @@ from app.core.config import settings
 from app.schemas.file_permission import FilePermissionUpdate
 from app.tests.utils.data_product import SampleDataProduct
 
+# Center of test.tif (EPSG:32616, WGS84 bounds approx -86.9445, 41.4440)
+TEST_TIF_CENTER_LON = -86.94447585281846
+TEST_TIF_CENTER_LAT = 41.44403702360668
+# Point within UTM Zone 16N but well outside the raster footprint
+TEST_TIF_OUTSIDE_LON = -87.5
+TEST_TIF_OUTSIDE_LAT = 41.0
+
 
 def test_read_public_data_product_bounds(client: TestClient, db: Session):
     # create data product owned by random user
@@ -66,3 +73,97 @@ def test_read_projected_data_product_bounds_with_authorized_user(
         -86.94442522789655,
         41.44408204910461,
     ]
+
+
+def test_read_data_product_point_value(client: TestClient, db: Session):
+    """Public data product sampled at raster center returns a numeric value."""
+    data_product = SampleDataProduct(db)
+    # make data product public
+    file_permission = crud.file_permission.get_by_data_product(
+        db, file_id=data_product.obj.id
+    )
+    assert file_permission
+    crud.file_permission.update(
+        db, db_obj=file_permission, obj_in=FilePermissionUpdate(is_public=True)
+    )
+    response = client.get(
+        f"{settings.API_V1_STR}/public/point"
+        f"?data_product_id={data_product.obj.id}"
+        f"&lon={TEST_TIF_CENTER_LON}&lat={TEST_TIF_CENTER_LAT}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    response_data = response.json()
+    assert "coordinates" in response_data
+    assert "values" in response_data
+    assert len(response_data["values"]) == 1
+    assert response_data["values"][0] is not None
+    assert isinstance(response_data["values"][0], float)
+
+
+def test_read_data_product_point_value_outside_footprint(
+    client: TestClient, db: Session
+):
+    """Sampling outside the raster footprint returns null (nodata) for all bands."""
+    data_product = SampleDataProduct(db)
+    file_permission = crud.file_permission.get_by_data_product(
+        db, file_id=data_product.obj.id
+    )
+    assert file_permission
+    crud.file_permission.update(
+        db, db_obj=file_permission, obj_in=FilePermissionUpdate(is_public=True)
+    )
+    response = client.get(
+        f"{settings.API_V1_STR}/public/point"
+        f"?data_product_id={data_product.obj.id}"
+        f"&lon={TEST_TIF_OUTSIDE_LON}&lat={TEST_TIF_OUTSIDE_LAT}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    response_data = response.json()
+    assert response_data["values"] == [None]
+
+
+def test_read_data_product_point_value_not_found(client: TestClient, db: Session):
+    """Non-public data product without authentication returns 404."""
+    data_product = SampleDataProduct(db)
+    response = client.get(
+        f"{settings.API_V1_STR}/public/point"
+        f"?data_product_id={data_product.obj.id}"
+        f"&lon={TEST_TIF_CENTER_LON}&lat={TEST_TIF_CENTER_LAT}"
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_read_data_product_point_value_authorized_user(
+    client: TestClient, db: Session, normal_user_access_token: str
+):
+    """Data product owner can sample even when the product is not public."""
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    data_product = SampleDataProduct(db, user=current_user)
+    response = client.get(
+        f"{settings.API_V1_STR}/public/point"
+        f"?data_product_id={data_product.obj.id}"
+        f"&lon={TEST_TIF_CENTER_LON}&lat={TEST_TIF_CENTER_LAT}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    response_data = response.json()
+    assert response_data["values"][0] is not None
+
+
+def test_read_data_product_point_value_non_raster(client: TestClient, db: Session):
+    """Non-raster data products return 400."""
+    data_product = SampleDataProduct(db, data_type="point_cloud")
+    file_permission = crud.file_permission.get_by_data_product(
+        db, file_id=data_product.obj.id
+    )
+    assert file_permission
+    crud.file_permission.update(
+        db, db_obj=file_permission, obj_in=FilePermissionUpdate(is_public=True)
+    )
+    response = client.get(
+        f"{settings.API_V1_STR}/public/point"
+        f"?data_product_id={data_product.obj.id}"
+        f"&lon={TEST_TIF_CENTER_LON}&lat={TEST_TIF_CENTER_LAT}"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/frontend/src/components/maps/CompareMap/CompareMap.tsx
+++ b/frontend/src/components/maps/CompareMap/CompareMap.tsx
@@ -7,6 +7,7 @@ import CompareToolsControl from './CompareToolsControl';
 import GridOverlay from './GridOverlay';
 import PointSyncMarkers from './PointSyncMarkers';
 import SwipeSlider from './SwipeSlider';
+import { usePointValue } from './usePointValue';
 import CompareModeControl, { Mode } from './CompareModeControl';
 import ProjectBoundary from '../ProjectBoundary';
 import { useMapContext } from '../MapContext';
@@ -127,6 +128,16 @@ export default function CompareMap() {
           ({ id }) => id === mapComparisonState.right?.dataProductId
         ) || null,
     [flights, mapComparisonState.right]
+  );
+
+  // Point value sampling for both sides
+  const { data: leftPointValue, loading: leftValueLoading } = usePointValue(
+    selectedLeftDataProduct,
+    syncPoint
+  );
+  const { data: rightPointValue, loading: rightValueLoading } = usePointValue(
+    selectedRightDataProduct,
+    syncPoint
   );
 
   // Symbology initialization for left data product
@@ -295,7 +306,13 @@ export default function CompareMap() {
 
         {/* Point sync marker */}
         {pointSyncActive && syncPoint && (
-          <PointSyncMarkers syncPoint={syncPoint} side="left" />
+          <PointSyncMarkers
+            syncPoint={syncPoint}
+            side="left"
+            dataProduct={selectedLeftDataProduct}
+            value={leftPointValue?.values ?? null}
+            loading={leftValueLoading}
+          />
         )}
 
         <ScaleControl />
@@ -342,7 +359,13 @@ export default function CompareMap() {
 
         {/* Point sync marker */}
         {pointSyncActive && syncPoint && (
-          <PointSyncMarkers syncPoint={syncPoint} side="right" />
+          <PointSyncMarkers
+            syncPoint={syncPoint}
+            side="right"
+            dataProduct={selectedRightDataProduct}
+            value={rightPointValue?.values ?? null}
+            loading={rightValueLoading}
+          />
         )}
 
         <ScaleControl />

--- a/frontend/src/components/maps/CompareMap/PointSyncMarkers.tsx
+++ b/frontend/src/components/maps/CompareMap/PointSyncMarkers.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Marker } from 'react-map-gl/maplibre';
+import { FaCircleInfo } from 'react-icons/fa6';
+
+import { DataProduct } from '../../pages/workspace/projects/Project';
+import { useRasterSymbologyContext } from '../RasterSymbologyContext';
+import { buildLabel } from '../utils';
 
 type SyncPoint = {
   lng: number;
@@ -10,11 +15,21 @@ type SyncPoint = {
 type PointSyncMarkersProps = {
   syncPoint: SyncPoint;
   side: 'left' | 'right';
+  dataProduct?: DataProduct | null;
+  value?: (number | null)[] | null;
+  loading?: boolean;
 };
 
-export default function PointSyncMarkers({ syncPoint, side }: PointSyncMarkersProps) {
+export default function PointSyncMarkers({
+  syncPoint,
+  side,
+  dataProduct,
+  value,
+  loading = false,
+}: PointSyncMarkersProps) {
   const isOrigin = syncPoint.originSide === side;
   const [showPing, setShowPing] = useState(true);
+  const { state: symbologyState } = useRasterSymbologyContext();
 
   // Reset ping animation on each new syncPoint, then stop after 2s
   useEffect(() => {
@@ -22,6 +37,9 @@ export default function PointSyncMarkers({ syncPoint, side }: PointSyncMarkersPr
     const timer = setTimeout(() => setShowPing(false), 2000);
     return () => clearTimeout(timer);
   }, [syncPoint.lng, syncPoint.lat]);
+
+  const label = buildLabel(value, dataProduct, symbologyState);
+  const showLabel = loading || label !== '';
 
   return (
     <Marker longitude={syncPoint.lng} latitude={syncPoint.lat} anchor="center">
@@ -38,6 +56,33 @@ export default function PointSyncMarkers({ syncPoint, side }: PointSyncMarkersPr
           className="relative inline-flex rounded-full w-3 h-3 border-2 border-white shadow"
           style={{ backgroundColor: isOrigin ? '#2563eb' : '#ee6c4d' }}
         />
+        {/* Value label — shown below the dot once values are available */}
+        {showLabel && (
+          <div className="absolute top-full mt-1.5 left-1/2 -translate-x-1/2 pointer-events-none whitespace-nowrap">
+            <div
+              className="rounded-lg overflow-hidden"
+              style={{ boxShadow: '0 4px 14px rgba(0,0,0,0.18)' }}
+            >
+              <div
+                className="flex items-center gap-1 px-2 py-1"
+                style={{
+                  backgroundColor: isOrigin ? '#2563eb' : '#ee6c4d',
+                  color: 'white',
+                }}
+              >
+                <FaCircleInfo className="w-2.5 h-2.5 shrink-0" />
+                <span className="text-[10px] font-semibold tracking-wide uppercase">
+                  Pixel Value
+                </span>
+              </div>
+              <div className="px-2 py-1.5 bg-white">
+                <span className="text-xs font-medium text-gray-800">
+                  {loading ? '…' : label}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </Marker>
   );

--- a/frontend/src/components/maps/CompareMap/usePointValue.ts
+++ b/frontend/src/components/maps/CompareMap/usePointValue.ts
@@ -1,0 +1,3 @@
+// Re-exports from the shared maps-level hook.
+// Import directly from '../usePointValue' in new consumers.
+export { usePointValue, type PointValueResult, type IdentifyPoint } from '../usePointValue';

--- a/frontend/src/components/maps/HomeMap.css
+++ b/frontend/src/components/maps/HomeMap.css
@@ -1,3 +1,29 @@
 .maplibregl-popup-close-button {
     margin-right: 5px;
 }
+
+/* Identify tool popup */
+.identify-popup .maplibregl-popup-content {
+    padding: 0;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+    min-width: 140px;
+}
+
+.identify-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip {
+    border-bottom-color: #3d5a80;
+}
+
+.identify-popup .maplibregl-popup-close-button {
+    color: rgba(255, 255, 255, 0.8);
+    margin-right: 0;
+    padding: 4px 6px;
+    font-size: 14px;
+    line-height: 1;
+}
+
+.identify-popup .maplibregl-popup-close-button:hover {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.15);
+}

--- a/frontend/src/components/maps/HomeMap.tsx
+++ b/frontend/src/components/maps/HomeMap.tsx
@@ -19,6 +19,8 @@ import AnnotationToolsToggle from './AnnotationToolsToggle';
 import ColorBarControl from './ColorBarControl';
 import DataProductZoom from './DataProductZoom';
 import GeocoderControl from './GeocoderControl';
+import IdentifyControl from './IdentifyControl';
+import IdentifyPopup from './IdentifyPopup';
 import ProjectCluster from './ProjectCluster';
 import FeaturePopup from './FeaturePopup';
 import MeasureToolsToggle from './MeasureToolsToggle';
@@ -41,7 +43,11 @@ import {
 } from './styles/basemapStyles';
 
 import { isPublicOnly, isSingleBand } from './utils';
+import { IdentifyPoint } from './usePointValue';
 import { BBox } from './Maps';
+
+// Data product types that are not sampable rasters (mirrors backend NON_RASTER_TYPES)
+const NON_RASTER_TYPES = ['panoramic', 'point_cloud', '3dgs'];
 
 export type PopupInfoProps = {
   feature: Feature;
@@ -54,6 +60,8 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
   const [activeProjectBBox, setActiveProjectBBox] = useState<BBox | null>(null);
   const [isMapReady, setIsMapReady] = useState(false);
   const [popupInfo, setPopupInfo] = useState<PopupInfoProps | null>(null);
+  const [identifyActive, setIdentifyActive] = useState(false);
+  const [identifyPoint, setIdentifyPoint] = useState<IdentifyPoint | null>(null);
   const [config, setConfig] = useState<{ osmLabelFilter?: string } | null>(
     null,
   );
@@ -104,7 +112,33 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
     }
   }, [activeProject, isMapReady]);
 
+  // True when a raster data product that supports point sampling is active
+  const isActivatedRaster =
+    !!activeProject &&
+    !!activeDataProduct &&
+    !NON_RASTER_TYPES.includes(activeDataProduct.data_type) &&
+    (activeDataProduct.stac_properties?.raster?.length ?? 0) > 0;
+
+  // Reset identify tool when no raster is active (e.g. product deactivated or changed to point cloud)
+  useEffect(() => {
+    if (!isActivatedRaster) {
+      setIdentifyActive(false);
+      setIdentifyPoint(null);
+    }
+  }, [isActivatedRaster]);
+
+  // Close any open popup when the active data product changes
+  useEffect(() => {
+    setIdentifyPoint(null);
+  }, [activeDataProduct?.id]);
+
   const handleMapClick = (event: MapLayerMouseEvent) => {
+    // Identify tool takes over map clicks while active
+    if (identifyActive) {
+      setIdentifyPoint({ lng: event.lngLat.lng, lat: event.lngLat.lat });
+      return;
+    }
+
     const map: maplibregl.Map = event.target;
 
     if (map.getLayer('unclustered-point')) {
@@ -226,6 +260,7 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       maxZoom={25}
       onClick={handleMapClick}
       onMoveEnd={handleMoveEnd}
+      cursor={identifyActive ? 'crosshair' : undefined}
     >
       {/* Display marker cluster for project centroids when no project is active */}
       {!activeProject && (
@@ -306,6 +341,22 @@ export default function HomeMap({ layers }: { layers: MapLayerProps[] }) {
       {!activeProject && <GeocoderControl />}
 
       <NavigationControl />
+      {/* Identify tool button — sits directly below the zoom +/- controls */}
+      <IdentifyControl
+        active={identifyActive}
+        disabled={!isActivatedRaster}
+        onClick={() => setIdentifyActive((v) => !v)}
+      />
+
+      {/* Identify value popup */}
+      {identifyActive && identifyPoint && activeDataProduct && (
+        <IdentifyPopup
+          dataProduct={activeDataProduct}
+          point={identifyPoint}
+          onClose={() => setIdentifyPoint(null)}
+        />
+      )}
+
       <ScaleControl />
     </Map>
   );

--- a/frontend/src/components/maps/IdentifyControl.tsx
+++ b/frontend/src/components/maps/IdentifyControl.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { useControl } from 'react-map-gl/maplibre';
+import { FaCircleInfo } from 'react-icons/fa6';
+
+type IdentifyControlProps = {
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+};
+
+/**
+ * A toggle button that sits directly below the map's NavigationControl zoom
+ * buttons, styled to match the native 29×29 px maplibre control buttons.
+ * When active the button highlights blue; when disabled it is muted.
+ */
+export default function IdentifyControl({
+  active,
+  disabled,
+  onClick,
+}: IdentifyControlProps) {
+  // Create the maplibre ctrl DOM container once and register it as a control
+  const container = useMemo(() => {
+    const el = document.createElement('div');
+    el.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+    el.style.overflow = 'hidden';
+    return el;
+  }, []);
+
+  useControl(
+    () => ({
+      onAdd: () => container,
+      onRemove: () => container.remove(),
+    }),
+    { position: 'top-right' }
+  );
+
+  // Portal a React-managed button into the maplibre ctrl container so we get
+  // full React event handling while the button lives in the map's DOM hierarchy.
+  return createPortal(
+    <button
+      type="button"
+      title="Identify"
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        width: 29,
+        height: 29,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: active ? 'var(--color-accent2)' : undefined,
+        color: active ? '#ffffff' : '#333333',
+        opacity: disabled ? 0.4 : undefined,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+      }}
+      className="border-0 outline-none transition-colors"
+    >
+      <FaCircleInfo className="w-3.5 h-3.5" />
+    </button>,
+    container
+  );
+}

--- a/frontend/src/components/maps/IdentifyPopup.tsx
+++ b/frontend/src/components/maps/IdentifyPopup.tsx
@@ -1,0 +1,64 @@
+import { Popup } from 'react-map-gl/maplibre';
+import { FaCircleInfo } from 'react-icons/fa6';
+
+import { DataProduct } from '../pages/workspace/projects/Project';
+import { useRasterSymbologyContext } from './RasterSymbologyContext';
+import { usePointValue, IdentifyPoint } from './usePointValue';
+import { buildLabel } from './utils';
+
+type IdentifyPopupProps = {
+  dataProduct: DataProduct;
+  point: IdentifyPoint;
+  onClose: () => void;
+};
+
+/**
+ * Popup that samples the raster cell value at a clicked point and displays it.
+ * - Single-band products show a value with unit (e.g. "187.42 metre").
+ * - Multiband/ortho products show R/G/B values matched to the displayed channels.
+ * - Points outside the raster footprint or nodata pixels show "No data".
+ */
+export default function IdentifyPopup({
+  dataProduct,
+  point,
+  onClose,
+}: IdentifyPopupProps) {
+  const { data, loading, error } = usePointValue(dataProduct, point);
+  const { state: symbologyState } = useRasterSymbologyContext();
+
+  let content: string;
+  if (loading) {
+    content = 'Sampling…';
+  } else if (error) {
+    content = 'Unable to read value';
+  } else {
+    content = buildLabel(data?.values ?? null, dataProduct, symbologyState);
+  }
+
+  return (
+    <Popup
+      anchor="top"
+      longitude={point.lng}
+      latitude={point.lat}
+      onClose={onClose}
+      closeOnClick={false}
+      maxWidth="240px"
+      className="identify-popup"
+    >
+      <div>
+        <div
+          className="flex items-center gap-1.5 px-3 py-1.5 pr-7"
+          style={{ backgroundColor: 'var(--color-primary)', color: 'white' }}
+        >
+          <FaCircleInfo className="w-3 h-3 shrink-0" />
+          <span className="text-xs font-semibold tracking-wide uppercase">
+            Pixel Value
+          </span>
+        </div>
+        <div className="px-3 py-2 bg-white">
+          <p className="text-sm font-medium text-gray-800">{content}</p>
+        </div>
+      </div>
+    </Popup>
+  );
+}

--- a/frontend/src/components/maps/usePointValue.ts
+++ b/frontend/src/components/maps/usePointValue.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react';
+
+import api from '../../api';
+import { DataProduct } from '../pages/workspace/projects/Project';
+
+/** Minimal point type — only lng/lat are required for the sampling request. */
+export type IdentifyPoint = {
+  lng: number;
+  lat: number;
+};
+
+export type PointValueResult = {
+  coordinates: [number, number];
+  values: (number | null)[];
+};
+
+type UsePointValueReturn = {
+  data: PointValueResult | null;
+  loading: boolean;
+  error: boolean;
+};
+
+/**
+ * Fetches the raster cell value(s) at a given point for a data product via
+ * GET /public/point. Re-fetches whenever the point coordinates or data product
+ * id change. Cancels stale in-flight requests on re-fire or cleanup.
+ */
+export function usePointValue(
+  dataProduct: DataProduct | null,
+  point: IdentifyPoint | null
+): UsePointValueReturn {
+  const [data, setData] = useState<PointValueResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    // clear state when tool is toggled off or no data product is selected
+    if (!point || !dataProduct) {
+      setData(null);
+      setLoading(false);
+      setError(false);
+      return;
+    }
+
+    // cancel any in-flight request before starting a new one
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(false);
+    setData(null);
+
+    api
+      .get<PointValueResult>('/public/point', {
+        params: {
+          data_product_id: dataProduct.id,
+          lon: point.lng,
+          lat: point.lat,
+        },
+        signal: controller.signal,
+      })
+      .then((res) => {
+        setData(res.data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        // ignore cancellation errors from rapid re-clicks
+        if (err.code === 'ERR_CANCELED') return;
+        setError(true);
+        setLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [dataProduct?.id, point?.lng, point?.lat]);
+
+  return { data, loading, error };
+}

--- a/frontend/src/components/maps/utils.tsx
+++ b/frontend/src/components/maps/utils.tsx
@@ -722,14 +722,72 @@ const fitMapToGeoJSON = (
   }
 };
 
+/**
+ * Format a single number for display: integers as integers, floats up to 2 d.p.
+ * @param v Numeric value.
+ * @returns Formatted string.
+ */
+function formatNum(v: number): string {
+  return Number.isInteger(v) ? v.toString() : parseFloat(v.toFixed(2)).toString();
+}
+
+/**
+ * Build a human-readable label string for raster cell value(s).
+ * - Single-band: "{value} {unit}" (unit omitted if empty).
+ * - Multiband: "R: {r}  G: {g}  B: {b}" using the displayed symbology's band indices.
+ * - All-nodata or no values: "No data".
+ * @param values  Per-band values from /public/point (null = nodata/out-of-range).
+ * @param dataProduct  Active data product.
+ * @param symbologyState  Current raster symbology state keyed by data product id.
+ */
+function buildLabel(
+  values: (number | null)[] | null | undefined,
+  dataProduct: DataProduct | null | undefined,
+  symbologyState: Record<
+    string,
+    { symbology: SingleBandSymbology | MultibandSymbology | null } | undefined
+  >
+): string {
+  if (!values || !dataProduct) return '';
+
+  const allNodata = values.every((v) => v === null);
+  if (allNodata) return 'No data';
+
+  if (isSingleBand(dataProduct)) {
+    const v = values[0];
+    if (v == null) return 'No data';
+    const unit = dataProduct.stac_properties?.raster?.[0]?.unit;
+    return unit ? `${formatNum(v)} ${unit}` : formatNum(v);
+  }
+
+  // multiband — label channels using the displayed symbology if available
+  const sym = symbologyState[dataProduct.id]?.symbology;
+  if (sym && 'red' in sym) {
+    const mb = sym as MultibandSymbology;
+    const fmt = (v: number | null | undefined) =>
+      v == null ? 'n/a' : formatNum(v);
+    const r = values[mb.red.idx - 1];
+    const g = values[mb.green.idx - 1];
+    const b = values[mb.blue.idx - 1];
+    return `R: ${fmt(r)}  G: ${fmt(g)}  B: ${fmt(b)}`;
+  }
+
+  // fallback: enumerate all bands
+  return values
+    .map((v, i) => `B${i + 1}: ${v == null ? 'n/a' : formatNum(v)}`)
+    .join('  ');
+}
+
 export {
   areProjectsEqual,
+  buildLabel,
   calculateBoundsFromGeoJSON,
   createDefaultSingleBandSymbology,
   createDefaultMultibandSymbology,
   filterValidGeoJSONFeatures,
   filterValidProjects,
   fitMapToGeoJSON,
+  formatNum,
   getCategory,
   getDefaultStyle,
   getHillshade,


### PR DESCRIPTION
## Summary
Adds a raster pixel value identify tool to the home map and inline pixel value labels to the compare map's point-sync markers. A new public backend endpoint handles raster sampling via rasterio so values are accurate regardless of TiTiler or Varnish configuration.

## Changes
- Backend: New `GET /public/point` endpoint that reprojects WGS84 coordinates to the raster's native CRS and samples with rasterio; `DataProductPointValue` schema; 5 new tests covering center, outside footprint, 404, auth, and non-raster cases
- Frontend: `usePointValue` hook (shared between HomeMap and CompareMap) with AbortController cancellation; `buildLabel` / `formatNum` utilities in `utils.tsx` that format single-band and multiband (R/G/B) values; `IdentifyControl` toggle button injected into the maplibre control stack below zoom +/−; `IdentifyPopup` with styled header/body layout; popup auto-closes when the active data product changes
- Frontend: `PointSyncMarkers` updated to accept sampled values and display matching styled labels; `CompareMap` wires up `usePointValue` for both sides

## Testing
- `docker compose exec backend pytest backend/app/tests/api/api_v1/test_public.py` — 8/8 passing
- `docker compose exec frontend npx tsc --noEmit` — no errors
- Manual QA:
  - Activate a raster on the home map → identify button becomes enabled; click it → cursor changes to crosshair and button fills accent orange
  - Click the map → popup appears below the point showing the sampled value ("187.42 metre" for single-band, "R: 210  G: 175  B: 204" for ortho); clicking a new spot moves the popup in a single click
  - Switch to a different raster → popup closes automatically; tool stays active
  - Deactivate raster or switch to point cloud → button disables and popup clears
  - In the compare map, click a sync point → value labels appear below the dot on both sides; blue header on origin side, orange on non-origin side; "…" shown while loading