### PR TITLE
[Bug] Fix refresh token persistence and logout cookie clearing

### DIFF
--- a/backend/alembic/versions/f7cd65434957_add_revoked_at_to_refresh_tokens.py
+++ b/backend/alembic/versions/f7cd65434957_add_revoked_at_to_refresh_tokens.py
@@ -1,0 +1,24 @@
+"""add revoked_at to refresh_tokens
+
+Revision ID: f7cd65434957
+Revises: fa8f9fed28e9
+Create Date: 2026-06-17 20:07:00.583021
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f7cd65434957'
+down_revision: str | None = 'fa8f9fed28e9'
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column('refresh_tokens', sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('refresh_tokens', 'revoked_at')

--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -28,7 +28,6 @@ from app.core import security
 from app.core.config import settings
 from app.core.limiter import limiter
 
-
 router = APIRouter()
 
 logger = logging.getLogger("__name__")
@@ -101,20 +100,31 @@ def refresh_access_token(
         )
     jti = UUID(jti_str)
 
-    # Check if token is revoked
+    # Check if token is revoked or expired
+    now = datetime.now(timezone.utc)
     db_token = crud.refresh_token.get_by_jti(db, jti=jti)
-    if (
-        not db_token
-        or db_token.revoked
-        or db_token.expires_at < datetime.now(timezone.utc)
-    ):
+    if not db_token or db_token.expires_at < now:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token revoked or expired",
         )
 
-    # Revoke the old refresh token
-    crud.refresh_token.revoke(db, jti=jti)
+    if db_token.revoked:
+        # Tolerate a recently-rotated token within a short grace window so that
+        # concurrent/cross-tab refreshes of the same token do not 401 each other.
+        within_grace = (
+            db_token.revoked_at is not None
+            and (now - db_token.revoked_at).total_seconds()
+            <= settings.REFRESH_TOKEN_REUSE_GRACE_SECONDS
+        )
+        if not within_grace:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Refresh token revoked or expired",
+            )
+    else:
+        # Revoke the old refresh token (rotation)
+        crud.refresh_token.revoke(db, jti=jti)
 
     # Get user from payload
     user = security.get_user_from_token_payload(db, payload)
@@ -135,9 +145,28 @@ def refresh_access_token(
 
 
 @router.get("/remove-access-token")
-def logout_access_token(response: Response) -> Any:
-    """Remove cookie containing JWT access token."""
-    response.delete_cookie(key="access_token")
+def logout_access_token(
+    response: Response,
+    refresh_token: str = Cookie(None),
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    """Log out by revoking the refresh token and clearing both auth cookies."""
+    # Best-effort revoke the refresh token in the database so the now-persistent
+    # refresh cookie can't be replayed to mint new access tokens after logout.
+    if refresh_token and refresh_token.startswith("Bearer "):
+        token = refresh_token.removeprefix("Bearer ").strip()
+        try:
+            # Ignore expiration so an expired token's jti is still revoked (signature
+            # is still verified); a garbage/invalid token falls through to the except.
+            payload = security.decode_token(token, verify_exp=False)
+            jti_str = payload.get("jti")
+            if jti_str:
+                crud.refresh_token.revoke(db, jti=UUID(jti_str))
+        except Exception:
+            # A malformed/invalid refresh token doesn't need revoking; still clear cookies.
+            logger.debug("Could not revoke refresh token during logout", exc_info=True)
+
+    security.delete_auth_cookies(response)
     return status.HTTP_200_OK
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     # 15 minutes
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
+    # Grace window (seconds) during which a just-rotated refresh token is still
+    # accepted, so concurrent/cross-tab refreshes do not self-revoke each other.
+    REFRESH_TOKEN_REUSE_GRACE_SECONDS: int = 10
     # Activity tracking throttle in minutes (only update last_activity_at if older than this)
     ACTIVITY_TRACKING_THROTTLE_MINUTES: int = 15
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -87,9 +87,19 @@ def create_refresh_token(
     return token
 
 
-def decode_token(token: str) -> dict[str, Any]:
-    """Decode JWT token and return payload."""
-    return jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+def decode_token(token: str, verify_exp: bool = True) -> dict[str, Any]:
+    """Decode JWT token and return payload.
+
+    The signature is always verified. ``verify_exp=False`` skips only the
+    expiration check, which logout uses so an expired refresh token's ``jti`` can
+    still be extracted and revoked in the database.
+    """
+    return jwt.decode(
+        token,
+        settings.SECRET_KEY,
+        algorithms=[ALGORITHM],
+        options={"verify_exp": verify_exp},
+    )
 
 
 def sign_map_tile_payload(payload: str, expiration: int = 600) -> Tuple[str, int]:
@@ -134,7 +144,9 @@ def get_token_hash(token: str, salt: str) -> str:
 
 def check_token_expired(token: SingleUseToken, minutes: int = 60) -> bool:
     """Check if token is older than value passed in minutes (defaults to 1 hour)."""
-    return datetime.now(tz=timezone.utc) > (token.created_at + timedelta(minutes=minutes))
+    return datetime.now(tz=timezone.utc) > (
+        token.created_at + timedelta(minutes=minutes)
+    )
 
 
 def validate_token_and_get_payload(token: str, expected_type: str) -> dict[str, Any]:
@@ -217,20 +229,20 @@ def get_user_from_token_payload(db: Session, payload: dict[str, Any]):
     return user
 
 
-def set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
-    """Set authentication cookies with proper security settings.
+def _resolve_cookie_security() -> tuple[bool, Literal["lax", "strict", "none"]]:
+    """Resolve the secure/samesite cookie attributes from the environment.
 
-    Args:
-        response: FastAPI Response object
-        access_token: JWT access token
-        refresh_token: JWT refresh token
+    Production (HTTPS) issues ``Secure``, ``SameSite=None`` cookies so they work
+    cross-origin. Tests and non-HTTPS/quickstart deployments fall back to
+    ``secure=False``, ``samesite="lax"``. Both setting and deleting auth cookies
+    must use these same attributes, otherwise browsers may refuse to apply the
+    deletion in a cross-site context and the cookie lingers.
     """
     # Import here to avoid circular imports
     from app.api.utils import str_to_bool
 
-    # Toggle secure off if running tests
     secure_cookie = True
-    samesite: Literal["lax", "strict", "none"] | None = "none"
+    samesite: Literal["lax", "strict", "none"] = "none"
     try:
         if str_to_bool(os.environ.get("RUNNING_TESTS", False)) or not str_to_bool(
             os.environ.get("HTTP_COOKIE_SECURE", True)
@@ -240,6 +252,19 @@ def set_auth_cookies(response: Response, access_token: str, refresh_token: str) 
     except ValueError:
         logger.exception("Defaulting to secure cookie")
 
+    return secure_cookie, samesite
+
+
+def set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+    """Set authentication cookies with proper security settings.
+
+    Args:
+        response: FastAPI Response object
+        access_token: JWT access token
+        refresh_token: JWT refresh token
+    """
+    secure_cookie, samesite = _resolve_cookie_security()
+
     # Set access token cookie
     response.set_cookie(
         key="access_token",
@@ -248,14 +273,37 @@ def set_auth_cookies(response: Response, access_token: str, refresh_token: str) 
         secure=secure_cookie,
         samesite=samesite,
     )
-    # Set refresh token cookie
+    # Set refresh token cookie. Unlike the access token, give the refresh cookie an
+    # explicit max_age so it persists across browser sessions for the full refresh
+    # token lifetime; otherwise it becomes a session cookie and is dropped when the
+    # browser session ends, forcing the user to log in again on their next visit.
     response.set_cookie(
         key="refresh_token",
         value=f"Bearer {refresh_token}",
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
         httponly=True,
         secure=secure_cookie,
         samesite=samesite,
     )
+
+
+def delete_auth_cookies(response: Response) -> None:
+    """Clear the auth cookies, mirroring the attributes used to set them.
+
+    The deletion ``Set-Cookie`` must carry the same ``secure``/``samesite``
+    attributes as ``set_auth_cookies``; otherwise a browser may reject clearing a
+    ``SameSite=None; Secure`` cookie from a cross-site context, leaving the user
+    effectively logged in.
+    """
+    secure_cookie, samesite = _resolve_cookie_security()
+    for key in ("access_token", "refresh_token"):
+        response.delete_cookie(
+            key=key,
+            path="/",
+            httponly=True,
+            secure=secure_cookie,
+            samesite=samesite,
+        )
 
 
 async def validate_turnstile(

--- a/backend/app/crud/crud_refresh_token.py
+++ b/backend/app/crud/crud_refresh_token.py
@@ -1,11 +1,17 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import CursorResult, delete, or_, select
 from sqlalchemy.orm import Session
 
 from app.crud.base import CRUDBase
 from app.models.refresh_token import RefreshToken
 from app.schemas.refresh_token import RefreshTokenCreate, RefreshTokenUpdate
+
+# Only purge revoked rows once they are well past the reuse grace window, so a
+# just-rotated token is never deleted while its grace window is still live.
+REVOKED_RETENTION = timedelta(days=1)
 
 
 class CRUDRefreshToken(CRUDBase[RefreshToken, RefreshTokenCreate, RefreshTokenUpdate]):
@@ -19,9 +25,31 @@ class CRUDRefreshToken(CRUDBase[RefreshToken, RefreshTokenCreate, RefreshTokenUp
         """Revoke a refresh token by JTI."""
         token = self.get_by_jti(db, jti=jti)
         if token:
-            token_update = RefreshTokenUpdate(revoked=True)
+            token_update = RefreshTokenUpdate(
+                revoked=True, revoked_at=datetime.now(timezone.utc)
+            )
             return self.update(db, db_obj=token, obj_in=token_update)
         return None
+
+    def delete_stale(self, db: Session) -> int:
+        """Purge stale refresh tokens and return the number of rows deleted.
+
+        Removes tokens that are past their expiry, plus tokens revoked longer ago
+        than REVOKED_RETENTION (safely beyond the reuse grace window). Returns the
+        deleted row count.
+        """
+        now = datetime.now(timezone.utc)
+        statement = delete(RefreshToken).where(
+            or_(
+                RefreshToken.expires_at < now,
+                RefreshToken.revoked.is_(True)
+                & (RefreshToken.revoked_at < now - REVOKED_RETENTION),
+            )
+        )
+        with db as session:
+            result = cast("CursorResult[Any]", session.execute(statement))
+            session.commit()
+        return result.rowcount
 
 
 refresh_token = CRUDRefreshToken(RefreshToken)

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -26,6 +26,9 @@ class RefreshToken(Base):
         DateTime(timezone=True), nullable=False
     )
     revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    revoked_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Foreign keys
     user_id: Mapped[uuid.UUID] = mapped_column(

--- a/backend/app/schemas/refresh_token.py
+++ b/backend/app/schemas/refresh_token.py
@@ -20,6 +20,7 @@ class RefreshTokenCreate(RefreshTokenBase):
 # properties to receive via API on update
 class RefreshTokenUpdate(BaseModel):
     revoked: bool | None = None
+    revoked_at: datetime | None = None
 
 
 # properties shared by models stored in DB

--- a/backend/app/tasks/admin_tasks.py
+++ b/backend/app/tasks/admin_tasks.py
@@ -19,6 +19,11 @@ celery_app.conf.beat_schedule = {
         "schedule": crontab(hour=6, minute=5),
         "args": (),
     },
+    "cleanup-refresh-tokens": {
+        "task": "cleanup_refresh_tokens_task",
+        "schedule": crontab(hour=3, minute=0),
+        "args": (),
+    },
 }
 
 
@@ -51,3 +56,14 @@ def calculate_disk_usage() -> None:
 
     # Update job status
     job.update(status=Status.SUCCESS)
+
+
+@celery_app.task(name="cleanup_refresh_tokens_task")
+def cleanup_refresh_tokens() -> None:
+    """Purge expired and long-revoked refresh tokens to keep the table bounded."""
+    db = next(get_db())
+    try:
+        deleted = crud.refresh_token.delete_stale(db)
+        logger.info("Purged %d stale refresh token(s)", deleted)
+    except Exception:
+        logger.exception("Unable to clean up refresh tokens")

--- a/backend/app/tests/api/api_v1/test_auth.py
+++ b/backend/app/tests/api/api_v1/test_auth.py
@@ -3,9 +3,9 @@ import secrets
 import string
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
-from fastapi import status
+from fastapi import Response, status
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -17,7 +17,7 @@ from app.models.single_use_token import SingleUseToken
 from app.api.deps import get_current_user
 from app.core import security
 from app.core.config import settings
-from app.schemas.refresh_token import RefreshTokenCreate
+from app.schemas.refresh_token import RefreshTokenCreate, RefreshTokenUpdate
 from app.schemas.single_use_token import SingleUseTokenCreate
 from app.schemas.user import UserUpdate
 from app.tests.utils.user import create_user
@@ -73,11 +73,56 @@ def test_logout_removes_authorization_cookie(client: TestClient, db: Session) ->
     assert r.status_code == 200
     assert r.cookies.get("access_token")
     assert client.cookies.get("access_token")
+    assert client.cookies.get("refresh_token")
     # logout
     r = client.get(f"{settings.API_V1_STR}/auth/remove-access-token")
     assert r.status_code == 200
     assert r.cookies.get("access_token") is None
     assert client.cookies.get("access_token") is None
+    # both cookies cleared
+    assert client.cookies.get("refresh_token") is None
+
+
+def test_logout_revokes_refresh_token(client: TestClient, db: Session) -> None:
+    """Logout should revoke the refresh token so it cannot be reused."""
+    user = create_user(db, password="mysecretpassword")
+    login = client.post(
+        f"{settings.API_V1_STR}/auth/access-token",
+        data={"username": user.email, "password": "mysecretpassword"},
+        headers={"content_type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 200
+    refresh_token = login.cookies.get("refresh_token")
+    assert refresh_token is not None
+
+    # Identify the token's jti before logging out (cookie value is quoted because
+    # it contains a space, so strip quotes before stripping the Bearer prefix)
+    raw_token = refresh_token.strip('"').removeprefix("Bearer ").strip()
+    jti = UUID(security.decode_token(raw_token)["jti"])
+    assert crud.refresh_token.get_by_jti(db, jti=jti).revoked is False
+
+    logout = client.get(f"{settings.API_V1_STR}/auth/remove-access-token")
+    assert logout.status_code == 200
+
+    # Token is revoked in the DB
+    assert crud.refresh_token.get_by_jti(db, jti=jti).revoked is True
+
+    # And reusing it (past the grace window) is rejected
+    db_token = crud.refresh_token.get_by_jti(db, jti=jti)
+    crud.refresh_token.update(
+        db,
+        db_obj=db_token,
+        obj_in=RefreshTokenUpdate(
+            revoked=True,
+            revoked_at=datetime.now(timezone.utc)
+            - timedelta(seconds=settings.REFRESH_TOKEN_REUSE_GRACE_SECONDS + 1),
+        ),
+    )
+    reuse = client.post(
+        f"{settings.API_V1_STR}/auth/refresh-token",
+        cookies={"refresh_token": refresh_token},
+    )
+    assert reuse.status_code == 401
 
 
 def test_email_confirmation_with_valid_token(client: TestClient, db: Session) -> None:
@@ -93,9 +138,7 @@ def test_email_confirmation_with_valid_token(client: TestClient, db: Session) ->
     assert user_in_db and user_in_db.is_email_confirmed is True
 
 
-def test_email_confirmation_with_expired_token(
-    client: TestClient, db: Session
-) -> None:
+def test_email_confirmation_with_expired_token(client: TestClient, db: Session) -> None:
     token = secrets.token_urlsafe()
     user = create_user(db, token=token)
     # Back-date token to 120 minutes ago (past the 60-minute expiry)
@@ -256,16 +299,27 @@ def test_refresh_token_missing_jti(client: TestClient, db: Session) -> None:
 
 
 def test_refresh_token_revoked(client: TestClient, db: Session) -> None:
-    """Test refresh token endpoint with revoked token."""
+    """Test refresh token endpoint rejects a token revoked beyond the grace window."""
     user = create_user(db)
 
     # Create a refresh token
     refresh_token_str = security.create_refresh_token(db, subject=str(user.id))
 
-    # Decode to get JTI and revoke the token
+    # Decode to get JTI and revoke the token, backdating revoked_at past the grace
+    # window so the reuse-grace path does not apply.
     payload = security.decode_token(refresh_token_str)
     jti = payload["jti"]
-    crud.refresh_token.revoke(db, jti=jti)
+    db_token = crud.refresh_token.get_by_jti(db, jti=jti)
+    assert db_token is not None
+    crud.refresh_token.update(
+        db,
+        db_obj=db_token,
+        obj_in=RefreshTokenUpdate(
+            revoked=True,
+            revoked_at=datetime.now(timezone.utc)
+            - timedelta(seconds=settings.REFRESH_TOKEN_REUSE_GRACE_SECONDS + 60),
+        ),
+    )
 
     response = client.post(
         f"{settings.API_V1_STR}/auth/refresh-token",
@@ -362,6 +416,163 @@ def test_refresh_token_revokes_old_token(client: TestClient, db: Session) -> Non
     db_token_after = crud.refresh_token.get_by_jti(db, jti=jti)
     assert db_token_after is not None
     assert db_token_after.revoked
+    # revoked_at should be recorded so the reuse-grace window can be evaluated
+    assert db_token_after.revoked_at is not None
+
+
+def test_delete_auth_cookies_mirrors_secure_attributes(monkeypatch) -> None:
+    """delete_auth_cookies must mirror the prod Secure/SameSite=None attributes."""
+    monkeypatch.delenv("RUNNING_TESTS", raising=False)
+    monkeypatch.setenv("HTTP_COOKIE_SECURE", "1")
+
+    response = Response()
+    security.delete_auth_cookies(response)
+
+    set_cookies = [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
+    assert len(set_cookies) == 2
+    assert any(h.startswith("access_token=") for h in set_cookies)
+    assert any(h.startswith("refresh_token=") for h in set_cookies)
+    for header in set_cookies:
+        assert "Secure" in header
+        assert "samesite=none" in header.lower()
+
+
+def test_logout_revokes_expired_refresh_token(client: TestClient, db: Session) -> None:
+    """An expired refresh token is still revoked in the DB on logout."""
+    user = create_user(db)
+    token_jti = uuid4()
+    crud.refresh_token.create(
+        db,
+        obj_in=RefreshTokenCreate(
+            jti=token_jti,
+            user_id=user.id,
+            issued_at=datetime.now(timezone.utc) - timedelta(days=1),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=29),
+        ),
+    )
+    # Craft a refresh JWT whose signature is valid but whose exp is in the past
+    expired_jwt = jwt.encode(
+        {
+            "sub": str(user.id),
+            "jti": str(token_jti),
+            "type": "refresh",
+            "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            "iat": datetime.now(timezone.utc) - timedelta(days=1),
+        },
+        settings.SECRET_KEY,
+        algorithm=security.ALGORITHM,
+    )
+
+    response = client.get(
+        f"{settings.API_V1_STR}/auth/remove-access-token",
+        cookies={"refresh_token": f"Bearer {expired_jwt}"},
+    )
+    assert response.status_code == 200
+
+    db_token = crud.refresh_token.get_by_jti(db, jti=token_jti)
+    assert db_token is not None
+    assert db_token.revoked is True
+
+
+def test_login_sets_persistent_refresh_cookie(client: TestClient, db: Session) -> None:
+    """Login should set a persistent (Max-Age) refresh cookie, not a session cookie."""
+    user = create_user(db, password="mysecretpassword")
+
+    response = client.post(
+        f"{settings.API_V1_STR}/auth/access-token",
+        data={"username": user.email, "password": "mysecretpassword"},
+        headers={"content_type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    refresh_cookie = next(
+        (h for h in set_cookie_headers if h.startswith("refresh_token=")), None
+    )
+    access_cookie = next(
+        (h for h in set_cookie_headers if h.startswith("access_token=")), None
+    )
+    assert refresh_cookie is not None
+    assert access_cookie is not None
+    # Refresh cookie persists across browser sessions; access cookie stays a session cookie
+    assert "Max-Age" in refresh_cookie
+    assert "Max-Age" not in access_cookie
+
+
+def test_refresh_token_within_grace_window_succeeds(
+    client: TestClient, db: Session
+) -> None:
+    """A just-rotated refresh token is still accepted within the grace window."""
+    user = create_user(db)
+
+    refresh_token_str = security.create_refresh_token(db, subject=str(user.id))
+    payload = security.decode_token(refresh_token_str)
+    jti = payload["jti"]
+
+    # Revoke just now (revoked_at = now), simulating a concurrent rotation
+    crud.refresh_token.revoke(db, jti=jti)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/auth/refresh-token",
+        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
+    )
+
+    assert response.status_code == 200
+    assert response.cookies.get("access_token") is not None
+    assert response.cookies.get("refresh_token") is not None
+
+
+def test_refresh_token_reuse_after_grace_window_fails(
+    client: TestClient, db: Session
+) -> None:
+    """A revoked token reused past the grace window is rejected."""
+    user = create_user(db)
+
+    refresh_token_str = security.create_refresh_token(db, subject=str(user.id))
+    payload = security.decode_token(refresh_token_str)
+    jti = payload["jti"]
+
+    db_token = crud.refresh_token.get_by_jti(db, jti=jti)
+    assert db_token is not None
+    crud.refresh_token.update(
+        db,
+        db_obj=db_token,
+        obj_in=RefreshTokenUpdate(
+            revoked=True,
+            revoked_at=datetime.now(timezone.utc)
+            - timedelta(seconds=settings.REFRESH_TOKEN_REUSE_GRACE_SECONDS + 1),
+        ),
+    )
+
+    response = client.post(
+        f"{settings.API_V1_STR}/auth/refresh-token",
+        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
+    )
+
+    assert response.status_code == 401
+    assert "Refresh token revoked or expired" in response.json()["detail"]
+
+
+def test_refresh_token_concurrent_reuse_both_succeed(
+    client: TestClient, db: Session
+) -> None:
+    """Two refreshes of the same token within the grace window both succeed."""
+    user = create_user(db)
+
+    refresh_token_str = security.create_refresh_token(db, subject=str(user.id))
+
+    first = client.post(
+        f"{settings.API_V1_STR}/auth/refresh-token",
+        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
+    )
+    assert first.status_code == 200
+
+    # Reusing the same (now rotated/revoked) token again immediately is tolerated
+    second = client.post(
+        f"{settings.API_V1_STR}/auth/refresh-token",
+        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
+    )
+    assert second.status_code == 200
 
 
 def test_login_updates_last_login_and_activity_timestamps(
@@ -422,6 +633,7 @@ def test_activity_tracking_updates_last_activity_on_authenticated_request(
 
     # Wait a moment and make an authenticated request
     import time
+
     time.sleep(1)
 
     # Make authenticated request (test token endpoint)
@@ -454,9 +666,7 @@ def test_activity_tracking_throttle_prevents_frequent_updates(
     db.refresh(user)
 
     # Test the CRUD method directly
-    updated_user = crud.user.update_last_activity(
-        db, user=user, throttle_minutes=15
-    )
+    updated_user = crud.user.update_last_activity(db, user=user, throttle_minutes=15)
 
     # Should return None because within throttle window
     assert updated_user is None
@@ -482,9 +692,7 @@ def test_activity_tracking_updates_when_outside_throttle_window(
 
     # Test the CRUD method directly
     before_update = datetime.now(timezone.utc)
-    updated_user = crud.user.update_last_activity(
-        db, user=user, throttle_minutes=15
-    )
+    updated_user = crud.user.update_last_activity(db, user=user, throttle_minutes=15)
     after_update = datetime.now(timezone.utc)
 
     # Should return updated user because outside throttle window
@@ -510,9 +718,7 @@ def test_activity_tracking_updates_when_last_activity_is_none(
 
     # Test the CRUD method directly
     before_update = datetime.now(timezone.utc)
-    updated_user = crud.user.update_last_activity(
-        db, user=user, throttle_minutes=15
-    )
+    updated_user = crud.user.update_last_activity(db, user=user, throttle_minutes=15)
     after_update = datetime.now(timezone.utc)
 
     # Should return updated user because last_activity_at was None
@@ -528,8 +734,11 @@ def test_activity_tracking_updates_when_last_activity_is_none(
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_notification")
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_verification")
 def test_change_email_success(
-    mock_verify, mock_notify,
-    client: TestClient, db: Session, normal_user_access_token: str
+    mock_verify,
+    mock_notify,
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
 ) -> None:
     """Test successful email change request sets pending_email."""
     current_user = get_current_user(db, normal_user_access_token)
@@ -546,8 +755,11 @@ def test_change_email_success(
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_notification")
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_verification")
 def test_change_email_wrong_password(
-    mock_verify, mock_notify,
-    client: TestClient, db: Session, normal_user_access_token: str
+    mock_verify,
+    mock_notify,
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
 ) -> None:
     """Test email change fails with wrong password."""
     new_email = random_email()
@@ -559,8 +771,11 @@ def test_change_email_wrong_password(
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_notification")
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_verification")
 def test_change_email_same_email(
-    mock_verify, mock_notify,
-    client: TestClient, db: Session, normal_user_access_token: str
+    mock_verify,
+    mock_notify,
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
 ) -> None:
     """Test email change fails when new email matches current email."""
     current_user = get_current_user(db, normal_user_access_token)
@@ -572,8 +787,11 @@ def test_change_email_same_email(
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_notification")
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_verification")
 def test_change_email_duplicate_email(
-    mock_verify, mock_notify,
-    client: TestClient, db: Session, normal_user_access_token: str
+    mock_verify,
+    mock_notify,
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
 ) -> None:
     """Test email change fails when new email is already in use."""
     other_user = create_user(db)
@@ -585,8 +803,11 @@ def test_change_email_duplicate_email(
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_notification")
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_verification")
 def test_change_email_demo_user(
-    mock_verify, mock_notify,
-    client: TestClient, db: Session, normal_user_access_token: str
+    mock_verify,
+    mock_notify,
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
 ) -> None:
     """Test email change is blocked for demo users."""
     current_user = get_current_user(db, normal_user_access_token)
@@ -597,9 +818,7 @@ def test_change_email_demo_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_confirm_email_change_with_valid_token(
-    client: TestClient, db: Session
-) -> None:
+def test_confirm_email_change_with_valid_token(client: TestClient, db: Session) -> None:
     """Test confirming an email change with a valid token."""
     new_email = random_email()
     user = create_user(db, password="mysecretpassword")
@@ -673,9 +892,7 @@ def test_confirm_email_change_with_invalid_token(
     assert r.request.url == settings.API_DOMAIN + "/auth/login?error=invalid"
 
 
-def test_confirm_email_change_duplicate_email(
-    client: TestClient, db: Session
-) -> None:
+def test_confirm_email_change_duplicate_email(client: TestClient, db: Session) -> None:
     """Test TOCTOU guard: another user registers the email before confirmation."""
     new_email = random_email()
     user = create_user(db, password="mysecretpassword")
@@ -707,8 +924,11 @@ def test_confirm_email_change_duplicate_email(
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_notification")
 @patch("app.api.api_v1.endpoints.auth.mail.send_email_change_verification")
 def test_change_email_cleans_up_previous_token(
-    mock_verify, mock_notify,
-    client: TestClient, db: Session, normal_user_access_token: str
+    mock_verify,
+    mock_notify,
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
 ) -> None:
     """Test that requesting a new email change cleans up previous tokens."""
     current_user = get_current_user(db, normal_user_access_token)

--- a/backend/app/tests/crud/test_refresh_token.py
+++ b/backend/app/tests/crud/test_refresh_token.py
@@ -1,9 +1,10 @@
 import uuid
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
 from app import crud
-from app.schemas.refresh_token import RefreshTokenUpdate
+from app.schemas.refresh_token import RefreshTokenCreate, RefreshTokenUpdate
 from app.tests.utils.refresh_token import create_refresh_token_data
 from app.tests.utils.user import create_user
 
@@ -100,6 +101,54 @@ def test_delete_refresh_token(db: Session) -> None:
     # Verify token is actually deleted
     retrieved_token = crud.refresh_token.get_by_jti(db, jti=refresh_token.jti)
     assert retrieved_token is None
+
+
+def test_delete_stale_refresh_tokens(db: Session) -> None:
+    """delete_stale purges expired and long-revoked tokens, keeps live/fresh ones."""
+    user = create_user(db)
+    now = datetime.now(timezone.utc)
+
+    # Expired token (past expires_at) -> should be deleted
+    expired = crud.refresh_token.create(
+        db,
+        obj_in=RefreshTokenCreate(
+            jti=uuid.uuid4(),
+            user_id=user.id,
+            issued_at=now - timedelta(days=31),
+            expires_at=now - timedelta(days=1),
+        ),
+    )
+
+    # Revoked long ago (beyond retention) but not yet expired -> should be deleted
+    revoked_old = crud.refresh_token.create(
+        db, obj_in=create_refresh_token_data(user.id)
+    )
+    crud.refresh_token.update(
+        db,
+        db_obj=revoked_old,
+        obj_in=RefreshTokenUpdate(revoked=True, revoked_at=now - timedelta(days=2)),
+    )
+
+    # Recently revoked (within retention) -> should be kept
+    revoked_recent = crud.refresh_token.create(
+        db, obj_in=create_refresh_token_data(user.id)
+    )
+    crud.refresh_token.update(
+        db,
+        db_obj=revoked_recent,
+        obj_in=RefreshTokenUpdate(revoked=True, revoked_at=now),
+    )
+
+    # Fresh, valid token -> should be kept
+    fresh = crud.refresh_token.create(db, obj_in=create_refresh_token_data(user.id))
+
+    deleted = crud.refresh_token.delete_stale(db)
+
+    assert deleted >= 2
+    assert crud.refresh_token.get_by_jti(db, jti=expired.jti) is None
+    assert crud.refresh_token.get_by_jti(db, jti=revoked_old.jti) is None
+    assert crud.refresh_token.get_by_jti(db, jti=revoked_recent.jti) is not None
+    assert crud.refresh_token.get_by_jti(db, jti=fresh.jti) is not None
 
 
 def test_get_multi_refresh_tokens(db: Session) -> None:

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -1,5 +1,11 @@
 import axios from 'axios';
-import { ReactNode, createContext, useContext, useState } from 'react';
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import { Navigate, useLocation } from 'react-router';
 
 interface Login {
@@ -47,6 +53,20 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
     return null;
   });
 
+  // When the api interceptor exhausts a token refresh, it dispatches
+  // 'auth:session-expired' instead of forcing a redirect. Clear the cached
+  // profile and user state so RequireAuth redirects protected routes while
+  // public routes (e.g. /explore) keep rendering with anonymous data.
+  useEffect(() => {
+    function handleSessionExpired() {
+      localStorage.removeItem('userProfile');
+      setUser(null);
+    }
+    window.addEventListener('auth:session-expired', handleSessionExpired);
+    return () =>
+      window.removeEventListener('auth:session-expired', handleSessionExpired);
+  }, []);
+
   async function login(data: { username: string; password: string }) {
     await axios.post('/api/v1/auth/access-token', data, {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -64,7 +84,7 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
   async function logout() {
     localStorage.removeItem('userProfile');
     await axios
-      .get('/api/v1/auth/remove-access-token')
+      .get('/api/v1/auth/remove-access-token', { withCredentials: true })
       .then(() => setUser(null));
   }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -59,7 +59,11 @@ api.interceptors.response.use(
           })
           .catch((err) => {
             processQueue(err);
-            window.location.href = '/auth/login';
+            // Don't hard-redirect here: that bounces users off public pages
+            // (e.g. /explore) too. Instead notify the app that the session is
+            // gone and let React Router decide — protected routes redirect to
+            // login via RequireAuth, public routes keep rendering.
+            window.dispatchEvent(new Event('auth:session-expired'));
             reject(err);
           })
           .finally(() => {


### PR DESCRIPTION
## Summary
Fixes an auth flow where an expired access token couldn't cleanly use the refresh token, bouncing users to the login screen — even on public pages like `/explore`. The root causes were the browser dropping the refresh cookie on restart and the frontend hard-redirecting on any refresh failure. Also addresses follow-up audit findings around logout cookie clearing, expired-token revocation, and unbounded growth of the refresh token table.

## Changes
- **Backend:**
  - Persist the refresh cookie across browser sessions by giving it an explicit `max_age` (the access cookie stays a session cookie).
  - Add a short reuse grace window (`REFRESH_TOKEN_REUSE_GRACE_SECONDS`, default 10s) so concurrent/cross-tab refreshes of a just-rotated token don't 401 each other.
  - Logout now revokes the refresh token's `jti` in the DB and clears **both** cookies; expired tokens are decoded with `verify_exp=False` (signature still verified) so their `jti` is still revoked.
  - Mirror the `secure`/`samesite` attributes when deleting auth cookies (shared `_resolve_cookie_security` helper) so logout actually clears cookies in a cross-site `SameSite=None; Secure` context.
  - Add `crud.refresh_token.delete_stale()` and a daily Celery beat task (`cleanup_refresh_tokens_task`, 03:00) to purge expired and long-revoked tokens, with a 1-day retention buffer safely beyond the grace window.
- **Frontend:**
  - On exhausted token refresh, the axios interceptor dispatches an `auth:session-expired` event instead of forcing `window.location.href = '/auth/login'`. `AuthContext` listens and clears cached user state, so protected routes redirect via `RequireAuth` while public routes keep rendering anonymously.
  - Send `withCredentials: true` on logout so the refresh cookie reaches the backend for revocation.
- **Database:**
  - Add `revoked_at` column to `refresh_tokens` (migration `f7cd65434957`).

## Testing
- `docker compose exec backend pytest app/tests/api/api_v1/test_auth.py app/tests/crud/test_refresh_token.py` — 49 passed.
- New/updated tests cover: persistent refresh cookie `max_age`, grace-window success + post-grace failure, concurrent reuse, logout revoking both active and expired tokens, cookie-deletion attributes mirroring (`Secure` + `SameSite=none`), and `delete_stale` purge behavior.
- `docker compose exec backend mypy app/crud/crud_refresh_token.py` — clean; `black --check` clean on all changed backend files.
- Manual QA (prod-like, `HTTP_COOKIE_SECURE=1`): log in, restart browser, confirm session survives; log out and confirm both `access_token` and `refresh_token` cookies are removed in devtools.

## Breaking Changes
- Migration required: `docker compose exec backend alembic upgrade head`
- Optional new env var: `REFRESH_TOKEN_REUSE_GRACE_SECONDS` (defaults to `10`)

## Related Issues
<!-- add issue references if applicable -->
