### PR TITLE
[Bug] Allow authenticated non-members to like public data products

### DIFF
--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -167,7 +167,7 @@ def get_shortened_url(
 def like_data_product(
     data_product_id: UUID,
     current_user: models.User = Depends(deps.get_current_approved_user),
-    data_product: models.DataProduct = Depends(deps.can_read_data_product),
+    data_product: models.DataProduct = Depends(deps.can_read_or_public_data_product),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     """Like a data product. Returns 400 if already liked."""
@@ -202,7 +202,7 @@ def like_data_product(
 def unlike_data_product(
     data_product_id: UUID,
     current_user: models.User = Depends(deps.get_current_approved_user),
-    data_product: models.DataProduct = Depends(deps.can_read_data_product),
+    data_product: models.DataProduct = Depends(deps.can_read_or_public_data_product),
     db: Session = Depends(deps.get_db),
 ) -> Any:
     """Remove a like from a data product. Returns 400 if not currently liked."""

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -481,6 +481,56 @@ def can_read_data_product(
     return data_product
 
 
+def can_read_or_public_data_product(
+    project_id: UUID,
+    flight_id: UUID,
+    data_product_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_approved_user),
+) -> models.DataProduct:
+    """Return data product if the current user can read it.
+
+    Access is granted when the data product is publicly accessible (its file
+    permission is_public is True, which is also set when the parent project is
+    published) OR the user is a member of the project. Used by engagement
+    endpoints so any authenticated user who can see a data product can engage
+    with it, not only project members.
+    """
+    data_product = crud.data_product.get(db, id=data_product_id)
+    if not data_product or not data_product.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        )
+    # IDOR guards: the data product must belong to the flight, and the flight
+    # to the project named in the path.
+    flight = crud.flight.get(db, id=flight_id)
+    if not flight or data_product.flight_id != flight.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Data product does not belong to specified flight",
+        )
+    if flight.project_id != project_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Flight does not belong to specified project",
+        )
+    # Publicly accessible files are readable by any authenticated user.
+    file_permission = crud.file_permission.get_by_data_product(
+        db, file_id=data_product_id
+    )
+    if file_permission and file_permission.is_public:
+        return data_product
+    # Otherwise require project membership.
+    project_member = crud.project_member.get_by_project_and_member_id(
+        db, project_uuid=project_id, member_id=current_user.id
+    )
+    if project_member:
+        return data_product
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+    )
+
+
 def can_read_write_data_product(
     data_product_id: UUID,
     db: Session = Depends(get_db),

--- a/backend/app/tests/api/api_v1/test_data_product_likes.py
+++ b/backend/app/tests/api/api_v1/test_data_product_likes.py
@@ -156,3 +156,37 @@ def test_like_denied_for_non_member(
     response = client.post(_like_url(data_product))
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_like_allowed_for_non_member_when_public(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    # Any authenticated user can like a data product in a published/public
+    # project, even without project membership.
+    data_product = SampleDataProduct(db)
+    crud.project.update_project_visibility(
+        db, project_id=data_product.project.id, is_public=True
+    )
+
+    response = client.post(_like_url(data_product))
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == {"liked": True, "like_count": 1}
+
+
+def test_unlike_allowed_for_non_member_when_public(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db)
+    crud.project.update_project_visibility(
+        db, project_id=data_product.project.id, is_public=True
+    )
+    create_data_product_like(
+        db, data_product_id=data_product.obj.id, user_id=current_user.id
+    )
+
+    response = client.delete(_like_url(data_product))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"liked": False, "like_count": 0}

--- a/frontend/src/components/maps/LayerPane/DataProductCard.tsx
+++ b/frontend/src/components/maps/LayerPane/DataProductCard.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
+import AuthContext from '../../../AuthContext';
 import { useMapContext } from '../MapContext';
 import { useMobileView } from '../MobileViewContext';
 
@@ -30,6 +31,7 @@ export default function DataProductCard({
   } = useMapContext();
 
   const { setMobileView } = useMobileView();
+  const { user } = useContext(AuthContext);
   const [shareOpen, setShareOpen] = useState(false);
 
   const { dispatch } = useRasterSymbologyContext();
@@ -39,12 +41,13 @@ export default function DataProductCard({
   );
   const isPointCloud = dataProduct.data_type === 'point_cloud';
 
-  // Likes are member-only; non-members (e.g. anonymous /explore) see a
-  // read-only count. The like button stops click propagation so liking never
-  // activates the card (clicking elsewhere on the card still does). The
-  // engagement sits in the card's title row in a fixed spot/size regardless of
-  // whether the card is expanded.
-  const interactive = Boolean(activeProject?.role);
+  // Likes require authentication; anonymous viewers (e.g. /explore) see a
+  // read-only count. Any logged-in user can like a data product they can see,
+  // including non-members viewing a published/public project. The like button
+  // stops click propagation so liking never activates the card (clicking
+  // elsewhere on the card still does). The engagement sits in the card's title
+  // row in a fixed spot/size regardless of whether the card is expanded.
+  const interactive = Boolean(user);
   const { engagement, toggleLike } = useDataProductLike(
     dataProduct,
     activeProject?.id,


### PR DESCRIPTION
## Summary
A logged-in user viewing a published/public data product (without being a project member) saw the like control as a read-only count and couldn't interact with it — and even if the button were clickable, the like endpoint would have rejected the request with a 404. Both layers now correctly allow any authenticated user who can view a data product to like it.

## Changes
- **Backend:** new `can_read_or_public_data_product` dependency in `deps.py` that grants access when the data product's file is public (set when its parent project is published) or the user is a project member. Wired into the `like`/`unlike` endpoints in place of the membership-only `can_read_data_product`.
- **Frontend:** the map `LayerPane` `DataProductCard` now gates the like button's interactivity on `Boolean(user)` (any authenticated user) instead of `Boolean(activeProject?.role)` (project role). Anonymous `/explore` viewers still see a read-only count, since they have no `user`.
- **Tests:** added coverage for a non-member liking/unliking a data product in a published/public project; the existing non-member + private denial (404) is unchanged.

## Testing
- Commands run: `docker compose exec backend pytest app/tests/api/api_v1/test_data_product_likes.py -v` — 11 passing (9 existing + 2 new).
- `docker compose exec frontend npx tsc --noEmit` and `npx eslint` on the changed frontend file — clean.
- Manual QA: as a logged-in user who is not a member of a published project, opened a data product on the map and confirmed the like button is now interactive and the like persists.

## Related Issues
Found while testing the profile Activity & stats feature (#364) — a user viewing their own engagement stats noticed they couldn't like a public data product they weren't a member of.