### PR TITLE
[Chore] Resolve fixable pytest warnings

### DIFF
--- a/backend/app/api/api_v1/endpoints/indoor_project_data.py
+++ b/backend/app/api/api_v1/endpoints/indoor_project_data.py
@@ -283,7 +283,7 @@ def read_indoor_project_data_spreadsheet(
             return payload_validated
         except ValidationError as e:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.errors()
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=e.errors()
             )
 
 
@@ -544,7 +544,7 @@ def read_indoor_project_data_plant(
         return payload_validated
     except ValidationError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.errors()
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=e.errors()
         )
 
 

--- a/backend/app/api/api_v1/endpoints/indoor_projects.py
+++ b/backend/app/api/api_v1/endpoints/indoor_projects.py
@@ -92,7 +92,7 @@ def update_indoor_project(
     if effective_start_date and effective_end_date:
         if effective_start_date > effective_end_date:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="Start date must be before end date",
             )
 

--- a/backend/app/api/api_v1/endpoints/projects.py
+++ b/backend/app/api/api_v1/endpoints/projects.py
@@ -133,7 +133,7 @@ def update_project(
     if project_in.planting_date and project.harvest_date:
         if project.harvest_date < project_in.planting_date:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=[
                     {
                         "loc": ["body", "harvest_date"],
@@ -146,7 +146,7 @@ def update_project(
     if project_in.harvest_date and project.planting_date:
         if project_in.harvest_date < project.planting_date:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=[
                     {
                         "loc": ["body", "harvest_date"],

--- a/backend/app/models/indoor_project.py
+++ b/backend/app/models/indoor_project.py
@@ -42,6 +42,7 @@ class IndoorProject(Base):
         cascade="all, delete-orphan",
         primaryjoin="and_(ProjectMember.project_type == 'INDOOR_PROJECT', ProjectMember.project_uuid == IndoorProject.id)",
         foreign_keys="[ProjectMember.project_uuid]",
+        overlaps="members",
     )
 
     def __repr__(self) -> str:

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -62,6 +62,7 @@ class Project(Base):
         cascade="all, delete-orphan",
         primaryjoin="and_(ProjectMember.project_type == 'PROJECT', ProjectMember.project_uuid == Project.id)",
         foreign_keys="[ProjectMember.project_uuid]",
+        overlaps="indoor_members",
     )
     modules: Mapped[List["ProjectModule"]] = relationship(
         back_populates="project", cascade="all, delete"

--- a/backend/app/models/project_member.py
+++ b/backend/app/models/project_member.py
@@ -62,14 +62,14 @@ class ProjectMember(Base):
         primaryjoin="and_(ProjectMember.project_type == 'PROJECT', ProjectMember.project_uuid == Project.id)",
         foreign_keys="[ProjectMember.project_uuid]",
         back_populates="members",
-        overlaps="indoor_project",
+        overlaps="indoor_project,indoor_members",
     )
     indoor_project: Mapped["IndoorProject"] = relationship(
         "IndoorProject",
         primaryjoin="and_(ProjectMember.project_type == 'INDOOR_PROJECT', ProjectMember.project_uuid == IndoorProject.id)",
         foreign_keys="[ProjectMember.project_uuid]",
         back_populates="indoor_members",
-        overlaps="uas_project",
+        overlaps="uas_project,members",
     )
     member: Mapped["User"] = relationship(back_populates="project_memberships")
     # TODO: Remove this relationship after migration

--- a/backend/app/schemas/indoor_project_data.py
+++ b/backend/app/schemas/indoor_project_data.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Extra, Field, field_validator, RootModel, UUID4
+from pydantic import BaseModel, ConfigDict, Field, field_validator, RootModel, UUID4
 
 
 class IndoorProjectDataBase(BaseModel):
@@ -158,10 +158,6 @@ class IndoorProjectDataPlantSideAvg(BaseModel):
     intensity: int
     fluorescence: int
 
-    class Config:
-        # extra = Extra.allow  # allows h0, h1, h2, etc. fields to be dynamically added
-        pass
-
     @classmethod
     def validate_dynamic_hue_fields(cls, values: Dict[str, int]) -> Dict[str, int]:
         for key in values:
@@ -234,10 +230,6 @@ class IndoorProjectDataPlantTop(BaseModel):
     saturation: int
     intensity: int
     fluorescence: int
-
-    class Config:
-        # extra = Extra.allow  # allows h0, h1, h2, etc. fields to be dynamically added
-        pass
 
     @classmethod
     def validate_dynamic_hue_fields(cls, values: Dict[str, int]) -> Dict[str, int]:
@@ -360,8 +352,7 @@ class VizRecord2(BaseModel):
     group: str
     interval_days: int
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class IndoorProjectDataViz2Response(BaseModel):

--- a/backend/app/tasks/toolbox_tasks.py
+++ b/backend/app/tasks/toolbox_tasks.py
@@ -47,7 +47,12 @@ def calculate_zonal_statistics(
         # required zonal statistics
         required_stats = "count min max mean median std"
         # get stats for zone
-        stats = zonal_stats(zones, data, affine=window_affine, stats=required_stats)
+        # rasterstats only receives the array, so pass the source nodata explicitly
+        # (falling back to its internal -999 sentinel) to silence its NodataWarning.
+        nodata = src.nodata if src.nodata is not None else -999
+        stats = zonal_stats(
+            zones, data, affine=window_affine, stats=required_stats, nodata=nodata
+        )
 
     job.update(status=Status.SUCCESS)
 

--- a/backend/app/tests/api/api_v1/test_auth.py
+++ b/backend/app/tests/api/api_v1/test_auth.py
@@ -1,6 +1,7 @@
 import random
 import secrets
 import string
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 from uuid import UUID, uuid4
@@ -22,6 +23,22 @@ from app.schemas.single_use_token import SingleUseTokenCreate
 from app.schemas.user import UserUpdate
 from app.tests.utils.user import create_user
 from app.tests.utils.utils import random_email
+
+
+@contextmanager
+def refresh_token_cookie(client: TestClient, token: str):
+    """Set the refresh_token cookie on the client for the wrapped request.
+
+    httpx deprecated per-request ``cookies=``; cookies must be set on the client
+    instance instead. The cookie is removed on exit to keep requests isolated.
+    """
+    client.cookies.set("refresh_token", token)
+    try:
+        yield
+    finally:
+        # delete() removes every refresh_token cookie by name; using pop()/get()
+        # here would raise CookieConflict when the response sets its own copy.
+        client.cookies.delete("refresh_token")
 
 
 def test_login_with_valid_credentials(client: TestClient, db: Session) -> None:
@@ -118,10 +135,8 @@ def test_logout_revokes_refresh_token(client: TestClient, db: Session) -> None:
             - timedelta(seconds=settings.REFRESH_TOKEN_REUSE_GRACE_SECONDS + 1),
         ),
     )
-    reuse = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": refresh_token},
-    )
+    with refresh_token_cookie(client, refresh_token):
+        reuse = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
     assert reuse.status_code == 401
 
 
@@ -223,10 +238,8 @@ def test_refresh_token_success(client: TestClient, db: Session) -> None:
     assert refresh_token is not None
 
     # Use refresh token to get new tokens
-    refresh_response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": refresh_token},
-    )
+    with refresh_token_cookie(client, refresh_token):
+        refresh_response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert refresh_response.status_code == 200
     response_data = refresh_response.json()
@@ -253,10 +266,8 @@ def test_refresh_token_missing(client: TestClient, db: Session) -> None:
 def test_refresh_token_malformed(client: TestClient, db: Session) -> None:
     """Test refresh token endpoint with malformed token."""
     # Test without Bearer prefix
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": "invalid-token-format"},
-    )
+    with refresh_token_cookie(client, "invalid-token-format"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     assert "Refresh token missing or malformed" in response.json()["detail"]
@@ -264,10 +275,8 @@ def test_refresh_token_malformed(client: TestClient, db: Session) -> None:
 
 def test_refresh_token_invalid_jwt(client: TestClient, db: Session) -> None:
     """Test refresh token endpoint with invalid JWT."""
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": "Bearer invalid.jwt.token"},
-    )
+    with refresh_token_cookie(client, "Bearer invalid.jwt.token"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     # Should fail during JWT validation
@@ -289,10 +298,8 @@ def test_refresh_token_missing_jti(client: TestClient, db: Session) -> None:
         payload, settings.SECRET_KEY, algorithm=security.ALGORITHM
     )
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {invalid_token}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {invalid_token}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     assert "Refresh token payload missing jti" in response.json()["detail"]
@@ -321,10 +328,8 @@ def test_refresh_token_revoked(client: TestClient, db: Session) -> None:
         ),
     )
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {refresh_token_str}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     assert "Refresh token revoked or expired" in response.json()["detail"]
@@ -345,10 +350,8 @@ def test_refresh_token_nonexistent_in_db(client: TestClient, db: Session) -> Non
 
     token = jwt.encode(payload, settings.SECRET_KEY, algorithm=security.ALGORITHM)
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {token}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {token}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     assert "Refresh token revoked or expired" in response.json()["detail"]
@@ -381,10 +384,8 @@ def test_refresh_token_expired_in_db(client: TestClient, db: Session) -> None:
 
     token = jwt.encode(payload, settings.SECRET_KEY, algorithm=security.ALGORITHM)
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {token}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {token}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     assert "Refresh token revoked or expired" in response.json()["detail"]
@@ -405,10 +406,8 @@ def test_refresh_token_revokes_old_token(client: TestClient, db: Session) -> Non
     assert not db_token_before.revoked
 
     # Use refresh token
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {refresh_token_str}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 200
 
@@ -463,10 +462,8 @@ def test_logout_revokes_expired_refresh_token(client: TestClient, db: Session) -
         algorithm=security.ALGORITHM,
     )
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/remove-access-token",
-        cookies={"refresh_token": f"Bearer {expired_jwt}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {expired_jwt}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/remove-access-token")
     assert response.status_code == 200
 
     db_token = crud.refresh_token.get_by_jti(db, jti=token_jti)
@@ -512,10 +509,8 @@ def test_refresh_token_within_grace_window_succeeds(
     # Revoke just now (revoked_at = now), simulating a concurrent rotation
     crud.refresh_token.revoke(db, jti=jti)
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {refresh_token_str}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 200
     assert response.cookies.get("access_token") is not None
@@ -544,10 +539,8 @@ def test_refresh_token_reuse_after_grace_window_fails(
         ),
     )
 
-    response = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {refresh_token_str}"):
+        response = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
 
     assert response.status_code == 401
     assert "Refresh token revoked or expired" in response.json()["detail"]
@@ -561,17 +554,13 @@ def test_refresh_token_concurrent_reuse_both_succeed(
 
     refresh_token_str = security.create_refresh_token(db, subject=str(user.id))
 
-    first = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {refresh_token_str}"):
+        first = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
     assert first.status_code == 200
 
     # Reusing the same (now rotated/revoked) token again immediately is tolerated
-    second = client.post(
-        f"{settings.API_V1_STR}/auth/refresh-token",
-        cookies={"refresh_token": f"Bearer {refresh_token_str}"},
-    )
+    with refresh_token_cookie(client, f"Bearer {refresh_token_str}"):
+        second = client.post(f"{settings.API_V1_STR}/auth/refresh-token")
     assert second.status_code == 200
 
 

--- a/backend/app/tests/api/api_v1/test_breedbase_connections.py
+++ b/backend/app/tests/api/api_v1/test_breedbase_connections.py
@@ -457,7 +457,7 @@ def test_brapi_proxy_rejects_invalid_method(
         json=payload,
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest_requires_breedbase

--- a/backend/app/tests/api/api_v1/test_contact.py
+++ b/backend/app/tests/api/api_v1/test_contact.py
@@ -82,7 +82,7 @@ def test_email_contact_message_with_too_few_characters(
 
     payload = {"subject": subject, "message": message}
     response = client.post(f"{settings.API_V1_STR}/contact", json=payload)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest_requires_mail
@@ -102,7 +102,7 @@ def test_email_contact_message_with_too_many_characters(
 
     payload = {"subject": subject, "message": message}
     response = client.post(f"{settings.API_V1_STR}/contact", json=payload)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest_requires_mail

--- a/backend/app/tests/api/api_v1/test_data_product_views.py
+++ b/backend/app/tests/api/api_v1/test_data_product_views.py
@@ -113,7 +113,7 @@ def test_public_view_session_id_too_long_returns_422(
         headers={"X-Session-Id": "x" * 65},
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_public_view_session_id_at_max_length_returns_201(

--- a/backend/app/tests/api/api_v1/test_indoor_projects.py
+++ b/backend/app/tests/api/api_v1/test_indoor_projects.py
@@ -72,7 +72,7 @@ def test_create_indoor_project_with_invalid_date(
     # post indoor project form data
     response = client.post(API_URL, json=payload)
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_indoor_project_with_invalid_end_date(
@@ -91,7 +91,7 @@ def test_create_indoor_project_with_invalid_end_date(
     # post indoor project form data
     response = client.post(API_URL, json=payload)
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_read_indoor_project(
@@ -390,7 +390,7 @@ def test_update_indoor_project_date_validation(
     )
     update_data = jsonable_encoder({"end_date": datetime(2024, 5, 1).isoformat()})
     response = client.put(f"{API_URL}/{indoor_project.id}", json=update_data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Invalid - start_date after end_date
     indoor_project = create_indoor_project(
@@ -401,7 +401,7 @@ def test_update_indoor_project_date_validation(
     )
     update_data = jsonable_encoder({"start_date": datetime(2024, 6, 2).isoformat()})
     response = client.put(f"{API_URL}/{indoor_project.id}", json=update_data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_deactivate_indoor_project_as_owner(

--- a/backend/app/tests/api/api_v1/test_projects.py
+++ b/backend/app/tests/api/api_v1/test_projects.py
@@ -175,7 +175,7 @@ def test_create_project_rejects_multipolygon(
         }
     )
     response = client.post(API_URL, json=data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     detail = response.json()["detail"]
     assert isinstance(detail, list)
     assert len(detail) == 1, f"Expected single-message detail, got: {detail}"
@@ -201,7 +201,7 @@ def test_create_project_rejects_point_geometry(
         }
     )
     response = client.post(API_URL, json=data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     detail = response.json()["detail"]
     assert isinstance(detail, list)
     assert len(detail) == 1, f"Expected single-message detail, got: {detail}"
@@ -228,7 +228,7 @@ def test_create_project_date_validation(
         }
     )
     response = client.post(API_URL, json=data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # valid - only planting_date
     data = jsonable_encoder(
@@ -791,7 +791,7 @@ def test_update_project_date_validation(
     )
     update_data = jsonable_encoder({"harvest_date": date(current_year, 5, 1)})
     response = client.put(f"{API_URL}/{project.id}", json=update_data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # invalid - harvest_date before planting_date
     project = create_project(
@@ -802,7 +802,7 @@ def test_update_project_date_validation(
     )
     update_data = jsonable_encoder({"planting_date": date(current_year, 6, 7)})
     response = client.put(f"{API_URL}/{project.id}", json=update_data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_dropping_team_from_project(

--- a/backend/app/tests/api/api_v1/test_users.py
+++ b/backend/app/tests/api/api_v1/test_users.py
@@ -577,7 +577,7 @@ def test_create_user_with_registration_intent_too_short(
     }
     with patch.object(settings, "TURNSTILE_SECRET_KEY", None):
         response = client.post(f"{settings.API_V1_STR}/users/", json=data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_user_with_registration_intent_too_long(
@@ -594,7 +594,7 @@ def test_create_user_with_registration_intent_too_long(
     }
     with patch.object(settings, "TURNSTILE_SECRET_KEY", None):
         response = client.post(f"{settings.API_V1_STR}/users/", json=data)
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_user_with_registration_intent_empty_string(
@@ -612,7 +612,7 @@ def test_create_user_with_registration_intent_empty_string(
     with patch.object(settings, "TURNSTILE_SECRET_KEY", None):
         response = client.post(f"{settings.API_V1_STR}/users/", json=data)
     # This should fail validation since empty strings don't meet min_length
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_user_with_registration_intent_whitespace_normalized(
@@ -652,7 +652,7 @@ def test_create_user_with_registration_intent_only_whitespace(
     with patch.object(settings, "TURNSTILE_SECRET_KEY", None):
         response = client.post(f"{settings.API_V1_STR}/users/", json=data)
     # Should fail since whitespace doesn't meet min_length at API layer
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_create_user_with_name_whitespace_normalized(

--- a/backend/app/tests/crud/test_crud_indoor_project_data.py
+++ b/backend/app/tests/crud/test_crud_indoor_project_data.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 from sqlalchemy.orm import Session
@@ -32,7 +32,7 @@ def test_create_indoor_data(db: Session) -> None:
         file_path = indoor_data_file.name
         file_size = os.stat(indoor_data_file.name).st_size
         file_type = os.path.splitext(original_filenamme)[1]
-        upload_date = datetime.utcnow()
+        upload_date = datetime.now(timezone.utc).replace(tzinfo=None)
         # indoor data creation object
         indoor_data_in = IndoorProjectDataCreate(
             original_filename=original_filenamme,
@@ -190,4 +190,6 @@ def test_deactivate_indoor_data(db: Session) -> None:
     assert deactivated_indoor_project_data.id == existing_indoor_project_data.id
     assert deactivated_indoor_project_data.is_active is False
     assert deactivated_indoor_project_data.deactivated_at
-    assert deactivated_indoor_project_data.deactivated_at < datetime.utcnow()
+    assert deactivated_indoor_project_data.deactivated_at < datetime.now(
+        timezone.utc
+    ).replace(tzinfo=None)

--- a/backend/app/tests/crud/test_indoor_project.py
+++ b/backend/app/tests/crud/test_indoor_project.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 from uuid import uuid4
 
@@ -186,7 +186,9 @@ def test_deactivate_indoor_project(db: Session) -> None:
     assert deactivated_indoor_project.id == existing_indoor_project.id
     assert deactivated_indoor_project.is_active is False
     assert deactivated_indoor_project.deactivated_at
-    assert deactivated_indoor_project.deactivated_at < datetime.utcnow()
+    assert deactivated_indoor_project.deactivated_at < datetime.now(timezone.utc).replace(
+        tzinfo=None
+    )
 
 
 def test_get_with_permission_owner_can_access_with_viewer_permission(

--- a/backend/app/tests/utils/indoor_project_data.py
+++ b/backend/app/tests/utils/indoor_project_data.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -37,7 +37,7 @@ def create_indoor_project_data(
         file_path = indoor_data_file.name
         file_size = os.stat(indoor_data_file.name).st_size
         file_type = os.path.splitext(original_filenamme)[1]
-        upload_date = datetime.utcnow()
+        upload_date = datetime.now(timezone.utc).replace(tzinfo=None)
         # indoor data creation object
         indoor_data_in = IndoorProjectDataCreate(
             original_filename=original_filenamme,

--- a/backend/app/tests/utils/test_stac.py
+++ b/backend/app/tests/utils/test_stac.py
@@ -21,7 +21,6 @@ from app.utils.stac.STACGenerator import STACGenerator, date_to_datetime
 
 
 @pytest.fixture
-@pytest_requires_stac
 def stac_collection_published(
     db: Session,
 ) -> Generator[STACCollectionHelper, None, None]:
@@ -37,7 +36,6 @@ def stac_collection_published(
 
 
 @pytest.fixture
-@pytest_requires_stac
 def stac_collection_unpublished(
     db: Session,
 ) -> Generator[STACCollectionHelper, None, None]:

--- a/backend/app/utils/stac/STACGenerator.py
+++ b/backend/app/utils/stac/STACGenerator.py
@@ -774,7 +774,7 @@ class STACGenerator:
             raise ValueError("Project must have a boundary.")
 
         try:
-            gdf = gpd.read_file(geojson.model_dump_json(), driver="GeoJSON")
+            gdf = gpd.read_file(geojson.model_dump_json())
             bounds = list(gdf.total_bounds)
         except Exception as e:
             logger.exception(e)


### PR DESCRIPTION
## Summary
Cleans up the warnings emitted by the backend test suite, taking it from 122 warnings down to 2. The remaining two are genuinely third-party (`fastapi-mail`, `passlib`) and not actionable in our code. No production behavior changes.

## Changes
- Backend:
  - Replaced deprecated class-based pydantic `Config` in `indoor_project_data` schemas with `ConfigDict` (and dropped the now-unused `Extra` import).
  - Added the recommended `overlaps=` hints to the `Project` / `IndoorProject` / `ProjectMember` relationships that share `project_members.project_uuid`, silencing the SQLAlchemy overlap warnings.
  - Dropped the redundant `driver="GeoJSON"` argument in `STACGenerator` to clear the pyogrio open-option warning.
  - Passed an explicit `nodata` to rasterstats `zonal_stats` in the zonal toolbox task to silence the `NodataWarning`.
  - Renamed deprecated `HTTP_422_UNPROCESSABLE_ENTITY` to `HTTP_422_UNPROCESSABLE_CONTENT` across endpoints.
- Tests:
  - Renamed the same `HTTP_422_*` constant across affected test modules.
  - Replaced deprecated `datetime.utcnow()` in indoor tests with `datetime.now(timezone.utc).replace(tzinfo=None)` (equivalent naive UTC, matching the naive DB columns).
  - Removed the no-effect `@pytest_requires_stac` mark from two fixtures in `test_stac.py` (the consuming tests are already marked).
  - Converted the 14 per-request `cookies=` call sites in `test_auth.py` to a `refresh_token_cookie` context manager that sets the cookie on the client instance and clears it on exit, dropping the httpx per-request-cookie deprecation.

## Testing
- `docker compose exec backend pytest` — all 1071 tests passing.
- `docker compose exec backend pytest app/tests/api/api_v1/test_auth.py` — 40 passing; httpx warning gone.
- Confirmed the warning count dropped from 122 to 2 (only the deferred `fastapi-mail` and `passlib` third-party warnings remain).

## Out of Scope
- `passlib` / stdlib `crypt` removal (Python 3.13 blocker) — deferred to a separate effort.
- `fastapi-mail` Pydantic 2.12 `@model_validator` deprecation — emitted inside the library; resolves on a future dependency bump.

## Breaking Changes
None.