### PR TITLE
[Bug] Skip caching error responses in Varnish

### DIFF
--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -174,6 +174,14 @@ sub vcl_hash {
 }
 
 sub vcl_backend_response {
+    # Never cache error responses; a transient backend failure (e.g. a tile
+    # requested before its layer exists) must not be served for a day
+    if (beresp.status < 200 || beresp.status >= 300) {
+        set beresp.ttl = 10s;
+        set beresp.uncacheable = true;
+        return (deliver);
+    }
+
     # Set TTL and grace period
     set beresp.ttl = 1d;
     set beresp.grace = 6h;


### PR DESCRIPTION
## Summary
Varnish applied its 1-day cache TTL to every backend response, including errors. On a fresh instance, tile requests made before the vector layer tables existed produced transient 404s from pg_tileserv that Varnish then cached and served for a full day, making vector layers appear permanently broken even after the backend recovered. Error responses are now excluded from long-term caching.

## Changes
- Varnish: `vcl_backend_response` marks non-2xx backend responses uncacheable with a short 10s hit-for-miss TTL; successful responses keep the existing 1-day TTL and 6-hour grace period

## Testing
- Reproduced the bug: signed vector tile request returned a cached 404 (`Unable to get layer 'public.vector_layers'`) with a climbing `Age` header, while the same request with a cache-busting parameter returned HTTP 200 — proving the error was stale cache, not a live failure
- Rebuilt the varnish image and verified the originally failing tile URL now returns HTTP 200 (`application/vnd.mapbox-vector-tile`, 4928 bytes) and that successful tiles are still cached (nonzero `Age` on repeat requests)
- `docker compose exec frontend npx tsc --noEmit` — no errors
- `docker compose exec backend pytest` — all tests passing

## Breaking Changes
- Requires rebuilding the varnish image to pick up the VCL change: `docker compose up -d --build varnish` (for quickstart deployments, the prebuilt `gdslab/d2s-varnish` image must be republished)

## Related Issues
N/A
