### PR TITLE
[Feature] Allow configurable CORS origins for credentialed cross-origin access

### DIFF
--- a/backend.example.env
+++ b/backend.example.env
@@ -1,6 +1,13 @@
 API_PROJECT_NAME="Data To Science"
 API_DOMAIN=http://localhost:8000
 
+# Comma-separated list of browser origins allowed to make credentialed
+# (cookie-bearing) cross-origin requests. When empty, the API falls back to
+# allowing anonymous GET requests from any origin. Required for partner web
+# apps that log in cross-origin.
+# Example: https://partner.app,https://viewer.partner.app
+BACKEND_CORS_ORIGINS=
+
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/0
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,6 +17,12 @@ class Settings(BaseSettings):
     ENV: str = "dev"
     API_V1_STR: str = "/api/v1"
 
+    # Comma-separated list of browser origins allowed to make credentialed
+    # (cookie-bearing) cross-origin requests. Empty falls back to anonymous GETs
+    # from any origin. Kept as a plain string (split at use site) because the list
+    # may include non-HTTP schemes such as "tauri://localhost".
+    BACKEND_CORS_ORIGINS: str = ""
+
     SECRET_KEY: str = ""
     # Secret key used for signing pg_tileserv and titiler requests
     TILE_SIGNING_SECRET_KEY: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,29 +48,38 @@ if settings.ENABLE_OPENTELEMETRY:
         print(f"Error setting up OpenTelemetry tracing: {e}")
 
 
-cors_origins = [
-    origin.strip()
-    for origin in settings.BACKEND_CORS_ORIGINS.split(",")
-    if origin.strip()
-]
+def configure_cors(app: FastAPI, allowed_origins: str) -> None:
+    """Configure CORS from a comma-separated origin allowlist.
 
-if cors_origins:
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=cors_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-        expose_headers=["*"],
-    )
-else:
-    # Backward-compatible default: anonymous, browser GETs from any origin.
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_methods=["GET"],
-        allow_headers=["*"],
-    )
+    When ``allowed_origins`` lists one or more origins, those origins may make
+    credentialed (cookie-bearing) cross-origin requests with any method. When it
+    is empty, the API falls back to allowing anonymous ``GET`` requests from any
+    origin (the historical default).
+    """
+    cors_origins = [
+        origin.strip() for origin in allowed_origins.split(",") if origin.strip()
+    ]
+
+    if cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+            expose_headers=["*"],
+        )
+    else:
+        # Backward-compatible default: anonymous, browser GETs from any origin.
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["GET"],
+            allow_headers=["*"],
+        )
+
+
+configure_cors(app, settings.BACKEND_CORS_ORIGINS)
 
 setup_logger()
 logger = logging.getLogger(__name__)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,9 +48,29 @@ if settings.ENABLE_OPENTELEMETRY:
         print(f"Error setting up OpenTelemetry tracing: {e}")
 
 
-app.add_middleware(
-    CORSMiddleware, allow_origins=["*"], allow_methods=["GET"], allow_headers=["*"]
-)
+cors_origins = [
+    origin.strip()
+    for origin in settings.BACKEND_CORS_ORIGINS.split(",")
+    if origin.strip()
+]
+
+if cors_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+        expose_headers=["*"],
+    )
+else:
+    # Backward-compatible default: anonymous, browser GETs from any origin.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["GET"],
+        allow_headers=["*"],
+    )
 
 setup_logger()
 logger = logging.getLogger(__name__)

--- a/backend/app/tests/core/test_cors.py
+++ b/backend/app/tests/core/test_cors.py
@@ -1,0 +1,71 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.main import configure_cors
+
+
+def _client(allowed_origins: str) -> TestClient:
+    """Build an isolated app with CORS configured from the given allowlist."""
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict:
+        return {"ok": True}
+
+    configure_cors(app, allowed_origins)
+    return TestClient(app)
+
+
+def _preflight(client: TestClient, origin: str) -> "object":
+    return client.options(
+        "/ping",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+
+def test_allowed_origin_gets_credentialed_cors() -> None:
+    client = _client("https://geolibre.app,tauri://localhost")
+
+    resp = _preflight(client, "https://geolibre.app")
+
+    assert resp.headers.get("access-control-allow-origin") == "https://geolibre.app"
+    assert resp.headers.get("access-control-allow-credentials") == "true"
+    assert "POST" in resp.headers.get("access-control-allow-methods", "")
+
+
+def test_non_http_origin_is_allowed() -> None:
+    """Origins such as tauri://localhost (non-HTTP scheme) must be honored."""
+    client = _client("https://geolibre.app,tauri://localhost")
+
+    resp = _preflight(client, "tauri://localhost")
+
+    assert resp.headers.get("access-control-allow-origin") == "tauri://localhost"
+
+
+def test_disallowed_origin_is_not_reflected() -> None:
+    client = _client("https://geolibre.app")
+
+    resp = _preflight(client, "https://evil.example")
+
+    # The browser blocks the request because the origin is never echoed back.
+    assert resp.headers.get("access-control-allow-origin") is None
+
+
+def test_empty_allowlist_falls_back_to_anonymous_get() -> None:
+    client = _client("")
+
+    resp = client.get("/ping", headers={"Origin": "https://anything.example"})
+
+    assert resp.headers.get("access-control-allow-origin") == "*"
+    assert resp.headers.get("access-control-allow-credentials") is None
+
+
+def test_whitespace_and_blank_entries_are_ignored() -> None:
+    client = _client("  ,  https://geolibre.app  , ")
+
+    resp = _preflight(client, "https://geolibre.app")
+
+    assert resp.headers.get("access-control-allow-origin") == "https://geolibre.app"

--- a/docs/explanation/authentication.md
+++ b/docs/explanation/authentication.md
@@ -13,6 +13,10 @@ D2S uses JSON Web Tokens (JWT) for session-based authentication:
 
 Tokens are signed using the `SECRET_KEY` environment variable. In production, `HTTP_COOKIE_SECURE` should be set to `1` to ensure cookies are only sent over HTTPS.
 
+### Cross-origin login
+
+By default the API answers cross-origin requests with `Access-Control-Allow-Origin: *` and allows only anonymous `GET` requests, which browsers reject for credentialed (cookie-bearing) requests. To let a partner web app log in from another origin, list its origin(s) in the `BACKEND_CORS_ORIGINS` environment variable. When set, the API returns the explicit origin together with `Access-Control-Allow-Credentials: true` and permits all methods, so the browser will send the auth cookie. This requires `HTTP_COOKIE_SECURE=1` (the production default), which issues the cookie with `SameSite=None; Secure` so it can be sent cross-origin. See [Configuration](../reference/configuration.md) for details.
+
 ### API keys
 
 For programmatic access, users can generate API keys. These are passed via the `X-API-Key` header and currently support a limited set of read-only endpoints (project details, flight listings, vector layer access).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -31,6 +31,7 @@ You must provide a value for `SECRET_KEY` in your `backend.env` file. Use a cryp
 | `AWS_S3_REGION` | AWS region for the S3 bucket (e.g., `us-east-1`). Defaults to `us-east-1` when unset. |
 | `AWS_ACCESS_KEY_ID` | AWS access key ID for the S3 bucket (optional). Leave empty to fall back to the boto3 default credential chain (e.g., IAM role). |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret access key for the S3 bucket (optional). Pair with `AWS_ACCESS_KEY_ID`. |
+| `BACKEND_CORS_ORIGINS` | Comma-separated list of browser origins allowed to make credentialed (cookie-bearing) cross-origin requests (e.g., `https://partner.app,https://viewer.partner.app`). When set, those origins may authenticate and call any method; when empty, the API falls back to allowing only anonymous `GET` requests from any origin. Required for partner web apps that log in cross-origin. |
 | `CELERY_BROKER_URL` | Address for local redis service. |
 | `CELERY_RESULT_BACKEND` | Address for local redis service. |
 | `BREEDBASE_ALLOWED_HOSTS` | Comma-separated list of allowed BreedBase hostnames for the BrAPI proxy (optional). When empty, any public host with a `/brapi/` path is allowed. Set to restrict which servers the proxy can reach. |


### PR DESCRIPTION
## Summary
Adds an env-driven CORS allowlist so partner web apps (e.g. a GeoLibre integration) can log into D2S cross-origin. Today the API hardcodes `Access-Control-Allow-Origin: *` with GET-only methods and no credentials, which browsers reject for cookie-bearing requests; this change lets specific origins opt into credentialed access while preserving today's behavior when unset.

## Changes
- Backend: Added `BACKEND_CORS_ORIGINS` setting (`backend/app/core/config.py`). Extracted CORS setup into `configure_cors(app, allowed_origins)` in `backend/app/main.py`: when the allowlist is non-empty, those origins get `allow_credentials=True`, all methods, and all headers; when empty, falls back to the existing `allow_origins=["*"], allow_methods=["GET"]` behavior.
- Config: Documented `BACKEND_CORS_ORIGINS` in `backend.example.env` (left empty by default).
- Docs: Added `BACKEND_CORS_ORIGINS` to the configuration reference table (`docs/reference/configuration.md`) and a new "Cross-origin login" subsection in `docs/explanation/authentication.md` explaining the requirement and its relationship to the `SameSite=None; Secure` auth cookie (already issued when `HTTP_COOKIE_SECURE=1`).
- Tests: Added `backend/app/tests/core/test_cors.py` covering allowed origins, non-HTTP schemes (e.g. `tauri://localhost`), rejection of unlisted origins, the empty-allowlist fallback, and whitespace/blank-entry handling.

## Testing
- Commands run: `docker compose exec backend pytest` — full suite passing.
- `docker compose exec backend pytest app/tests/core/test_cors.py -q` — 5 passed.
- Manual QA: Restart backend with `BACKEND_CORS_ORIGINS` set to a test origin, then:
