### PR TITLE
[Bug] Open published data products from profile activity for non-members

### DIFF
--- a/frontend/src/components/pages/auth/activity/DataProductRow.tsx
+++ b/frontend/src/components/pages/auth/activity/DataProductRow.tsx
@@ -3,14 +3,13 @@ import { ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import api from '../../../../api';
-import { DataProduct, ProjectDetail } from '../../workspace/projects/Project';
+import { DataProduct, ProjectItem } from '../../workspace/projects/Project';
 
 export default function DataProductRow({
   dataProductId,
   projectName,
   subline,
   projectId,
-  flightId,
   rank,
   metric,
 }: {
@@ -18,7 +17,6 @@ export default function DataProductRow({
   projectName: string;
   subline: string;
   projectId: string;
-  flightId: string;
   rank?: number;
   metric: ReactNode;
 }) {
@@ -27,20 +25,35 @@ export default function DataProductRow({
 
   // Open the data product in the map workspace, mirroring the "View" action in
   // DataProductCard/DataProductsTable. The map's LayerPane expects the full
-  // project and data product objects in navigation state, so fetch them first.
+  // project and data product objects in navigation state.
+  //
+  // "Your activity" rows can reference data products in published projects the
+  // user is not a member of, so both fetches must work for non-members:
+  //  - project: try the member endpoint, then fall back to the public published
+  //    endpoint, tagging it is_public (as ProjectLoader does) so the map uses
+  //    its public data sources.
+  //  - data product: /public/user_access returns the signed data product for
+  //    members and public viewers alike.
   async function handleClick() {
     if (isLoading) return;
     setIsLoading(true);
     try {
-      const [projectResponse, dataProductResponse] = await Promise.all([
-        api.get<ProjectDetail>(`/projects/${projectId}`),
-        api.get<DataProduct>(
-          `/projects/${projectId}/flights/${flightId}/data_products/${dataProductId}`
-        ),
-      ]);
+      let project: ProjectItem;
+      try {
+        const response = await api.get<ProjectItem>(`/projects/${projectId}`);
+        project = response.data;
+      } catch {
+        const response = await api.get<ProjectItem>(
+          `/public/projects/${projectId}`
+        );
+        project = { ...response.data, is_public: true };
+      }
+      const dataProductResponse = await api.get<DataProduct>(
+        `/public/user_access?file_id=${dataProductId}`
+      );
       navigate('/home', {
         state: {
-          project: projectResponse.data,
+          project,
           dataProduct: dataProductResponse.data,
           navContext: 'dataProductCard',
         },

--- a/frontend/src/components/pages/auth/activity/ProfileActivity.tsx
+++ b/frontend/src/components/pages/auth/activity/ProfileActivity.tsx
@@ -148,7 +148,6 @@ export default function ProfileActivity({ active }: { active: boolean }) {
                     subline={subline(row.data_type, row.flight_date)}
                     dataProductId={row.id}
                     projectId={row.project_id}
-                    flightId={row.flight_id}
                     metric={
                       <span className="flex items-center gap-1 text-gray-600">
                         <FaRegEye className="h-4 w-4" />
@@ -171,7 +170,6 @@ export default function ProfileActivity({ active }: { active: boolean }) {
                     subline={subline(row.data_type, row.flight_date)}
                     dataProductId={row.id}
                     projectId={row.project_id}
-                    flightId={row.flight_id}
                     metric={
                       <span className="flex items-center gap-1 text-accent2">
                         <FaHeart className="h-4 w-4" />
@@ -230,7 +228,6 @@ export default function ProfileActivity({ active }: { active: boolean }) {
                     )}
                     dataProductId={row.id}
                     projectId={row.project_id}
-                    flightId={row.flight_id}
                     metric={
                       <span className="text-xs text-gray-400">
                         {formatRelativeTime(row.last_action_at)}
@@ -255,7 +252,6 @@ export default function ProfileActivity({ active }: { active: boolean }) {
                     )}
                     dataProductId={row.id}
                     projectId={row.project_id}
-                    flightId={row.flight_id}
                     metric={
                       <span className="text-xs text-gray-400">
                         {formatRelativeTime(row.last_action_at)}


### PR DESCRIPTION
## Summary
Fixes navigation from the profile **Activity & stats** tab when a row points to a data product in a **published** project the user isn't a member of. Previously, clicking such a row in "Your activity" (e.g. Recently viewed/liked) silently did nothing because the project and data product were fetched from membership-gated endpoints that return 404 for non-members.

## Changes
- Frontend: In `DataProductRow.handleClick`, fetch the project from the member endpoint (`/projects/{id}`) and fall back to the public published endpoint (`/public/projects/{id}`), tagging the fallback with `is_public: true` (matching `ProjectLoader`) so the map's `isPublicOnly` logic uses public data sources for non-members.
- Frontend: Fetch the data product via `/public/user_access`, which returns the signed data product for members and public viewers alike (also ensures COG tiles get a valid signature).
- Frontend: Removed the now-unused `flightId` prop from `DataProductRow` and its call sites in `ProfileActivity`.

## Testing
- `docker compose exec frontend npx tsc --noEmit` — passes
- `docker compose exec frontend npx eslint src/components/pages/auth/activity/DataProductRow.tsx src/components/pages/auth/activity/ProfileActivity.tsx` — clean
- Manual QA: As a user who is **not** a member of a published project, go to Profile → Activity & stats → "Your activity" → Recently viewed/liked, and click an item from that project. Verify it opens and renders in the map workspace. Confirm the member case (own/member projects) still opens as before.