### PR TITLE
[Bug] Fall back to /explore instead of /login on a dead cached session

### DIFF
--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react';
 import { Navigate, useLocation } from 'react-router';
 
+import api from './api';
+
 interface Login {
   username: string;
   password: string;
@@ -32,11 +34,13 @@ export interface User {
 
 const context: {
   user: User | null;
+  authChecked: boolean;
   login: (data: Login) => Promise<void>;
   logout: () => Promise<void>;
   updateProfile: () => Promise<void>;
 } = {
   user: null,
+  authChecked: true,
   login: async () => {},
   logout: async () => {},
   updateProfile: async () => {},
@@ -53,6 +57,18 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
     return null;
   });
 
+  // The cached profile above is read optimistically so the UI can render
+  // immediately, but it isn't proof the session is still valid (e.g. the
+  // refresh token may have expired or been revoked while the browser was
+  // closed). authChecked tracks whether we've confirmed that. Routes that
+  // care about auth state (RequireAuth, Landing) should wait for this before
+  // deciding where to send the user, otherwise a dead cached session causes
+  // a flash into protected content followed by a bounce to /auth/login
+  // instead of falling back to the public /explore page.
+  const [authChecked, setAuthChecked] = useState(() => {
+    return localStorage.getItem('userProfile') === null;
+  });
+
   // When the api interceptor exhausts a token refresh, it dispatches
   // 'auth:session-expired' instead of forcing a redirect. Clear the cached
   // profile and user state so RequireAuth redirects protected routes while
@@ -61,10 +77,44 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
     function handleSessionExpired() {
       localStorage.removeItem('userProfile');
       setUser(null);
+      setAuthChecked(true);
     }
     window.addEventListener('auth:session-expired', handleSessionExpired);
     return () =>
       window.removeEventListener('auth:session-expired', handleSessionExpired);
+  }, []);
+
+  // Validate the cached profile on startup. /auth/test-token requires a
+  // valid access token; if it's expired, the api interceptor transparently
+  // refreshes it via the (httponly) refresh cookie and retries. If that
+  // also fails, the interceptor dispatches 'auth:session-expired' (handled
+  // above), which clears the stale profile and marks auth as checked.
+  useEffect(() => {
+    if (authChecked) return;
+
+    let cancelled = false;
+
+    api
+      .post('/auth/test-token')
+      .then((res) => {
+        if (cancelled) return;
+        localStorage.setItem('userProfile', JSON.stringify(res.data));
+        setUser(res.data);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // auth:session-expired already cleared user/localStorage if the
+        // refresh ultimately failed; defensively ensure user is cleared.
+        setUser(null);
+      })
+      .finally(() => {
+        if (!cancelled) setAuthChecked(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function login(data: { username: string; password: string }) {
@@ -78,6 +128,7 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
     if (currentUser) {
       localStorage.setItem('userProfile', JSON.stringify(currentUser.data));
       setUser(currentUser.data);
+      setAuthChecked(true);
     }
   }
 
@@ -85,7 +136,10 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('userProfile');
     await axios
       .get('/api/v1/auth/remove-access-token', { withCredentials: true })
-      .then(() => setUser(null));
+      .then(() => {
+        setUser(null);
+        setAuthChecked(true);
+      });
   }
 
   async function updateProfile() {
@@ -99,15 +153,24 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, updateProfile }}>
+    <AuthContext.Provider
+      value={{ user, authChecked, login, logout, updateProfile }}
+    >
       {children}
     </AuthContext.Provider>
   );
 }
 
 export function RequireAuth({ children }: { children: React.ReactNode }) {
-  const { user } = useContext(AuthContext);
+  const { user, authChecked } = useContext(AuthContext);
   const location = useLocation();
+
+  // Wait for the cached profile to be verified before redirecting, so a
+  // dead session isn't briefly treated as authenticated and then bounced
+  // to /auth/login. Render nothing during the brief verification window.
+  if (!authChecked) {
+    return null;
+  }
 
   if (!user) {
     return <Navigate to="/auth/login" state={{ from: location }} replace />;
@@ -117,8 +180,12 @@ export function RequireAuth({ children }: { children: React.ReactNode }) {
 }
 
 export function RequireAdmin({ children }: { children: React.ReactNode }) {
-  const { user } = useContext(AuthContext);
+  const { user, authChecked } = useContext(AuthContext);
   const location = useLocation();
+
+  if (!authChecked) {
+    return null;
+  }
 
   if (!user || (user && !user.is_superuser)) {
     return <Navigate to="/auth/login" state={{ from: location }} replace />;

--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -8,17 +8,24 @@ import brandLogo from '../assets/d2s-logo-amber-text-white-symbol.svg';
 import landingVideo from '../assets/landing.mp4';
 
 export default function Landing() {
-  const { user } = useContext(AuthContext);
+  const { user, authChecked } = useContext(AuthContext);
   const navigate = useNavigate();
   useEffect(() => {
+    // Wait until the cached profile (if any) has been verified before
+    // deciding where to send the user. Otherwise a stale profile with a
+    // dead session briefly looks authenticated and routes into protected
+    // /home, which then bounces to /auth/login once the session check
+    // fails, instead of falling back to the public /explore page.
+    if (!authChecked) return;
+
     if (user) {
       navigate('/home');
     } else if (import.meta.env.VITE_STAC_ENABLED === 'true') {
       navigate('/explore');
     }
-  }, [navigate, user]);
+  }, [navigate, user, authChecked]);
 
-  if (user || import.meta.env.VITE_STAC_ENABLED === 'true') {
+  if (!authChecked || user || import.meta.env.VITE_STAC_ENABLED === 'true') {
     return null;
   }
 


### PR DESCRIPTION
## Summary
Fixes a bug where a returning user with a stale `userProfile` cached in `localStorage` and an unrecoverable session (expired/revoked refresh token) was bounced to `/auth/login` instead of landing on the public `/explore` page.

## Changes
- Frontend: `AuthContext` now treats the cached `userProfile` as provisional. On startup, if a cached profile exists, it's verified via `POST /auth/test-token` (which transparently goes through the existing refresh interceptor). A new `authChecked` flag tracks whether this verification has completed.
- Frontend: `RequireAuth` / `RequireAdmin` render nothing (instead of redirecting) until `authChecked` is true, so they never act on an unverified profile.
- Frontend: `Landing` waits for `authChecked` before deciding where to navigate, so a dead session resolves to anonymous and routes to `/explore` (STAC enabled) instead of flashing into protected `/home` and then bouncing to `/auth/login`.

## Testing
- `docker compose exec frontend npx tsc --noEmit` — clean
- `yarn lint` on changed files — no new errors (pre-existing unrelated errors in `DashboardUserList.tsx` only)
- Manual QA on `ps2.d2s.org`:
  - Stale `userProfile` + dead session (deleted `access_token` and `refresh_token` cookies) → navigating to `/` lands on `/explore`, no flash of `/home`, no redirect to `/auth/login`.
  - No cached profile + valid session cookies → lands on `/explore` as expected.
  - Valid cached profile + valid session → `/auth/test-token` fires once, lands on `/home` as before (no regression).
  - Deep-linking to `/projects` while logged out still redirects to `/auth/login` (protected routes still enforced).

## Related Issues
Follow-up to #362 (refresh token persistence and logout cookie clearing).
