### PR TITLE
[Bug] Sign data product on single fetch so map tiles load

### DIFF
--- a/backend/app/crud/crud_data_product.py
+++ b/backend/app/crud/crud_data_product.py
@@ -111,6 +111,7 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
                 set_like_attrs(data_product, like_count, liked)
                 set_view_count_attr(data_product, view_count)
                 set_spatial_metadata_attrs(data_product)
+                set_signature_attr(data_product)
                 set_url_attr(data_product, upload_dir)
                 is_status_set = set_status_attr(data_product, data_product.jobs)
                 if user_style:

--- a/backend/app/tests/crud/test_data_product.py
+++ b/backend/app/tests/crud/test_data_product.py
@@ -51,6 +51,11 @@ def test_read_data_product(db: Session) -> None:
     )
     assert hasattr(stored_data_product, "url")
     assert hasattr(stored_data_product, "user_style")
+    # Signature is required for the map to request secure COG tiles; without it
+    # the tile URL has an empty secure value and expires=0 (403 URL expired).
+    assert hasattr(stored_data_product, "signature")
+    assert stored_data_product.signature["secure"]
+    assert stored_data_product.signature["expires"]
     assert stored_data_product.created_at is not None
     assert stored_data_product.updated_at is not None
 


### PR DESCRIPTION
## Summary
Opening a data product fetched via the single data-product endpoint (e.g. navigating to it from the profile Activity tab) failed to load its map layer, throwing `403: URL expired`. The endpoint omitted the tile signature that other read paths already attach.

## Changes
- Backend: `crud_data_product.get_single_by_id` now calls `set_signature_attr`, matching `get_multi_by_flight` and `get_public_data_product_by_id`
- Tests: `test_read_data_product` asserts `get_single_by_id` returns a populated `signature` (`secure` and `expires`)

## Testing
- Commands run: `docker compose exec backend pytest app/tests/crud/test_data_product.py -v` — all 18 passing
- Manual QA: open a data product via `GET /projects/{id}/flights/{id}/data_products/{id}` (e.g. via the profile Activity tab's "Recently viewed/liked" rows) and confirm the COG tile layer renders instead of erroring with `403 URL expired`

## Related Issues
Found while testing the profile Activity & stats feature.
