### PR TITLE
[Bug] Fix view counts not incrementing for shared map links

### DIFF
--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -375,9 +375,10 @@ def record_public_data_product_view(
     """Record an anonymous or authenticated view for a data product.
 
     Authenticated callers use their user_id. Anonymous callers must supply an
-    X-Session-Id header. A view is recorded only when the project is published or
-    the caller is a project member. Returns 201 on insert, 200 on dedup-skip,
-    400 on missing identity, 404 on not-found or unauthorized.
+    X-Session-Id header. A view is recorded only when the project is published,
+    the data product's file permission is public (shared link), or the caller is
+    a project member. Returns 201 on insert, 200 on dedup-skip, 400 on missing
+    identity, 404 on not-found or unauthorized.
     """
     data_product = crud.data_product.get(db, id=data_product_id)
     if (
@@ -389,7 +390,8 @@ def record_public_data_product_view(
             status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
         )
 
-    # Require access via publication or project membership for every caller.
+    # Require access via publication, a public file permission (shared link),
+    # or project membership for every caller.
     flight = crud.flight.get(db, id=data_product.flight_id)
     project = crud.project.get(db, id=flight.project_id) if flight else None
     if not project:
@@ -404,9 +406,13 @@ def record_public_data_product_view(
         )
     )
     if not project.is_published and not is_member:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        file_permission = crud.file_permission.get_by_data_product(
+            db, file_id=data_product_id
         )
+        if not file_permission or not file_permission.is_public:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+            )
 
     if not current_user and not session_id:
         raise HTTPException(

--- a/backend/app/tests/api/api_v1/test_data_product_views.py
+++ b/backend/app/tests/api/api_v1/test_data_product_views.py
@@ -9,6 +9,7 @@ from app import crud
 from app.api.deps import get_current_user
 from app.core.config import settings
 from app.models.data_product_view import DataProductView
+from app.schemas.file_permission import FilePermissionUpdate
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.data_product_view import create_data_product_view
 from app.tests.utils.flight import create_flight
@@ -101,6 +102,17 @@ def _make_published(db: Session, data_product: SampleDataProduct) -> None:
     )
 
 
+def _make_file_public(db: Session, data_product: SampleDataProduct) -> None:
+    """Mark the data product's file permission as public (shared link)."""
+    file_permission = crud.file_permission.get_by_data_product(
+        db, file_id=data_product.obj.id
+    )
+    assert file_permission
+    crud.file_permission.update(
+        db, db_obj=file_permission, obj_in=FilePermissionUpdate(is_public=True)
+    )
+
+
 def test_public_view_session_id_too_long_returns_422(
     client: TestClient, db: Session
 ) -> None:
@@ -167,6 +179,23 @@ def test_public_view_on_unpublished_project_returns_404(
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_public_view_anonymous_file_public_unpublished_returns_201(
+    client: TestClient, db: Session
+) -> None:
+    # Shared-link access model: a public file permission must allow view
+    # recording even when the project itself is not published.
+    data_product = SampleDataProduct(db)
+    _make_file_public(db, data_product)
+
+    response = client.post(
+        _public_view_url(data_product),
+        headers={"X-Session-Id": "test-session-share"},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == {"view_count": 1}
 
 
 def test_public_view_dedup_same_session_returns_200(
@@ -246,6 +275,27 @@ def test_public_view_signed_in_non_member_unpublished_returns_404(
         db, data_product_id=data_product.obj.id
     )
     assert count == 0
+
+
+def test_public_view_signed_in_non_member_file_public_unpublished_returns_201(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    # Shared-link access model: signed-in non-members can record views on a
+    # publicly shared file in an unpublished project.
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db)
+    _make_file_public(db, data_product)
+
+    response = client.post(_public_view_url(data_product))
+
+    assert response.status_code == status.HTTP_201_CREATED
+    view = db.scalar(
+        select(DataProductView).where(
+            DataProductView.data_product_id == data_product.obj.id
+        )
+    )
+    assert view is not None
+    assert view.user_id == current_user.id
 
 
 def test_public_view_signed_in_non_member_published_returns_201(

--- a/frontend/src/components/maps/ShareLCCViewer.tsx
+++ b/frontend/src/components/maps/ShareLCCViewer.tsx
@@ -7,6 +7,7 @@ import { AlertBar, Status } from '../Alert';
 
 import api from '../../api';
 import LCCViewer from './LCCViewer';
+import { recordDataProductView } from '../../utils/recordDataProductView';
 
 function useQuery() {
   const { search } = useLocation();
@@ -29,6 +30,7 @@ export default function ShareLCCViewer() {
         );
         if (response.status === 200) {
           setLccUrl(response.data.url);
+          recordDataProductView(response.data.id);
         } else {
           setStatus({ type: 'error', msg: 'Unable to load file' });
         }

--- a/frontend/src/components/maps/ShareMap.tsx
+++ b/frontend/src/components/maps/ShareMap.tsx
@@ -24,6 +24,7 @@ import {
 
 import api from '../../api';
 import { isSingleBand } from './utils';
+import { recordDataProductView } from '../../utils/recordDataProductView';
 
 function useQuery() {
   const { search } = useLocation();
@@ -96,6 +97,7 @@ export default function ShareMap() {
         const response = await api.get(`/public?file_id=${fileID}`);
         if (response) {
           setDataProduct(response.data);
+          recordDataProductView(response.data.id);
         } else {
           setStatus({ type: 'error', msg: 'Unable to load data product' });
         }

--- a/frontend/src/components/maps/SharePanoViewer.tsx
+++ b/frontend/src/components/maps/SharePanoViewer.tsx
@@ -6,6 +6,7 @@ import { DataProduct } from '../pages/workspace/projects/Project';
 import { AlertBar, Status } from '../Alert';
 
 import api from '../../api';
+import { recordDataProductView } from '../../utils/recordDataProductView';
 
 function useQuery() {
   const { search } = useLocation();
@@ -29,6 +30,7 @@ export default function SharePanoViewer() {
         );
         if (response.status === 200) {
           setImageUrl(response.data.url);
+          recordDataProductView(response.data.id);
         } else {
           setStatus({ type: 'error', msg: 'Unable to load image' });
         }

--- a/frontend/src/components/maps/SharePlayCanvasglTFViewer.tsx
+++ b/frontend/src/components/maps/SharePlayCanvasglTFViewer.tsx
@@ -7,6 +7,7 @@ import PlayCanvasglTFViewer from './PlayCanvasglTFViewer';
 import { DataProduct } from '../pages/workspace/projects/Project';
 
 import api from '../../api';
+import { recordDataProductView } from '../../utils/recordDataProductView';
 
 function useQuery() {
   const { search } = useLocation();
@@ -29,6 +30,7 @@ export default function SharePlayCanvasglTFViewer() {
         );
         if (response.status === 200) {
           setModelUrl(response.data.url);
+          recordDataProductView(response.data.id);
         } else {
           setStatus({ type: 'error', msg: 'Unable to load file' });
         }


### PR DESCRIPTION
## Summary
Data product view counts incremented from the signed-in map UI and the anonymous `/explore` route, but not from share links (`/sharemap` URLs, short URLs, QR codes). Two independent bugs caused this: the share viewers never called the view-recording endpoint, and the endpoint's access gate rejected views for publicly shared files in unpublished projects.

## Changes
- Backend: Broadened the access gate in `record_public_data_product_view` (`public.py`) to also accept views when the data product's file permission is public (shared-link access model), in addition to published-project or project-member access
- Frontend: Added `recordDataProductView()` calls after the data product fetch in `ShareMap`, `ShareLCCViewer`, `SharePanoViewer`, and `SharePlayCanvasglTFViewer`, mirroring the existing pattern in `ShareCopcMapViewer` and `SharePotreeViewer`
- Tests: Added two gate tests covering anonymous and signed-in non-member views of a publicly shared file in an unpublished project

## Testing
- Commands run:
  - `docker compose exec backend pytest` — all 1073 tests passing (includes 2 new gate tests in `test_data_product_views.py`)
  - `docker compose exec frontend npx tsc --noEmit` — no errors
- Manual QA: Opened `/sharemap?file_id=<uuid>&symbology=...` links on staging as anonymous and signed-in users, including via short URLs and QR codes — network tab shows `POST /api/v1/public/data_products/{id}/view` returning 201 and the view count incrementing; reloading within 30 minutes returns 200 (dedup window)
- Verified the existing unpublished + non-public 404 behavior is unchanged