### PR TITLE
[Bug] Fix STAC test confinement to a single xdist worker

### DIFF
--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -232,6 +232,7 @@ def cleanup_stac_catalog() -> Generator[None, None, None]:
         logger.error(f"Failed to cleanup STAC catalog: {str(e)}")
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Confine STAC tests to a single xdist worker.
 
@@ -239,6 +240,14 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     workers causes collisions. Assigning them all to the same ``xdist_group``
     makes ``--dist loadgroup`` schedule them onto one worker, where they run
     serially relative to each other.
+
+    ``tryfirst`` is required: this conftest loads as an *initial* conftest
+    (``testpaths`` in pytest.ini, pytest >= 8.1), i.e. before xdist's worker
+    plugin registers. Hooks run last-registered-first, so without ``tryfirst``
+    xdist's own ``pytest_collection_modifyitems`` -- which turns ``xdist_group``
+    markers into the ``@group`` nodeid suffix the loadgroup scheduler groups
+    by -- would run before this hook and see no markers, silently scattering
+    STAC tests across all workers.
     """
     for item in items:
         if "stac" in item.nodeid.lower():


### PR DESCRIPTION
## Summary
Fixes the flaky STAC test failures introduced with the parallelized test suite (#372). The `xdist_group("stac")` marker that was supposed to confine STAC tests to a single pytest-xdist worker never took effect, so STAC tests ran concurrently across all workers against the one shared test catalog, causing intermittent pgstac `DeadlockDetectedError` 500s and empty-fetch assertion failures.

## Root Cause
With `testpaths` set in `pytest.ini` (pytest ≥ 8.1), `app/tests/conftest.py` loads as an *initial* conftest — before xdist's worker plugin registers. Pytest hooks run last-registered-first, so xdist's own `pytest_collection_modifyitems` — which converts `xdist_group` markers into the `@group` nodeid suffix the `loadgroup` scheduler groups by — ran **before** the conftest hook that adds the marker. No test ever got the `@stac` suffix, and loadgroup silently degenerated to plain distribution. Concurrent collection deletes then deadlocked in pgstac, and early-finishing workers ran the catalog-wide cleanup while other workers' STAC tests were still mid-run (the source of the `assert 0 == 2` / `assert None is not None` failures).

## Changes
- Backend: Declared the `pytest_collection_modifyitems` hook in `backend/app/tests/conftest.py` as `@pytest.hookimpl(tryfirst=True)` so it runs before xdist's marker-reading hook regardless of registration order, and documented why in the docstring.

## Testing
- Commands run:
  - `docker compose exec backend pytest -v app/tests/utils/test_stac.py app/tests/tasks/test_stac_tasks.py app/tests/tasks/test_stac_s3_upload.py` — all 56 STAC tests now report the `@stac` nodeid suffix and run on the same worker (`gw1`); all passing, including the previously flaky `test_fetch_public_items`, `test_fetch_public_items_full`, `test_publish_to_catalog`, `test_publish_to_catalog_with_scientific_metadata`, and `test_compare_and_update_no_changes`.
  - `docker compose exec backend pytest` — full suite run twice back to back: **1073 passed** both times, no deadlocks or flakes.

## Related Issues
Related to #372