### PR TITLE
[Bug] Fix data product liked status, engagement access checks, and logout method

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -144,7 +144,7 @@ def refresh_access_token(
     }
 
 
-@router.get("/remove-access-token")
+@router.post("/remove-access-token")
 def logout_access_token(
     response: Response,
     refresh_token: str = Cookie(None),

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -514,6 +514,13 @@ def can_read_or_public_data_product(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Flight does not belong to specified project",
         )
+    # Explicitly validate the parent hierarchy's soft-delete state rather than
+    # relying solely on the deactivation cascade reaching the data product.
+    project = crud.project.get(db, id=project_id)
+    if not flight.is_active or not project or not project.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        )
     # Publicly accessible files are readable by any authenticated user.
     file_permission = crud.file_permission.get_by_data_product(
         db, file_id=data_product_id

--- a/backend/app/crud/crud_data_product.py
+++ b/backend/app/crud/crud_data_product.py
@@ -133,6 +133,20 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
         upload_dir: str,
         user_id: Optional[UUID] = None,
     ) -> Optional[DataProduct]:
+        # Whether the requesting user has liked this data product. With user_id
+        # None (anonymous/share read), `user_id == None` renders IS NULL and
+        # matches no rows, so liked resolves to False.
+        liked_exists = (
+            select(1)
+            .where(
+                and_(
+                    DataProductLike.data_product_id == DataProduct.id,
+                    DataProductLike.user_id == user_id,
+                )
+            )
+            .exists()
+            .label("liked")
+        )
         like_count_sq = (
             select(func.count(DataProductLike.id))
             .where(DataProductLike.data_product_id == DataProduct.id)
@@ -146,7 +160,7 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
             .label("view_count")
         )
         data_product_query = (
-            select(DataProduct, like_count_sq, view_count_sq)
+            select(DataProduct, liked_exists, like_count_sq, view_count_sq)
             .join(DataProduct.file_permission)
             .join(DataProduct.flight)
             .options(joinedload(DataProduct.file_permission))
@@ -166,9 +180,8 @@ class CRUDDataProduct(CRUDBase[DataProduct, DataProductCreate, DataProductUpdate
             row = session.execute(data_product_query).unique().one_or_none()
             if not row:
                 return None
-            data_product, like_count, view_count = row
-            # Public/share read: no authenticated user, so liked is always False.
-            set_like_attrs(data_product, like_count, False)
+            data_product, liked, like_count, view_count = row
+            set_like_attrs(data_product, like_count, liked)
             set_view_count_attr(data_product, view_count)
             if data_product.file_permission.is_public:
                 set_spatial_metadata_attrs(data_product)

--- a/backend/app/tests/api/api_v1/test_auth.py
+++ b/backend/app/tests/api/api_v1/test_auth.py
@@ -75,7 +75,7 @@ def test_logout_removes_authorization_cookie(client: TestClient, db: Session) ->
     assert client.cookies.get("access_token")
     assert client.cookies.get("refresh_token")
     # logout
-    r = client.get(f"{settings.API_V1_STR}/auth/remove-access-token")
+    r = client.post(f"{settings.API_V1_STR}/auth/remove-access-token")
     assert r.status_code == 200
     assert r.cookies.get("access_token") is None
     assert client.cookies.get("access_token") is None
@@ -101,7 +101,7 @@ def test_logout_revokes_refresh_token(client: TestClient, db: Session) -> None:
     jti = UUID(security.decode_token(raw_token)["jti"])
     assert crud.refresh_token.get_by_jti(db, jti=jti).revoked is False
 
-    logout = client.get(f"{settings.API_V1_STR}/auth/remove-access-token")
+    logout = client.post(f"{settings.API_V1_STR}/auth/remove-access-token")
     assert logout.status_code == 200
 
     # Token is revoked in the DB
@@ -463,7 +463,7 @@ def test_logout_revokes_expired_refresh_token(client: TestClient, db: Session) -
         algorithm=security.ALGORITHM,
     )
 
-    response = client.get(
+    response = client.post(
         f"{settings.API_V1_STR}/auth/remove-access-token",
         cookies={"refresh_token": f"Bearer {expired_jwt}"},
     )

--- a/backend/app/tests/api/api_v1/test_data_product_likes.py
+++ b/backend/app/tests/api/api_v1/test_data_product_likes.py
@@ -1,10 +1,12 @@
 from fastapi import status
 from fastapi.testclient import TestClient
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from app import crud
 from app.api.deps import get_current_user
 from app.core.config import settings
+from app.models import Flight, Project
 from app.schemas.role import Role
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.data_product_like import create_data_product_like
@@ -190,3 +192,39 @@ def test_unlike_allowed_for_non_member_when_public(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"liked": False, "like_count": 0}
+
+
+def test_like_on_deactivated_flight_returns_404(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    # Defensive guard: a desync where the data product stays active but its
+    # parent flight is deactivated must not allow engagement.
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    db.execute(
+        update(Flight)
+        .where(Flight.id == data_product.flight.id)
+        .values(is_active=False)
+    )
+    db.commit()
+
+    response = client.post(_like_url(data_product))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_like_on_deactivated_project_returns_404(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user)
+    db.execute(
+        update(Project)
+        .where(Project.id == data_product.project.id)
+        .values(is_active=False)
+    )
+    db.commit()
+
+    response = client.post(_like_url(data_product))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/api_v1/test_public.py
+++ b/backend/app/tests/api/api_v1/test_public.py
@@ -7,6 +7,7 @@ from app.api.deps import get_current_user, get_current_approved_user
 from app.core.config import settings
 from app.schemas.file_permission import FilePermissionUpdate
 from app.tests.utils.data_product import SampleDataProduct
+from app.tests.utils.data_product_like import create_data_product_like
 
 # Center of test.tif (EPSG:32616, WGS84 bounds approx -86.9445, 41.4440)
 TEST_TIF_CENTER_LON = -86.94447585281846
@@ -167,3 +168,39 @@ def test_read_data_product_point_value_non_raster(client: TestClient, db: Sessio
         f"&lon={TEST_TIF_CENTER_LON}&lat={TEST_TIF_CENTER_LAT}"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_user_access_returns_liked_true_for_member_who_liked(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """A member opening their own (private) liked data product sees liked=True."""
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    # Owned by the current user, not public.
+    data_product = SampleDataProduct(db, user=current_user)
+    create_data_product_like(
+        db, data_product_id=data_product.obj.id, user_id=current_user.id
+    )
+
+    response = client.get(
+        f"{settings.API_V1_STR}/public/user_access?file_id={data_product.obj.id}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["liked"] is True
+
+
+def test_user_access_returns_liked_false_when_not_liked(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """The same access path reports liked=False when the user has not liked it."""
+    current_user = get_current_approved_user(
+        get_current_user(db, normal_user_access_token)
+    )
+    data_product = SampleDataProduct(db, user=current_user)
+
+    response = client.get(
+        f"{settings.API_V1_STR}/public/user_access?file_id={data_product.obj.id}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["liked"] is False

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -135,7 +135,7 @@ export function AuthContextProvider({ children }: { children: ReactNode }) {
   async function logout() {
     localStorage.removeItem('userProfile');
     await axios
-      .get('/api/v1/auth/remove-access-token', { withCredentials: true })
+      .post('/api/v1/auth/remove-access-token', null, { withCredentials: true })
       .then(() => {
         setUser(null);
         setAuthChecked(true);


### PR DESCRIPTION
 ## Summary
Fixes three issues surfaced by a bug audit of the recently merged engagement/auth work. The headline fix restores the "Unlike" action for members viewing their own data products; the other two are defensive hardening (parent-hierarchy access checks) and an HTTP-semantics correction (logout method).

## Changes
 - **Backend:**
   - `crud.data_product.get_public_data_product_by_id` now computes `liked` per-user via an `EXISTS` subquery instead of hardcoding `False`. With no authenticated user it renders `IS NULL` and matches no rows, so anonymous/share reads still return `liked: false` (behavior preserved).
   - `can_read_or_public_data_product` dependency now explicitly validates `Flight.is_active` and loads/validates `Project.is_active` (returns 404), instead of relying solely on `DataProduct.is_active` and the deactivation cascade.
   - `/auth/remove-access-token` changed from `GET` to `POST` (it revokes the refresh token and clears auth cookies, so it must not use a safe/idempotent method).
 - **Frontend:**
   - `AuthContext.logout` now calls the logout endpoint with `POST`.

## Testing
 - `docker compose exec backend pytest` — full suite passing.
 - Targeted: `docker compose exec backend pytest app/tests/api/api_v1/test_public.py app/tests/api/api_v1/test_data_product_likes.py app/tests/api/api_v1/test_auth.py` — 63 passed (includes 2 liked-status regressions, 2 deactivated flight/project guards, and updated logout tests).
 - `docker compose exec frontend npx tsc --noEmit` — clean.
 - Manual QA: as a project member, like one of your own private data products, open it from Profile Activity → heart shows **liked**; click → unlike (`DELETE`) succeeds with **no  400**.

## Breaking Changes
 - `/api/v1/auth/remove-access-token` is now **POST** (was GET). The frontend caller is updated in this PR; any other client must switch to POST.

## Related Issues
Found via internal bug audit (no tracking issue).