### PR TITLE
[Feature] Add XML metadata attachment for data products

### DIFF
--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import xml.etree.ElementTree as ET
 from io import BytesIO
 from pathlib import Path
 from typing import Annotated, Any, Optional, Sequence, Union
@@ -9,7 +10,7 @@ from urllib.parse import urlparse, parse_qs
 from uuid import UUID, uuid4
 
 import segno
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 from geojson_pydantic import Feature, FeatureCollection, Polygon, MultiPolygon
@@ -34,11 +35,13 @@ from app.schemas.shortened_url import ShortenedUrlApiResponse, UrlPayload
 from app.utils.job_manager import JobManager
 from app.utils.tusd.post_processing import process_data_product_uploaded_to_tusd
 
-
 router = APIRouter()
 
 
 logger = logging.getLogger("__name__")
+
+
+XML_FILE_MAX_SIZE = 10 * 1024 * 1024  # 10 MiB
 
 
 def get_static_dir() -> str:
@@ -329,6 +332,126 @@ def deactivate_data_product(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Unable to deactivate"
         )
     return deactivated_data_product
+
+
+@router.post(
+    "/{data_product_id}/xml",
+    response_model=schemas.DataProductMetadata,
+    status_code=status.HTTP_201_CREATED,
+)
+def upload_data_product_xml(
+    data_product_id: UUID,
+    file: UploadFile,
+    current_user: models.User = Depends(deps.get_current_approved_user),
+    flight: models.Flight = Depends(deps.can_read_write_flight),
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    """Uploads XML file and associates it with a data product. Only one XML file
+    can be associated with a data product at a time. The existing XML file must
+    be deleted before a new one can be uploaded.
+    """
+    if not flight:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Flight not found"
+        )
+
+    upload_dir = get_static_dir()
+    data_product = crud.data_product.get_single_by_id(
+        db,
+        data_product_id=data_product_id,
+        upload_dir=upload_dir,
+        user_id=current_user.id,
+    )
+    if not data_product:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        )
+
+    # only accept files with an .xml extension
+    if not file.filename or Path(file.filename).suffix.lower() != ".xml":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File must have an .xml extension",
+        )
+
+    # limit file size and verify file contains well-formed xml
+    xml_content = file.file.read()
+    if len(xml_content) > XML_FILE_MAX_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="XML file exceeds maximum size of 10 MB",
+        )
+    try:
+        ET.fromstring(xml_content)
+    except ET.ParseError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File is not well-formed XML",
+        )
+
+    # only one xml file allowed per data product
+    existing_metadata = crud.data_product_metadata.get_by_data_product(
+        db, category="xml", data_product_id=data_product_id
+    )
+    if len(existing_metadata) > 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Data product already has an XML file. "
+                "Delete it before uploading a new one."
+            ),
+        )
+
+    # write xml file to data product directory
+    data_product_dir = utils.get_data_product_dir(
+        str(flight.project_id), str(flight.id), str(data_product_id)
+    )
+    xml_filepath = data_product_dir / f"{uuid4()}.xml"
+    with open(xml_filepath, "wb") as xml_file:
+        xml_file.write(xml_content)
+
+    metadata_in = schemas.DataProductMetadataCreate(
+        category="xml",
+        properties={
+            "filepath": str(xml_filepath),
+            "original_filename": file.filename,
+            "file_size": len(xml_content),
+        },
+    )
+    metadata = crud.data_product_metadata.create_with_data_product(
+        db, obj_in=metadata_in, data_product_id=data_product_id
+    )
+    return metadata
+
+
+@router.delete("/{data_product_id}/xml", response_model=schemas.DataProductMetadata)
+def delete_data_product_xml(
+    data_product_id: UUID,
+    current_user: models.User = Depends(deps.get_current_approved_user),
+    flight: models.Flight = Depends(deps.can_read_write_flight),
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    """Removes XML file associated with a data product."""
+    if not flight:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Flight not found"
+        )
+
+    existing_metadata = crud.data_product_metadata.get_by_data_product(
+        db, category="xml", data_product_id=data_product_id
+    )
+    if len(existing_metadata) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="XML file not found"
+        )
+
+    xml_metadata = existing_metadata[0]
+    xml_filepath = xml_metadata.properties.get("filepath")
+    if xml_filepath and os.path.exists(xml_filepath):
+        os.remove(xml_filepath)
+
+    removed_metadata = crud.data_product_metadata.remove(db, id=xml_metadata.id)
+    return removed_metadata
 
 
 @router.post("/create_from_ext_storage", status_code=status.HTTP_202_ACCEPTED)

--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -22,6 +22,7 @@ from app import crud, models, schemas
 from app.api import deps, utils
 from app.core import security
 from app.core.config import settings
+from app.models.constants import XML_METADATA_EXCLUDED_TYPES
 from app.models.vector_layer import VectorLayer
 from app.schemas.data_product_metadata import ZonalStatisticsProps
 from app.schemas.job import Status
@@ -365,6 +366,16 @@ def upload_data_product_xml(
     if not data_product:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        )
+
+    # xml metadata limited to raster and point cloud data products
+    if data_product.data_type.lower() in XML_METADATA_EXCLUDED_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "XML metadata is only supported for raster and point cloud "
+                "data products"
+            ),
         )
 
     # only accept files with an .xml extension

--- a/backend/app/crud/crud_data_product.py
+++ b/backend/app/crud/crud_data_product.py
@@ -17,6 +17,7 @@ from app.crud.base import CRUDBase
 from app.db.session import SessionLocal
 from app.models.constants import NON_RASTER_TYPES, PROCESSING_JOB_NAMES
 from app.models.data_product import DataProduct
+from app.models.data_product_metadata import DataProductMetadata
 from app.models.flight import Flight
 from app.models.project import Project
 from app.models.job import Job
@@ -65,6 +66,12 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
                 UserStyle.user_id == user_id,
             )
         )
+        xml_metadata_query = select(DataProductMetadata).where(
+            and_(
+                DataProductMetadata.data_product_id == data_product_id,
+                DataProductMetadata.category == "xml",
+            )
+        )
         with db as session:
             data_product = session.execute(data_product_query).scalar_one_or_none()
             user_style = session.execute(user_style_query).scalar_one_or_none()
@@ -74,6 +81,9 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
                 is_status_set = set_status_attr(data_product, data_product.jobs)
                 if user_style:
                     set_user_style_attr(data_product, user_style.settings)
+                xml_metadata = session.execute(xml_metadata_query).scalar_one_or_none()
+                if xml_metadata:
+                    set_xml_metadata_attr(data_product, xml_metadata)
                 # do not return if record shows initial processing incomplete, and
                 # there is not a job for the initial processing
                 if is_status_set:
@@ -153,6 +163,21 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
                         user_style
                     )
 
+            # Batch load all xml metadata to avoid N+1 queries
+            xml_metadata_by_data_product_id = {}
+            if data_product_ids:
+                xml_metadata_query = select(DataProductMetadata).where(
+                    and_(
+                        DataProductMetadata.data_product_id.in_(data_product_ids),
+                        DataProductMetadata.category == "xml",
+                    )
+                )
+                xml_metadata_rows = session.execute(xml_metadata_query).scalars().all()
+                for xml_metadata_row in xml_metadata_rows:
+                    xml_metadata_by_data_product_id[
+                        xml_metadata_row.data_product_id
+                    ] = xml_metadata_row
+
             updated_data_products = []
             for data_product in data_products:
                 # if not a non-raster type, find user style settings for data product
@@ -167,6 +192,9 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
                 set_signature_attr(data_product)
                 set_url_attr(data_product, upload_dir)
                 is_status_set = set_status_attr(data_product, data_product.jobs)
+                xml_metadata = xml_metadata_by_data_product_id.get(data_product.id)
+                if xml_metadata:
+                    set_xml_metadata_attr(data_product, xml_metadata)
 
                 # Only include data product if a status was set
                 if is_status_set and hasattr(data_product, "status"):
@@ -222,9 +250,7 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
 
         return crud.data_product.get(db, id=data_product_id)
 
-    def update_s3_url(
-        self, db: Session, data_product_id: UUID, s3_url: str
-    ) -> None:
+    def update_s3_url(self, db: Session, data_product_id: UUID, s3_url: str) -> None:
         """Set the s3_url for a single data product."""
         stmt = (
             update(DataProduct)
@@ -342,7 +368,7 @@ def set_spatial_metadata_attrs(data_product: DataProduct) -> None:
                     .values(
                         bbox=metadata["bbox"],
                         crs=metadata["crs"],
-                        resolution=metadata["resolution"]
+                        resolution=metadata["resolution"],
                     )
                 )
                 migration_session.execute(update_stmt)
@@ -386,6 +412,37 @@ def set_url_attr(data_product_obj: DataProduct, upload_dir: str) -> None:
 
 def set_user_style_attr(data_product_obj: DataProduct, user_style: Dict) -> None:
     setattr(data_product_obj, "user_style", user_style)
+
+
+def set_xml_metadata_attr(
+    data_product_obj: DataProduct, xml_metadata: DataProductMetadata
+) -> None:
+    """Sets XML file metadata and contents to the "xml_metadata" attribute.
+
+    Args:
+        data_product_obj (DataProduct): Data product object.
+        xml_metadata (DataProductMetadata): Metadata record with category "xml".
+    """
+    filepath = xml_metadata.properties.get("filepath")
+    if not filepath:
+        return
+    try:
+        with open(filepath, "r") as xml_file:
+            content = xml_file.read()
+    except OSError as e:
+        logger.warning(
+            f"Unable to read XML file for data product {data_product_obj.id}: {e}"
+        )
+        return
+    setattr(
+        data_product_obj,
+        "xml_metadata",
+        {
+            "original_filename": xml_metadata.properties.get("original_filename", ""),
+            "file_size": xml_metadata.properties.get("file_size", len(content)),
+            "content": content,
+        },
+    )
 
 
 def calculate_raster_metadata(filepath: str) -> Optional[Dict]:

--- a/backend/app/models/constants.py
+++ b/backend/app/models/constants.py
@@ -7,6 +7,9 @@ across CRUD operations and avoid code duplication.
 # Data type classifications for data products
 NON_RASTER_TYPES = frozenset({"panoramic", "point_cloud", "3dgs"})
 
+# Data product types that cannot have XML metadata attached
+XML_METADATA_EXCLUDED_TYPES = frozenset({"panoramic", "3dgs"})
+
 # Job names used for filtering processing jobs
 PROCESSING_JOB_NAMES = frozenset({
     "upload-data-product",

--- a/backend/app/schemas/data_product.py
+++ b/backend/app/schemas/data_product.py
@@ -64,6 +64,12 @@ class DataProductSignature(BaseModel):
     secure: str
 
 
+class DataProductXMLMetadata(BaseModel):
+    original_filename: str
+    file_size: int
+    content: str
+
+
 class DataProduct(DataProductInDBBase):
     bbox: Optional[List[float]] = None
     crs: Optional[Dict] = None
@@ -72,6 +78,7 @@ class DataProduct(DataProductInDBBase):
     signature: Optional[DataProductSignature] = None
     status: Optional[str] = None
     url: Optional[AnyHttpUrl] = None
+    xml_metadata: Optional[DataProductXMLMetadata] = None
 
 
 # additional properties stored in DB

--- a/backend/app/tests/api/api_v1/test_data_products.py
+++ b/backend/app/tests/api/api_v1/test_data_products.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
@@ -13,7 +14,9 @@ from app.schemas.file_permission import FilePermissionUpdate
 from app.schemas.role import Role
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.data_product_metadata import (
+    create_xml_metadata,
     create_zonal_metadata,
+    get_sample_xml_filepath,
     get_zonal_feature_collection,
 )
 from app.tests.utils.project import create_project
@@ -646,6 +649,208 @@ def test_deactivate_data_product_when_project_is_published(
         f"/flights/{data_product.flight.id}/data_products/{data_product.obj.id}"
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def get_data_product_xml_url(data_product: SampleDataProduct) -> str:
+    return (
+        f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+        f"/flights/{data_product.flight.id}/data_products/{data_product.obj.id}/xml"
+    )
+
+
+def read_sample_xml_bytes() -> bytes:
+    with open(get_sample_xml_filepath(), "rb") as xml_file:
+        return xml_file.read()
+
+
+def test_upload_data_product_xml_with_project_owner_role(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    response_metadata = response.json()
+    assert response_metadata["category"] == "xml"
+    assert response_metadata["data_product_id"] == str(data_product.obj.id)
+    assert response_metadata["properties"]["original_filename"] == "sample.xml"
+    assert os.path.exists(response_metadata["properties"]["filepath"])
+
+
+def test_upload_data_product_xml_with_project_manager_role(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db)
+    create_project_member(
+        db,
+        role=Role.MANAGER,
+        member_id=current_user.id,
+        project_uuid=data_product.project.id,
+    )
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_upload_data_product_xml_with_project_viewer_role(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db)
+    create_project_member(
+        db,
+        role=Role.VIEWER,
+        member_id=current_user.id,
+        project_uuid=data_product.project.id,
+    )
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_upload_data_product_xml_without_project_access(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    data_product = SampleDataProduct(db)
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_upload_data_product_xml_with_malformed_xml(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", b"<metadata><unclosed></metadata>", "text/xml")},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_upload_data_product_xml_with_wrong_extension(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.txt", read_sample_xml_bytes(), "text/plain")},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_upload_data_product_xml_when_xml_already_exists(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    create_xml_metadata(db, data_product_id=data_product.obj.id)
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+def test_read_data_product_includes_xml_metadata(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    create_xml_metadata(db, data_product_id=data_product.obj.id)
+    response = client.get(
+        f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+        f"/flights/{data_product.flight.id}/data_products/{data_product.obj.id}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    response_data_product = response.json()
+    assert response_data_product["xml_metadata"] is not None
+    assert response_data_product["xml_metadata"]["original_filename"] == "sample.xml"
+    assert response_data_product["xml_metadata"][
+        "content"
+    ] == read_sample_xml_bytes().decode("utf-8")
+
+
+def test_read_data_products_includes_xml_metadata(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id)
+    data_product = SampleDataProduct(
+        db, flight=flight, project=project, user=current_user
+    )
+    SampleDataProduct(db, flight=flight, project=project, user=current_user)
+    create_xml_metadata(db, data_product_id=data_product.obj.id)
+    response = client.get(
+        f"{settings.API_V1_STR}/projects/{project.id}"
+        f"/flights/{flight.id}/data_products"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    response_data_products = response.json()
+    assert len(response_data_products) == 2
+    for response_data_product in response_data_products:
+        if response_data_product["id"] == str(data_product.obj.id):
+            assert response_data_product["xml_metadata"] is not None
+            assert (
+                response_data_product["xml_metadata"]["original_filename"]
+                == "sample.xml"
+            )
+        else:
+            assert response_data_product["xml_metadata"] is None
+
+
+def test_delete_data_product_xml_with_project_owner_role(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    metadata = create_xml_metadata(db, data_product_id=data_product.obj.id)
+    xml_filepath = metadata.properties["filepath"]
+    assert os.path.exists(xml_filepath)
+    response = client.delete(get_data_product_xml_url(data_product))
+    assert response.status_code == status.HTTP_200_OK
+    response_metadata = response.json()
+    assert response_metadata["id"] == str(metadata.id)
+    assert not os.path.exists(xml_filepath)
+    assert crud.data_product_metadata.get(db, id=metadata.id) is None
+
+
+def test_delete_data_product_xml_with_project_viewer_role(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db)
+    create_project_member(
+        db,
+        role=Role.VIEWER,
+        member_id=current_user.id,
+        project_uuid=data_product.project.id,
+    )
+    create_xml_metadata(db, data_product_id=data_product.obj.id)
+    response = client.delete(get_data_product_xml_url(data_product))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_delete_data_product_xml_when_no_xml_exists(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    response = client.delete(get_data_product_xml_url(data_product))
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_running_tool_on_data_product(

--- a/backend/app/tests/api/api_v1/test_data_products.py
+++ b/backend/app/tests/api/api_v1/test_data_products.py
@@ -764,6 +764,31 @@ def test_upload_data_product_xml_when_xml_already_exists(
     assert response.status_code == status.HTTP_409_CONFLICT
 
 
+def test_upload_data_product_xml_with_unsupported_data_type(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    for data_type in ["panoramic", "3dgs"]:
+        data_product = SampleDataProduct(db, data_type=data_type, user=current_user)
+        response = client.post(
+            get_data_product_xml_url(data_product),
+            files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_upload_data_product_xml_with_point_cloud_data_type(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="point_cloud", user=current_user)
+    response = client.post(
+        get_data_product_xml_url(data_product),
+        files={"file": ("sample.xml", read_sample_xml_bytes(), "text/xml")},
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 def test_read_data_product_includes_xml_metadata(
     client: TestClient, db: Session, normal_user_access_token: str
 ) -> None:

--- a/backend/app/tests/crud/test_data_product_metadata.py
+++ b/backend/app/tests/crud/test_data_product_metadata.py
@@ -15,6 +15,7 @@ from app.schemas.data_product_metadata import (
 )
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.data_product_metadata import (
+    create_xml_metadata,
     create_zonal_metadata,
     get_zonal_statistics,
 )
@@ -205,6 +206,64 @@ def test_update_data_product_metadata(db: Session) -> None:
     assert metadata_in_db[0].properties["count"] == updated_properties["count"]
     assert metadata_in_db[0].properties["median"] == updated_properties["median"]
     assert metadata_in_db[0].properties["std"] == updated_properties["std"]
+
+
+def test_create_xml_metadata(db: Session) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    metadata = create_xml_metadata(db, data_product_id=data_product.obj.id)
+    assert metadata
+    assert metadata.category == "xml"
+    assert metadata.data_product_id == data_product.obj.id
+    assert metadata.vector_layer_feature_id is None
+    assert os.path.exists(metadata.properties["filepath"])
+    assert metadata.properties["original_filename"] == "sample.xml"
+    assert metadata.properties["file_size"] > 0
+
+
+def test_read_xml_metadata_by_data_product(db: Session) -> None:
+    metadata = create_xml_metadata(db)
+    metadata_in_db = crud.data_product_metadata.get_by_data_product(
+        db, category="xml", data_product_id=metadata.data_product_id
+    )
+    assert isinstance(metadata_in_db, list)
+    assert len(metadata_in_db) == 1
+    assert metadata_in_db[0].id == metadata.id
+    assert metadata_in_db[0].category == "xml"
+    assert metadata_in_db[0].properties == metadata.properties
+
+
+def test_xml_metadata_coexists_with_zonal_metadata(db: Session) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    zonal_stats = {
+        "min": 1.0,
+        "max": 2.0,
+        "mean": 1.5,
+        "median": 1.5,
+        "std": 0.5,
+        "count": 4,
+    }
+    zonal_metadata_in = DataProductMetadataCreate(
+        category="zonal", properties={"stats": zonal_stats}
+    )
+    zonal_metadata = crud.data_product_metadata.create_with_data_product(
+        db, obj_in=zonal_metadata_in, data_product_id=data_product.obj.id
+    )
+    xml_metadata = create_xml_metadata(db, data_product_id=data_product.obj.id)
+    assert xml_metadata.data_product_id == zonal_metadata.data_product_id
+    # zonal metadata record should be unchanged by xml metadata creation
+    zonal_metadata_in_db = crud.data_product_metadata.get(db, id=zonal_metadata.id)
+    assert zonal_metadata_in_db
+    assert zonal_metadata_in_db.category == "zonal"
+    assert zonal_metadata_in_db.properties == {"stats": zonal_stats}
+
+
+def test_delete_xml_metadata(db: Session) -> None:
+    metadata = create_xml_metadata(db)
+    metadata_removed = crud.data_product_metadata.remove(db, id=metadata.id)
+    metadata_get_after_removed = crud.data_product_metadata.get(db, id=metadata.id)
+    assert metadata_get_after_removed is None
+    assert metadata_removed
+    assert metadata_removed.id == metadata.id
 
 
 def test_delete_data_product_metadata(db: Session) -> None:

--- a/backend/app/tests/data/sample.xml
+++ b/backend/app/tests/data/sample.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <idinfo>
+    <citation>
+      <citeinfo>
+        <origin>Test Origin</origin>
+        <title>Sample Data Product Metadata</title>
+      </citeinfo>
+    </citation>
+    <descript>
+      <abstract>Sample XML metadata file used for testing.</abstract>
+      <purpose>Testing XML uploads for data products.</purpose>
+    </descript>
+  </idinfo>
+</metadata>

--- a/backend/app/tests/utils/data_product_metadata.py
+++ b/backend/app/tests/utils/data_product_metadata.py
@@ -1,7 +1,8 @@
 import json
 import os
+import shutil
 from typing import Dict, List, Tuple, TypedDict, Union
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi.encoders import jsonable_encoder
 from geojson_pydantic import Feature, FeatureCollection
@@ -67,6 +68,52 @@ def get_zonal_feature_collection(
         return zones_feature_collection.features[0]
     else:
         return zones_feature_collection
+
+
+def get_sample_xml_filepath() -> str:
+    """Returns path to sample XML file in test data directory."""
+    return os.path.join(os.sep, "app", "app", "tests", "data", "sample.xml")
+
+
+def create_xml_metadata(
+    db: Session, data_product_id: UUID | None = None
+) -> DataProductMetadata:
+    """Create DataProductMetadata record for an XML file. Copies the sample XML
+    test file into the data product's directory.
+
+    Args:
+        db (Session): Database session.
+        data_product_id (UUID | None, optional): Data product ID. Defaults to None.
+
+    Returns:
+        DataProductMetadata: Instance of DataProductMetadata with category "xml".
+    """
+    # create data product if ID for one is not provided
+    if not data_product_id:
+        data_product = SampleDataProduct(db, data_type="dsm").obj
+    else:
+        data_product_in_db = crud.data_product.get(db, id=data_product_id)
+        if not data_product_in_db:
+            raise Exception("Cannot find test data product in db")
+        data_product = data_product_in_db
+    # copy sample xml file into data product directory
+    src_filepath = get_sample_xml_filepath()
+    dest_filepath = os.path.join(
+        os.path.dirname(data_product.filepath), f"{uuid4()}.xml"
+    )
+    shutil.copyfile(src_filepath, dest_filepath)
+    metadata_in = DataProductMetadataCreate(
+        category="xml",
+        properties={
+            "filepath": dest_filepath,
+            "original_filename": "sample.xml",
+            "file_size": os.path.getsize(dest_filepath),
+        },
+    )
+    metadata = crud.data_product_metadata.create_with_data_product(
+        db, obj_in=metadata_in, data_product_id=data_product.id
+    )
+    return metadata
 
 
 def create_zonal_metadata(

--- a/frontend/src/components/pages/workspace/projects/Project.d.ts
+++ b/frontend/src/components/pages/workspace/projects/Project.d.ts
@@ -49,6 +49,14 @@ export interface DataProduct {
   status: string;
   url: string;
   user_style: SingleBandSymbology | MultibandSymbology;
+  xml_metadata?: XmlMetadata | null;
+}
+
+// supplemental xml file attached to a data product
+export interface XmlMetadata {
+  original_filename: string;
+  file_size: number;
+  content: string;
 }
 
 // earth observation info from gdalinfo

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductCard.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductCard.tsx
@@ -15,6 +15,7 @@ import DataProductDeleteModal from './DataProductDeleteModal';
 import DataProductMetadataModal from './DataProductMetadataModal';
 import EditableDataType from './EditableDataType';
 import ToolboxModal from './ToolboxModal';
+import XmlMetadataAttachment from './XmlMetadata/XmlMetadataAttachment';
 import { useProjectContext } from '../../ProjectContext';
 import DataProductShareModal from './DataProductShareModal';
 
@@ -166,6 +167,10 @@ export default function DataProductCard({
               {!isEditing && (
                 <div className="flex flex-row gap-4">
                   <DataProductMetadataModal dataProduct={dataProduct} />
+                  <XmlMetadataAttachment
+                    dataProduct={dataProduct}
+                    variant="icon"
+                  />
                   <a href={dataProduct.url} target="_blank" download>
                     <ArrowDownTrayIcon
                       className="w-5 h-5 hover:scale-110"

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductsTable.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductsTable.tsx
@@ -18,6 +18,7 @@ import EditableDataType from './EditableDataType';
 import { useProjectContext } from '../../ProjectContext';
 import Table, { TableBody, TableHead } from '../../../../../Table';
 import ToolboxModal from './ToolboxModal';
+import XmlMetadataAttachment from './XmlMetadata/XmlMetadataAttachment';
 import DataProductShareModal from './DataProductShareModal';
 import { DataProduct, ProjectDetail } from '../../Project';
 
@@ -277,12 +278,16 @@ export default function DataProductsTable({
                     dataset.status === 'SUCCESS' ? (
                       <div
                         key={`row-${dataset.id}-file`}
-                        className="h-full flex items-center justify-center"
+                        className="h-full flex flex-col items-center justify-center gap-2.5"
                       >
                         <CopyURLButton
                           copyText="Copy File URL"
                           copiedText="Copied"
                           url={dataset.url}
+                        />
+                        <XmlMetadataAttachment
+                          dataProduct={dataset}
+                          compact={true}
                         />
                       </div>
                     ) : (

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlMetadataAttachModal.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlMetadataAttachModal.tsx
@@ -1,0 +1,211 @@
+import { useRef, useState } from 'react';
+import { isAxiosError } from 'axios';
+import { useParams, useRevalidator } from 'react-router';
+import {
+  ArrowUpTrayIcon,
+  DocumentTextIcon,
+  ExclamationCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+
+import { Button, OutlineButton } from '../../../../../../Buttons';
+import Modal from '../../../../../../Modal';
+import { getDataProductName } from '../DataProductsTable';
+import { formatFileSize, parseXml, XML_FILE_MAX_SIZE } from './xmlUtils';
+
+import { DataProduct } from '../../../Project';
+
+import api from '../../../../../../../api';
+
+export default function XmlMetadataAttachModal({
+  dataProduct,
+  open,
+  setOpen,
+}: {
+  dataProduct: DataProduct;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [stagedFile, setStagedFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const params = useParams();
+  const revalidator = useRevalidator();
+
+  function reset() {
+    setError(null);
+    setIsDragOver(false);
+    setIsUploading(false);
+    setStagedFile(null);
+  }
+
+  function handleClose() {
+    reset();
+    setOpen(false);
+  }
+
+  async function stageFile(file: File) {
+    setError(null);
+    setStagedFile(null);
+    if (!file.name.toLowerCase().endsWith('.xml')) {
+      setError(`Couldn't read "${file.name}" — that file isn't valid XML.`);
+      return;
+    }
+    if (file.size > XML_FILE_MAX_SIZE) {
+      setError(`"${file.name}" is too large (max 10 MB).`);
+      return;
+    }
+    const parsed = parseXml(await file.text());
+    if ('error' in parsed) {
+      setError(`Couldn't read "${file.name}" — that file isn't valid XML.`);
+      return;
+    }
+    setStagedFile(file);
+  }
+
+  async function handleAttach() {
+    if (!stagedFile) return;
+    setIsUploading(true);
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.append('file', stagedFile);
+      const response = await api.post(
+        `projects/${params.projectId}/flights/${params.flightId}/data_products/${dataProduct.id}/xml`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } }
+      );
+      if (response) {
+        handleClose();
+        revalidator.revalidate();
+      } else {
+        setError('Unable to attach XML file');
+      }
+    } catch (err) {
+      if (isAxiosError(err) && err.response?.data?.detail) {
+        setError(err.response.data.detail);
+      } else {
+        setError('Unable to attach XML file');
+      }
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return (
+    <Modal open={open} setOpen={setOpen}>
+      <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+        <h3 className="text-lg font-medium leading-6 text-gray-900">
+          Attach XML metadata
+        </h3>
+        <p className="mt-1 text-sm text-gray-500">
+          Associate a supplemental XML file with{' '}
+          <span className="font-semibold">
+            {getDataProductName(dataProduct.data_type)}
+          </span>
+          .
+        </p>
+        <div
+          className={`mt-4 flex flex-col items-center justify-center gap-2 border-2 border-dashed rounded-xl p-8 text-center ${
+            isDragOver
+              ? 'border-sky-600 bg-sky-50'
+              : 'border-slate-300 bg-slate-50'
+          }`}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragOver(true);
+          }}
+          onDragLeave={() => setIsDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setIsDragOver(false);
+            if (e.dataTransfer.files.length > 0) {
+              stageFile(e.dataTransfer.files[0]);
+            }
+          }}
+        >
+          <div className="rounded-lg bg-sky-100 p-2">
+            <ArrowUpTrayIcon className="w-6 h-6 text-sky-600" />
+          </div>
+          <p className="text-sm font-semibold text-slate-700">
+            Drag &amp; drop an XML file
+          </p>
+          <p className="text-sm text-slate-500">
+            or{' '}
+            <button
+              type="button"
+              className="font-semibold text-sky-600 hover:text-sky-700"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              browse your computer
+            </button>
+          </p>
+          <p className="text-xs text-slate-400">.xml only · up to 10 MB</p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".xml,text/xml,application/xml"
+            className="hidden"
+            onChange={(e) => {
+              if (e.target.files && e.target.files.length > 0) {
+                stageFile(e.target.files[0]);
+              }
+              e.target.value = '';
+            }}
+          />
+        </div>
+        {stagedFile && (
+          <div className="mt-3 flex items-center justify-between gap-2 bg-slate-50 border border-slate-200 rounded-lg px-2.5 py-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <DocumentTextIcon className="w-5 h-5 shrink-0 text-sky-600" />
+              <div className="min-w-0 text-left">
+                <div
+                  className="text-sm font-semibold text-slate-700 truncate"
+                  title={stagedFile.name}
+                >
+                  {stagedFile.name}
+                </div>
+                <div className="text-[11px] font-semibold text-slate-500">
+                  {formatFileSize(stagedFile.size)}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Remove staged file"
+              className="shrink-0 text-slate-500 hover:text-red-500"
+              onClick={() => setStagedFile(null)}
+            >
+              <XMarkIcon className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+        {error && (
+          <div className="mt-3 flex items-center gap-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+            <ExclamationCircleIcon className="w-5 h-5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-4 bg-gray-50 px-4 py-3 sm:px-6">
+        <div className="w-36">
+          <OutlineButton type="button" size="sm" onClick={handleClose}>
+            Cancel
+          </OutlineButton>
+        </div>
+        <div className="w-36">
+          <Button
+            type="button"
+            size="sm"
+            disabled={!stagedFile || isUploading}
+            onClick={handleAttach}
+          >
+            {isUploading ? 'Attaching...' : 'Attach file'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlMetadataAttachment.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlMetadataAttachment.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import { useParams, useRevalidator } from 'react-router';
+import {
+  ArrowDownTrayIcon,
+  DocumentTextIcon,
+  EyeIcon,
+  PlusIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+
+import { AlertBar, Status } from '../../../../../../Alert';
+import { ConfirmationPopup } from '../../../../../../ConfirmationPopup';
+import Modal from '../../../../../../Modal';
+import { isGeoTIFF } from '../DataProductsTable';
+import XmlMetadataAttachModal from './XmlMetadataAttachModal';
+import XmlMetadataViewerModal from './XmlMetadataViewerModal';
+import { downloadXml, formatFileSize } from './xmlUtils';
+import { useProjectContext } from '../../../ProjectContext';
+
+import { DataProduct } from '../../../Project';
+
+import api from '../../../../../../../api';
+
+export default function XmlMetadataAttachment({
+  dataProduct,
+  compact = false,
+  variant = 'pill',
+}: {
+  dataProduct: DataProduct;
+  compact?: boolean;
+  variant?: 'pill' | 'icon';
+}) {
+  const [openAttachModal, setOpenAttachModal] = useState(false);
+  const [openRemoveConfirmation, setOpenRemoveConfirmation] = useState(false);
+  const [openViewerModal, setOpenViewerModal] = useState(false);
+  const [status, setStatus] = useState<Status | null>(null);
+  const params = useParams();
+  const revalidator = useRevalidator();
+  const { projectRole } = useProjectContext();
+
+  const canEdit = projectRole === 'owner' || projectRole === 'manager';
+  // xml metadata limited to raster and point cloud data products
+  const supportsXml =
+    isGeoTIFF(dataProduct.data_type) ||
+    dataProduct.data_type === 'point_cloud';
+  const xmlMetadata = dataProduct.xml_metadata;
+
+  if (!xmlMetadata && (!canEdit || !supportsXml)) {
+    return null;
+  }
+
+  return (
+    <div className={variant === 'icon' ? '' : compact ? 'w-56' : 'w-full'}>
+      {variant === 'icon' ? (
+        xmlMetadata ? (
+          <button
+            type="button"
+            aria-label="View XML metadata"
+            title="View XML metadata"
+            className="h-5 flex items-center text-xs font-bold hover:scale-110"
+            onClick={() => setOpenViewerModal(true)}
+          >
+            XML
+          </button>
+        ) : (
+          <button
+            type="button"
+            aria-label="Attach XML metadata"
+            title="Attach XML metadata"
+            className="h-5 flex items-center text-xs font-bold hover:scale-110"
+            onClick={() => setOpenAttachModal(true)}
+          >
+            + XML
+          </button>
+        )
+      ) : xmlMetadata ? (
+        <div
+          className={`flex items-center justify-between gap-2 bg-slate-50 border border-slate-200 rounded-lg px-2.5 ${
+            compact ? 'py-1.5' : 'py-2'
+          }`}
+        >
+          <div
+            className="flex items-center gap-2 min-w-0 cursor-pointer"
+            onClick={() => setOpenViewerModal(true)}
+          >
+            <DocumentTextIcon className="w-5 h-5 shrink-0 text-sky-600" />
+            <div className="min-w-0 text-left">
+              <div
+                className="text-sm font-semibold text-slate-700 truncate"
+                title={xmlMetadata.original_filename}
+              >
+                {xmlMetadata.original_filename}
+              </div>
+              {!compact && (
+                <div className="text-[11px] font-semibold text-slate-500">
+                  {formatFileSize(xmlMetadata.file_size)}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <button
+              type="button"
+              aria-label="View XML metadata"
+              title="View XML metadata"
+              className="text-slate-500 hover:text-sky-600"
+              onClick={() => setOpenViewerModal(true)}
+            >
+              <EyeIcon className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Download XML metadata"
+              title="Download XML metadata"
+              className="text-slate-500 hover:text-sky-600"
+              onClick={() =>
+                downloadXml(xmlMetadata.original_filename, xmlMetadata.content)
+              }
+            >
+              <ArrowDownTrayIcon className="w-4 h-4" />
+            </button>
+            {canEdit && (
+              <button
+                type="button"
+                aria-label="Remove XML metadata"
+                title="Remove XML metadata"
+                className="text-slate-500 hover:text-red-500"
+                onClick={() => setOpenRemoveConfirmation(true)}
+              >
+                <XMarkIcon className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-1 text-sm font-semibold text-slate-500 border border-dashed border-slate-300 rounded-lg px-3 py-1.5 hover:text-sky-600 hover:border-sky-600"
+          onClick={() => setOpenAttachModal(true)}
+        >
+          <PlusIcon className="w-4 h-4" />
+          Attach XML metadata
+        </button>
+      )}
+      {supportsXml && (
+        <XmlMetadataAttachModal
+          dataProduct={dataProduct}
+          open={openAttachModal}
+          setOpen={setOpenAttachModal}
+        />
+      )}
+      {xmlMetadata && (
+        <XmlMetadataViewerModal
+          dataProduct={dataProduct}
+          xmlMetadata={xmlMetadata}
+          open={openViewerModal}
+          setOpen={setOpenViewerModal}
+          onRemove={
+            canEdit
+              ? () => {
+                  setOpenViewerModal(false);
+                  setOpenRemoveConfirmation(true);
+                }
+              : undefined
+          }
+        />
+      )}
+      <Modal open={openRemoveConfirmation} setOpen={setOpenRemoveConfirmation}>
+        <ConfirmationPopup
+          title="Are you sure you want to remove this XML file?"
+          content="The XML file will be permanently removed from the data product. You can attach a new XML file afterward."
+          confirmText="Yes, remove"
+          rejectText="No, keep XML file"
+          setOpen={setOpenRemoveConfirmation}
+          onConfirm={async () => {
+            setStatus(null);
+            try {
+              const response = await api.delete(
+                `projects/${params.projectId}/flights/${params.flightId}/data_products/${dataProduct.id}/xml`
+              );
+              if (response) {
+                setOpenRemoveConfirmation(false);
+                revalidator.revalidate();
+              } else {
+                setOpenRemoveConfirmation(false);
+                setStatus({
+                  type: 'error',
+                  msg: 'Unable to remove XML file',
+                });
+              }
+            } catch {
+              setOpenRemoveConfirmation(false);
+              setStatus({
+                type: 'error',
+                msg: 'Unable to remove XML file',
+              });
+            }
+          }}
+        />
+      </Modal>
+      {status ? (
+        <AlertBar alertType={status.type}>{status.msg}</AlertBar>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlMetadataViewerModal.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlMetadataViewerModal.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ArrowDownTrayIcon,
+  DocumentTextIcon,
+  TrashIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+
+import Modal from '../../../../../../Modal';
+import { getDataProductName } from '../DataProductsTable';
+import XmlRawView from './XmlRawView';
+import XmlTree, { collectCollapsiblePaths } from './XmlTree';
+import { downloadXml, formatFileSize, parseXml, XmlNode } from './xmlUtils';
+
+import { DataProduct, XmlMetadata } from '../../../Project';
+
+type ViewerMode = 'structure' | 'raw';
+
+function getDefaultExpandedPaths(root: XmlNode): Set<string> {
+  // expand root and its immediate children; collapse deeper levels
+  const paths = new Set<string>(['0']);
+  root.children.forEach((_, index) => paths.add(`0.${index}`));
+  return paths;
+}
+
+export default function XmlMetadataViewerModal({
+  dataProduct,
+  xmlMetadata,
+  open,
+  setOpen,
+  onRemove,
+}: {
+  dataProduct: DataProduct;
+  xmlMetadata: XmlMetadata;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onRemove?: () => void;
+}) {
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [mode, setMode] = useState<ViewerMode>('structure');
+
+  const parsed = useMemo(
+    () => (open ? parseXml(xmlMetadata.content) : null),
+    [open, xmlMetadata.content]
+  );
+  const root = parsed && 'root' in parsed ? parsed.root : null;
+  const allExpanded = root
+    ? collectCollapsiblePaths(root).every((path) => expandedPaths.has(path))
+    : false;
+
+  useEffect(() => {
+    if (root) {
+      setExpandedPaths(getDefaultExpandedPaths(root));
+    }
+  }, [root]);
+
+  function handleToggle(path: string) {
+    setExpandedPaths((previous) => {
+      const next = new Set(previous);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <Modal open={open} setOpen={setOpen}>
+      {/* header */}
+      <div className="flex items-center justify-between gap-4 border-b border-slate-200 px-4 py-4 sm:px-6">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="shrink-0 rounded-lg bg-sky-100 p-2">
+            <DocumentTextIcon className="w-6 h-6 text-sky-600" />
+          </div>
+          <div className="min-w-0 text-left">
+            <h3
+              className="text-lg font-bold text-gray-900 truncate"
+              title={xmlMetadata.original_filename}
+            >
+              {xmlMetadata.original_filename}
+            </h3>
+            <p className="text-[13px] font-semibold text-slate-500 truncate">
+              {formatFileSize(xmlMetadata.file_size)} ·{' '}
+              {getDataProductName(dataProduct.data_type)}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            className="flex items-center gap-1.5 rounded-lg bg-accent3 px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent3-dark"
+            onClick={() =>
+              downloadXml(xmlMetadata.original_filename, xmlMetadata.content)
+            }
+          >
+            <ArrowDownTrayIcon className="w-4 h-4" />
+            Download
+          </button>
+          {onRemove && (
+            <button
+              type="button"
+              className="flex items-center gap-1.5 rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 hover:border-red-300 hover:text-red-600"
+              onClick={onRemove}
+            >
+              <TrashIcon className="w-4 h-4" />
+              Remove
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Close"
+            className="rounded-lg border border-slate-300 p-1.5 text-slate-500 hover:text-slate-700"
+            onClick={() => setOpen(false)}
+          >
+            <XMarkIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+      {/* toolbar */}
+      <div className="flex items-center justify-between gap-4 border-b border-slate-200 px-4 py-2.5 sm:px-6">
+        <div className="flex rounded-lg bg-slate-200 p-0.5">
+          {(['structure', 'raw'] as ViewerMode[]).map((viewerMode) => (
+            <button
+              key={viewerMode}
+              type="button"
+              className={`rounded-md px-3 py-1 text-sm font-semibold capitalize ${
+                mode === viewerMode
+                  ? 'bg-white text-slate-700 shadow-sm'
+                  : 'text-slate-500 hover:text-slate-700'
+              }`}
+              onClick={() => setMode(viewerMode)}
+            >
+              {viewerMode}
+            </button>
+          ))}
+        </div>
+        {mode === 'structure' && root && (
+          <button
+            type="button"
+            className="text-sm font-semibold text-sky-600 hover:text-sky-700"
+            onClick={() => {
+              if (allExpanded) {
+                setExpandedPaths(new Set());
+              } else {
+                setExpandedPaths(new Set(collectCollapsiblePaths(root)));
+              }
+            }}
+          >
+            {allExpanded ? 'Collapse all' : 'Expand all'}
+          </button>
+        )}
+      </div>
+      {/* content (swappable region; future Summary tab slots in here) */}
+      <div className="max-h-[60vh] overflow-auto bg-white px-4 py-4 sm:px-6">
+        {mode === 'structure' && root ? (
+          <XmlTree
+            root={root}
+            expandedPaths={expandedPaths}
+            onToggle={handleToggle}
+          />
+        ) : (
+          <XmlRawView content={xmlMetadata.content} />
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlRawView.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlRawView.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { ClipboardIcon } from '@heroicons/react/24/outline';
+
+// matches a full tag-like chunk on a single line
+const TAG_CHUNK_REGEX = /<[^>]*>/g;
+// matches attribute name="value" pairs inside a tag chunk
+const ATTRIBUTE_REGEX = /([\w:.-]+)(=)("[^"]*")/g;
+// matches the tag name following the opening punctuation
+const TAG_NAME_REGEX = /^(<\/?)([\w:.-]+)/;
+
+function highlightTagChunk(chunk: string, key: number): React.ReactNode {
+  // declarations (<?xml ?>) and comments/doctypes (<!) render muted
+  if (chunk.startsWith('<?') || chunk.startsWith('<!')) {
+    return (
+      <span key={key} className="text-[#98a3b3]">
+        {chunk}
+      </span>
+    );
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let rest = chunk;
+  const tagNameMatch = rest.match(TAG_NAME_REGEX);
+  if (tagNameMatch) {
+    nodes.push(
+      <span key={`${key}-open`} className="text-[#8a98ad]">
+        {tagNameMatch[1]}
+      </span>,
+      <span key={`${key}-tag`} className="text-[#1f74bf]">
+        {tagNameMatch[2]}
+      </span>
+    );
+    rest = rest.slice(tagNameMatch[0].length);
+  }
+
+  let lastIndex = 0;
+  let attrIndex = 0;
+  for (const match of rest.matchAll(ATTRIBUTE_REGEX)) {
+    if (match.index > lastIndex) {
+      nodes.push(rest.slice(lastIndex, match.index));
+    }
+    nodes.push(
+      <span key={`${key}-attr-${attrIndex}`}>
+        <span className="text-[#b06a1e]">{match[1]}</span>
+        <span className="text-[#8a98ad]">{match[2]}</span>
+        <span className="text-[#2f8f5b]">{match[3]}</span>
+      </span>
+    );
+    lastIndex = match.index + match[0].length;
+    attrIndex += 1;
+  }
+  if (lastIndex < rest.length) {
+    nodes.push(
+      <span key={`${key}-close`} className="text-[#8a98ad]">
+        {rest.slice(lastIndex)}
+      </span>
+    );
+  }
+
+  return <span key={key}>{nodes}</span>;
+}
+
+function highlightLine(line: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let chunkIndex = 0;
+  for (const match of line.matchAll(TAG_CHUNK_REGEX)) {
+    if (match.index > lastIndex) {
+      nodes.push(
+        <span key={`text-${chunkIndex}`} className="text-[#33404f]">
+          {line.slice(lastIndex, match.index)}
+        </span>
+      );
+    }
+    nodes.push(highlightTagChunk(match[0], chunkIndex));
+    lastIndex = match.index + match[0].length;
+    chunkIndex += 1;
+  }
+  if (lastIndex < line.length) {
+    nodes.push(
+      <span key={`text-${chunkIndex}`} className="text-[#33404f]">
+        {line.slice(lastIndex)}
+      </span>
+    );
+  }
+  return nodes;
+}
+
+export default function XmlRawView({ content }: { content: string }) {
+  const [isCopied, setIsCopied] = useState(false);
+  const lines = content.split('\n');
+
+  return (
+    <div className="relative rounded-[10px] border border-slate-200 bg-slate-50/50 overflow-hidden">
+      <button
+        type="button"
+        className="absolute top-2 right-2 flex items-center gap-1 rounded-md border border-slate-300 bg-white px-2 py-1 text-xs font-semibold text-slate-600 hover:text-sky-600"
+        onClick={() => {
+          navigator.clipboard.writeText(content);
+          setIsCopied(true);
+          setTimeout(() => {
+            setIsCopied(false);
+          }, 3000);
+        }}
+      >
+        <ClipboardIcon className="w-3.5 h-3.5" />
+        {isCopied ? 'Copied' : 'Copy'}
+      </button>
+      <div className="flex overflow-x-auto">
+        <div className="shrink-0 select-none bg-slate-100 px-2 py-3 text-right font-mono text-[13px] leading-relaxed text-slate-400">
+          {lines.map((_, index) => (
+            <div key={index}>{index + 1}</div>
+          ))}
+        </div>
+        <pre className="flex-1 px-3 py-3 font-mono text-[13px] leading-relaxed">
+          {lines.map((line, index) => (
+            <div key={index} className="whitespace-pre">
+              {highlightLine(line)}
+            </div>
+          ))}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlTree.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/XmlTree.tsx
@@ -1,0 +1,107 @@
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+
+import { XmlNode } from './xmlUtils';
+
+export function collectCollapsiblePaths(
+  node: XmlNode,
+  path = '0',
+  acc: string[] = []
+): string[] {
+  if (node.children.length > 0) {
+    acc.push(path);
+    node.children.forEach((child, index) =>
+      collectCollapsiblePaths(child, `${path}.${index}`, acc)
+    );
+  }
+  return acc;
+}
+
+function XmlTreeNode({
+  node,
+  path,
+  expandedPaths,
+  onToggle,
+}: {
+  node: XmlNode;
+  path: string;
+  expandedPaths: Set<string>;
+  onToggle: (path: string) => void;
+}) {
+  const hasChildren = node.children.length > 0;
+  const isExpanded = expandedPaths.has(path);
+
+  return (
+    <div className="font-mono text-[13px] leading-relaxed">
+      <div className="flex items-center gap-1.5 min-w-0">
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={isExpanded ? 'Collapse node' : 'Expand node'}
+            className="shrink-0 text-slate-400 hover:text-slate-600"
+            onClick={() => onToggle(path)}
+          >
+            {isExpanded ? (
+              <ChevronDownIcon className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronRightIcon className="w-3.5 h-3.5" />
+            )}
+          </button>
+        ) : (
+          <span className="w-3.5 shrink-0" />
+        )}
+        <span className="font-bold text-[#1f74bf] shrink-0">{node.tag}</span>
+        {Object.entries(node.attrs).map(([name, value]) => (
+          <span
+            key={name}
+            className="shrink-0 rounded border border-[#f0e0c8] bg-[#fff5e9] px-1.5 text-[11.5px] text-[#b06a1e]"
+            title={`${name}="${value}"`}
+          >
+            {name}=<span className="text-[#2f8f5b]">"{value}"</span>
+          </span>
+        ))}
+        {!hasChildren && node.text && (
+          <span className="text-slate-700 truncate" title={node.text}>
+            : {node.text}
+          </span>
+        )}
+        {hasChildren && (
+          <span className="shrink-0 rounded-full bg-slate-100 px-1.5 text-[11px] text-slate-500">
+            {node.children.length}
+          </span>
+        )}
+      </div>
+      {hasChildren && isExpanded && (
+        <div className="ml-[18px] border-l border-slate-100 pl-2">
+          {node.children.map((child, index) => (
+            <XmlTreeNode
+              key={`${path}.${index}`}
+              node={child}
+              path={`${path}.${index}`}
+              expandedPaths={expandedPaths}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function XmlTree({
+  root,
+  expandedPaths,
+  onToggle,
+}: {
+  root: XmlNode;
+  expandedPaths: Set<string>;
+  onToggle: (path: string) => void;
+}) {
+  return (
+    <XmlTreeNode
+      node={root}
+      path="0"
+      expandedPaths={expandedPaths}
+      onToggle={onToggle}
+    />
+  );
+}

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/xmlUtils.ts
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/XmlMetadata/xmlUtils.ts
@@ -1,0 +1,47 @@
+export type XmlNode = {
+  tag: string;
+  attrs: Record<string, string>;
+  text?: string; // direct text content if this node has no element children
+  children: XmlNode[];
+};
+
+export type ParsedXml =
+  | { root: XmlNode; lineCount: number }
+  | { error: string };
+
+export const XML_FILE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB (matches backend cap)
+
+export function parseXml(raw: string): ParsedXml {
+  const doc = new DOMParser().parseFromString(raw, 'application/xml');
+  if (doc.querySelector('parsererror')) return { error: 'Not valid XML' };
+  const toNode = (el: Element): XmlNode => {
+    const children = Array.from(el.children).map(toNode);
+    return {
+      tag: el.tagName,
+      attrs: Object.fromEntries(
+        Array.from(el.attributes).map((a) => [a.name, a.value])
+      ),
+      text: children.length ? undefined : el.textContent?.trim() || undefined,
+      children,
+    };
+  };
+  return { root: toNode(doc.documentElement), lineCount: raw.split('\n').length };
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function downloadXml(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'application/xml' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
Adds the ability to attach a supplemental XML metadata file to raster and point cloud data products. Users with owner or manager roles can upload, view, download, and remove XML files directly from the data product card and table views.

## Changes

- **Backend:** New `POST /{data_product_id}/xml` endpoint accepts an XML file upload (max 10 MB, well-formed XML required, `.xml` extension enforced, one file per data product). New `DELETE /{data_product_id}/xml` endpoint removes the associated file and database record. XML content is read from disk and returned inline on data product responses via a new `xml_metadata` field. XML is restricted to raster and point cloud types (`panoramic` and `3dgs` are excluded). Added `XML_METADATA_EXCLUDED_TYPES` constant and `DataProductXMLMetadata` Pydantic schema.
- **Frontend:** New `XmlMetadata/` component directory with an attach modal (drag-and-drop or file browse), a viewer modal with switchable structure-tree and syntax-highlighted raw views, and an `XmlMetadataAttachment` component integrated into both `DataProductCard` (icon variant) and `DataProductsTable` (compact pill variant). Added `XmlMetadata` type to `Project.d.ts`.
- **Database:** No schema migrations required; XML records are stored in the existing `data_product_metadata` table with `category = "xml"`.

## Testing

- Commands run:
  - `docker compose exec backend pytest backend/app/tests/api/api_v1/test_data_products.py -v`
  - `docker compose exec backend pytest backend/app/tests/crud/test_data_product_metadata.py -v`
  - `docker compose exec frontend npx tsc --noEmit`
- New API tests cover: upload with owner/manager/viewer roles, upload without project access, malformed XML, wrong file extension, duplicate upload (409 conflict), unsupported data types, point cloud support, XML included in single and list data product responses, delete with owner/viewer roles, delete when no XML exists.
- New CRUD tests cover: create, read, coexistence with zonal metadata, and delete for XML metadata records.
- Manual QA: Navigate to a flight's data products, click "+ XML" or "Attach XML metadata" on a raster product, upload a valid `.xml` file, verify the file appears in both card and table views, open the viewer in structure and raw modes, download the file, and remove it.

## Related Issues
NA