### PR TITLE
[Feature] Track zonal statistics jobs and surface status in the toolbox

### DIFF
--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -23,7 +23,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 from geojson_pydantic import Feature, FeatureCollection, Polygon, MultiPolygon
 from pydantic import BaseModel, UUID4
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -663,7 +663,7 @@ def process_data_product_from_external_storage(
 
 
 @router.post("/{data_product_id}/tools", status_code=status.HTTP_202_ACCEPTED)
-async def run_processing_tool(
+def run_processing_tool(
     data_product_id: UUID,
     toolbox_in: schemas.ProcessingRequest,
     current_user: models.User = Depends(deps.get_current_approved_user),
@@ -931,27 +931,87 @@ async def run_processing_tool(
         )
 
     # zonal
-    if toolbox_in.zonal and not os.environ.get("RUNNING_TESTS") == "1":
+    accepted_jobs = []
+    if toolbox_in.zonal:
+        if not toolbox_in.zonal_layer_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Vector layer is required for zonal statistics",
+            )
         features = crud.vector_layer.get_vector_layer_by_id(
             db, project_id=project.id, layer_id=toolbox_in.zonal_layer_id
         )
+        if len(features) == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Vector layer not found",
+            )
+        for feature in features:
+            geom_type = feature.geometry.type if feature.geometry else None
+            if geom_type not in ("Polygon", "MultiPolygon"):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Vector layer must only contain polygon features",
+                )
         feature_collection = FeatureCollection(
             **{"type": "FeatureCollection", "features": features}
         )
-        calculate_bulk_zonal_statistics.apply_async(
-            args=(
-                data_product.filepath,
-                data_product_id,
-                jsonable_encoder(feature_collection.__dict__),
-            )
+        # create job up front so its id can be returned to the client;
+        # layer_id in extra lets clients match the job to a vector layer
+        zonal_job = JobManager(
+            data_product_id=data_product_id,
+            job_name="zonal",
+            extra={"layer_id": toolbox_in.zonal_layer_id},
+            db=db,
         )
+        try:
+            calculate_bulk_zonal_statistics.apply_async(
+                args=(
+                    data_product.filepath,
+                    data_product_id,
+                    jsonable_encoder(feature_collection.__dict__),
+                    zonal_job.job_id,
+                )
+            )
+        except Exception:
+            # dispatch failed; no worker will ever update the job, so mark it
+            # failed instead of leaving it WAITING forever
+            zonal_job.update(status=Status.FAILED)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unable to start zonal statistics job",
+            )
+        accepted_jobs.append(
+            {
+                "id": zonal_job.job_id,
+                "name": "zonal",
+                "layer_id": toolbox_in.zonal_layer_id,
+            }
+        )
+
+    return {"jobs": accepted_jobs}
+
+
+@router.get("/{data_product_id}/jobs", response_model=Sequence[schemas.Job])
+def read_data_product_jobs(
+    name: Optional[str] = None,
+    current_user: models.User = Depends(deps.get_current_approved_user),
+    data_product: models.DataProduct = Depends(deps.can_read_data_product),
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    """Retrieve jobs associated with a data product, optionally filtered by
+    job name (e.g., "zonal"). Newest jobs are returned first.
+    """
+    return crud.job.get_multi_by_data_product(
+        db, data_product_id=data_product.id, job_name=name
+    )
 
 
 @router.post(
     "/{data_product_id}/zonal_statistics",
     response_model=Feature[Union[Polygon, MultiPolygon], ZonalStatisticsProps],
 )
-async def create_zonal_statistics(
+def create_zonal_statistics(
     data_product_id: UUID,
     zone_in: Feature,
     current_user: models.User = Depends(deps.get_current_approved_user),
@@ -969,6 +1029,10 @@ async def create_zonal_statistics(
         upload_dir=upload_dir,
         user_id=current_user.id,
     )
+    if not data_product:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Data product not found"
+        )
 
     if not zone_in.properties:
         raise HTTPException(
@@ -978,11 +1042,31 @@ async def create_zonal_statistics(
 
     vector_layer_feature_id = zone_in.properties.get("feature_id", None)
 
+    # only trust a claimed feature id if it resolves to an active vector layer
+    # in this flight's project; a stale id (e.g., embedded in a re-uploaded
+    # export) must not return another feature's cached stats and geometry
+    if vector_layer_feature_id and utils.is_valid_uuid(vector_layer_feature_id):
+        feature_in_project_query = select(VectorLayer.feature_id).where(
+            and_(
+                VectorLayer.feature_id == vector_layer_feature_id,
+                VectorLayer.project_id == flight.project_id,
+                VectorLayer.is_active,
+            )
+        )
+        with db as session:
+            if (
+                session.execute(feature_in_project_query).scalar_one_or_none()
+                is None
+            ):
+                vector_layer_feature_id = None
+    else:
+        vector_layer_feature_id = None
+
     # required zonal stats
     required_stats = {"count", "min", "max", "mean", "median", "std"}
 
     # check if zonal stats already exist for this feature/data product
-    if vector_layer_feature_id and utils.is_valid_uuid(vector_layer_feature_id):
+    if vector_layer_feature_id:
         metadata = crud.data_product_metadata.get_by_data_product(
             db,
             category="zonal",
@@ -991,11 +1075,7 @@ async def create_zonal_statistics(
         )
         if len(metadata) == 1:
             # return previously generated zonal stats
-            if (
-                "stats" in metadata[0].properties
-                and vector_layer_feature_id
-                and utils.is_valid_uuid(vector_layer_feature_id)
-            ):
+            if "stats" in metadata[0].properties:
                 # if all required stats are present
                 if all(
                     key in metadata[0].properties["stats"] for key in required_stats
@@ -1036,7 +1116,7 @@ async def create_zonal_statistics(
             detail="Unable to calculate zonal statistics",
         )
 
-    if vector_layer_feature_id and utils.is_valid_uuid(vector_layer_feature_id):
+    if vector_layer_feature_id:
         metadata_in = schemas.DataProductMetadataCreate(
             category="zonal",
             properties={"stats": zonal_stats[0]},
@@ -1058,7 +1138,13 @@ async def create_zonal_statistics(
                 **zonal_stats[0],
             }
 
-    return update_feature_properties(Feature(**vector_layer_geojson_dict))
+        return update_feature_properties(Feature(**vector_layer_geojson_dict))
+
+    # anonymous zone (no matching vector layer in this project): return the
+    # submitted feature with stats merged, without caching metadata
+    zone_dict = zone_in.model_dump()
+    zone_dict["properties"] = {**(zone_in.properties or {}), **zonal_stats[0]}
+    return update_feature_properties(Feature(**zone_dict))
 
 
 @router.get(

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -1,4 +1,7 @@
 from celery import Celery  # type: ignore
+from celery.signals import after_setup_logger  # type: ignore
+
+from app.core.logging import suppress_noisy_loggers
 
 celery_app = Celery("worker")  # Check backend.env for broker env settings
 celery_app.conf.update(
@@ -14,3 +17,11 @@ celery_app.conf.worker_prefetch_multiplier = 1
 
 # Autodiscover tasks
 celery_app.autodiscover_tasks(["app.tasks"], related_name="tasks")
+
+
+@after_setup_logger.connect
+def _suppress_noisy_loggers(**kwargs) -> None:
+    """Apply our third-party log-level overrides after celery configures its
+    own logging, so celery's setup doesn't reset them back to the defaults.
+    """
+    suppress_noisy_loggers()

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -155,8 +155,21 @@ def get_http_info(request: Request, response: Response) -> Dict:
     }
 
 
+def suppress_noisy_loggers() -> None:
+    """Raise the level of third-party loggers that emit unactionable INFO noise.
+
+    rasterio's Cython internals construct a rasterio.Env (and with it a boto3
+    session) for every rasterize call, so botocore logs "Found credentials in
+    environment variables." once per zone during zonal statistics runs. This
+    is expected, not an error, and unrelated to how credentials are supplied.
+    """
+    logging.getLogger("botocore.credentials").setLevel(logging.WARNING)
+
+
 def setup_logger() -> None:
     os.makedirs(API_LOGDIR, exist_ok=True)
+
+    suppress_noisy_loggers()
 
     # Reset only the root logger handlers so third-party loggers keep theirs
     root_logger = logging.getLogger()

--- a/backend/app/crud/crud_job.py
+++ b/backend/app/crud/crud_job.py
@@ -24,6 +24,19 @@ class CRUDJob(CRUDBase[Job, JobCreate, JobUpdate]):
             session.refresh(job)
         return job
 
+    def get_multi_by_data_product(
+        self,
+        db: Session,
+        data_product_id: UUID,
+        job_name: Optional[str] = None,
+    ) -> Sequence[Job]:
+        select_statement = select(Job).where(Job.data_product_id == data_product_id)
+        if job_name:
+            select_statement = select_statement.where(Job.name == job_name)
+        select_statement = select_statement.order_by(Job.start_time.desc())
+        with db as session:
+            return session.scalars(select_statement).all()
+
     def get_multi_by_flight(
         self, db: Session, flight_id: UUID, incomplete: bool = False
     ) -> Sequence[Job]:

--- a/backend/app/crud/crud_vector_layer.py
+++ b/backend/app/crud/crud_vector_layer.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from app import crud
 from app.api.utils import create_vector_layer_preview
 from app.crud.base import CRUDBase
+from app.models.constants import RESERVED_VECTOR_PROPERTY_KEYS
 from app.models.data_product_metadata import DataProductMetadata
 from app.models.vector_layer import VectorLayer
 from app.schemas.vector_layer import VectorLayerCreate, VectorLayerUpdate
@@ -57,6 +58,17 @@ class CRUDVectorLayer(CRUDBase[VectorLayer, VectorLayerCreate, VectorLayerUpdate
             props_series = props_series.where(props_series.notna(), None)
 
             props = props_series.to_dict()
+            # Preserve a user-supplied "id" attribute (common in GIS exports)
+            # under the "fid" name zonal statistic exports already use
+            if "id" in props and "fid" not in props:
+                props["fid"] = props.pop("id")
+            # Drop reserved internal keys (e.g., from a re-uploaded D2S export)
+            # so they cannot shadow the real columns in map tiles
+            props = {
+                key: value
+                for key, value in props.items()
+                if key not in RESERVED_VECTOR_PROPERTY_KEYS
+            }
             properties = jsonable_encoder(props)
 
             # Layer ID will be same for each feature from the feature collection

--- a/backend/app/models/constants.py
+++ b/backend/app/models/constants.py
@@ -10,6 +10,21 @@ NON_RASTER_TYPES = frozenset({"panoramic", "point_cloud", "3dgs"})
 # Data product types that cannot have XML metadata attached
 XML_METADATA_EXCLUDED_TYPES = frozenset({"panoramic", "3dgs"})
 
+# Vector layer property keys reserved for internal use. Uploaded feature
+# properties with these names are dropped so they cannot shadow the real
+# table columns when ST_AsMVT flattens the properties JSONB into map tiles
+# (e.g., a re-uploaded D2S export carrying a stale feature_id).
+RESERVED_VECTOR_PROPERTY_KEYS = frozenset({
+    "id",
+    "feature_id",
+    "layer_name",
+    "layer_id",
+    "is_active",
+    "project_id",
+    "flight_id",
+    "data_product_id",
+})
+
 # Job names used for filtering processing jobs
 PROCESSING_JOB_NAMES = frozenset({
     "upload-data-product",

--- a/backend/app/tasks/toolbox_tasks.py
+++ b/backend/app/tasks/toolbox_tasks.py
@@ -1,5 +1,6 @@
+import math
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 import geopandas as gpd
@@ -18,8 +19,54 @@ from app.schemas.data_product_metadata import ZonalStatisticsProps
 from app.schemas.job import Status
 from app.utils.Toolbox import Toolbox
 
-
 logger = get_task_logger(__name__)
+
+
+def compute_zonal_statistics(
+    input_raster: str, feature_collection: Dict[str, Any]
+) -> List[ZonalStatisticsProps]:
+    """Compute zonal statistics for a raster using a feature collection."""
+    features = feature_collection.get("features", [])
+    if len(features) == 0:
+        return []
+
+    with rasterio.open(input_raster) as src:
+        # convert feature collection to dataframe and update crs to match src crs
+        zones = gpd.GeoDataFrame.from_features(features, crs="EPSG:4326")
+        zones = zones.to_crs(src.crs)
+        minx, miny, maxx, maxy = zones.total_bounds
+        # affine transformation
+        affine = src.transform
+        # create window for total bounding box of all zones in zone_feature
+        # snap to whole pixels (floor offsets, ceil ends) so the window fully
+        # covers the zones and its transform matches the read array
+        window = rasterio.windows.from_bounds(minx, miny, maxx, maxy, affine)
+        col_off = math.floor(window.col_off)
+        row_off = math.floor(window.row_off)
+        width = math.ceil(window.col_off + window.width) - col_off
+        height = math.ceil(window.row_off + window.height) - row_off
+        window = rasterio.windows.Window(col_off, row_off, width, height)
+        window_affine = rasterio.windows.transform(window, src.transform)
+        # rasterstats only receives the array, so pass the source nodata explicitly
+        # to silence its NodataWarning. Without a source nodata, fall back to
+        # rasterstats' internal -999 sentinel when the band dtype can hold it,
+        # else the dtype's maximum (-999 overflows unsigned integer bands)
+        nodata = src.nodata
+        if nodata is None:
+            dtype_min, dtype_max = rasterio.dtypes.dtype_ranges[src.dtypes[0]]
+            nodata = -999 if dtype_min <= -999 <= dtype_max else dtype_max
+        # read first band contained within window into array
+        # boundless read keeps the array aligned with window_affine when zones
+        # extend past the raster's edge; out-of-raster pixels become nodata
+        data = src.read(1, window=window, boundless=True, fill_value=nodata)
+        # required zonal statistics
+        required_stats = "count min max mean median std"
+        # get stats for zone
+        stats = zonal_stats(
+            zones, data, affine=window_affine, stats=required_stats, nodata=nodata
+        )
+
+    return stats
 
 
 @celery_app.task(name="calculate_zonal_statistics_task")
@@ -30,53 +77,51 @@ def calculate_zonal_statistics(
     job = JobManager(job_name="zonal")
     job.start()
 
-    with rasterio.open(input_raster) as src:
-        # convert feature collection to dataframe and update crs to match src crs
-        zones = gpd.GeoDataFrame.from_features(
-            feature_collection["features"], crs="EPSG:4326"
-        )
-        zones = zones.to_crs(src.crs)
-        minx, miny, maxx, maxy = zones.total_bounds
-        # affine transformation
-        affine = src.transform
-        # create window for total bounding box of all zones in zone_feature
-        window = rasterio.windows.from_bounds(minx, miny, maxx, maxy, affine)
-        window_affine = rasterio.windows.transform(window, src.transform)
-        # read first band contained within window into array
-        data = src.read(1, window=window)
-        # required zonal statistics
-        required_stats = "count min max mean median std"
-        # get stats for zone
-        # rasterstats only receives the array, so pass the source nodata explicitly
-        # (falling back to its internal -999 sentinel) to silence its NodataWarning.
-        nodata = src.nodata if src.nodata is not None else -999
-        stats = zonal_stats(
-            zones, data, affine=window_affine, stats=required_stats, nodata=nodata
-        )
+    try:
+        stats = compute_zonal_statistics(input_raster, feature_collection)
+    except Exception:
+        logger.exception("Unable to calculate zonal statistics")
+        job.update(status=Status.FAILED)
+        # re-raise so callers blocking on the result see a server error
+        # rather than mistaking the failure for an empty result
+        raise
 
     job.update(status=Status.SUCCESS)
 
     return stats
 
 
+def _fail_job(job: JobManager, detail: str) -> None:
+    """Mark a job as failed, preserving existing extra and recording a reason."""
+    existing_extra = job.job.extra if job.job and job.job.extra else {}
+    job.update(status=Status.FAILED, extra={**existing_extra, "detail": detail[:200]})
+
+
 @celery_app.task(name="calculate_bulk_zonal_statistics_task")
 def calculate_bulk_zonal_statistics(
-    input_raster: str, data_product_id: UUID, feature_collection_dict: Dict[str, Any]
+    input_raster: str,
+    data_product_id: UUID,
+    feature_collection_dict: Dict[str, Any],
+    job_id: Optional[UUID] = None,
 ) -> List[ZonalStatisticsProps]:
     # database session for updating data product and job tables
     db = next(get_db())
 
-    # create new job for tool process
-    job = JobManager(data_product_id=data_product_id, job_name="zonal")
+    # use job created by the tools endpoint, or create one if not provided
+    if job_id:
+        job = JobManager(job_id=job_id, db=db)
+    else:
+        job = JobManager(data_product_id=data_product_id, job_name="zonal", db=db)
 
     try:
         job.start()
-        all_zonal_stats = calculate_zonal_statistics(
+        all_zonal_stats = compute_zonal_statistics(
             input_raster, feature_collection_dict
         )
-    except Exception:
+    except Exception as e:
         logger.exception("Unable to complete tool process")
-        job.update(status=Status.FAILED)
+        # record only the exception class; str(e) can contain server paths
+        _fail_job(job, f"Unable to calculate zonal statistics ({type(e).__name__})")
         return []
 
     try:
@@ -115,11 +160,11 @@ def calculate_bulk_zonal_statistics(
                     )
                 else:
                     logger.exception("Unable to save zonal statistics")
-                    job.update(status=Status.FAILED)
+                    _fail_job(job, "Unable to save zonal statistics")
                     return []
-    except Exception:
+    except Exception as e:
         logger.exception("Unable to save zonal statistics")
-        job.update(status=Status.FAILED)
+        _fail_job(job, f"Unable to save zonal statistics ({type(e).__name__})")
         return []
 
     # update job to indicate process finished

--- a/backend/app/tasks/toolbox_tasks.py
+++ b/backend/app/tasks/toolbox_tasks.py
@@ -97,6 +97,16 @@ def _fail_job(job: JobManager, detail: str) -> None:
     job.update(status=Status.FAILED, extra={**existing_extra, "detail": detail[:200]})
 
 
+def _zone_has_data(zstats: Dict[str, Any]) -> bool:
+    """Return True if a zone overlaps valid raster pixels.
+
+    rasterstats returns an integer ``count`` of valid (non-nodata) pixels; a
+    zone that falls outside the raster or covers only no-data pixels has a
+    count of 0 and ``None`` for every other statistic.
+    """
+    return bool(zstats.get("count"))
+
+
 @celery_app.task(name="calculate_bulk_zonal_statistics_task")
 def calculate_bulk_zonal_statistics(
     input_raster: str,
@@ -133,6 +143,19 @@ def calculate_bulk_zonal_statistics(
         # create metadata record for each zone
         for index, zstats in enumerate(all_zonal_stats):
             vector_layer_feature_id = features[index].properties["feature_id"]
+            # a zone with no valid raster data produces only None stats; skip
+            # persisting it so it never poisons the download endpoint, and drop
+            # any stale row from an earlier run of the same layer
+            if not _zone_has_data(zstats):
+                stale_metadata = crud.data_product_metadata.get_by_data_product(
+                    db,
+                    category="zonal",
+                    data_product_id=data_product_id,
+                    vector_layer_feature_id=vector_layer_feature_id,
+                )
+                for stale in stale_metadata:
+                    crud.data_product_metadata.remove(db, id=stale.id)
+                continue
             metadata_in = schemas.DataProductMetadataCreate(
                 category="zonal",
                 properties={"stats": zstats},
@@ -167,8 +190,19 @@ def calculate_bulk_zonal_statistics(
         _fail_job(job, f"Unable to save zonal statistics ({type(e).__name__})")
         return []
 
-    # update job to indicate process finished
-    job.update(status=Status.SUCCESS)
+    # update job to indicate process finished, recording how many zones
+    # actually overlapped the raster so the UI can report the outcome
+    existing_extra = job.job.extra if job.job and job.job.extra else {}
+    job.update(
+        status=Status.SUCCESS,
+        extra={
+            **existing_extra,
+            "zones_total": len(all_zonal_stats),
+            "zones_with_data": sum(
+                1 for zstats in all_zonal_stats if _zone_has_data(zstats)
+            ),
+        },
+    )
 
     return all_zonal_stats
 

--- a/backend/app/tests/api/api_v1/test_data_products.py
+++ b/backend/app/tests/api/api_v1/test_data_products.py
@@ -1,6 +1,8 @@
 import os
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import patch, MagicMock
+from uuid import UUID
 
 from geojson_pydantic import Feature, FeatureCollection
 from fastapi import status
@@ -11,6 +13,7 @@ from app import crud
 from app.api.deps import get_current_user
 from app.core.config import settings
 from app.schemas.file_permission import FilePermissionUpdate
+from app.schemas.job import Status as JobStatus
 from app.schemas.role import Role
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.data_product_metadata import (
@@ -19,11 +22,13 @@ from app.tests.utils.data_product_metadata import (
     get_sample_xml_filepath,
     get_zonal_feature_collection,
 )
+from app.tests.utils.job import create_job
 from app.tests.utils.project import create_project
 from app.tests.utils.project_member import create_project_member
 from app.tests.utils.flight import create_flight
 from app.tests.utils.user import create_user
 from app.tests.utils.vector_layers import (
+    create_feature_collection,
     create_vector_layer_with_provided_feature_collection,
 )
 from app.utils.ColorBar import create_outfilename
@@ -893,13 +898,11 @@ def test_delete_data_product_xml_when_no_xml_exists(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_running_tool_on_data_product(
-    client: TestClient, db: Session, normal_user_access_token: str
-) -> None:
-    current_user = get_current_user(db, normal_user_access_token)
-    rgb_data_product = SampleDataProduct(
-        db, data_type="ortho", multispectral=True, user=current_user
-    )
+def get_processing_request(**overrides: Any) -> dict:
+    """Return a processing tool request payload with no tools selected.
+
+    Keyword arguments override individual fields (e.g., zonal=True).
+    """
     processing_request = {
         "chm": False,
         "chmResolution": 0.5,
@@ -908,7 +911,7 @@ def test_running_tool_on_data_product(
         "dtm": False,
         "dtmResolution": 0.5,
         "dtmRigidness": 2,
-        "exg": True,
+        "exg": False,
         "exgRed": 3,
         "exgGreen": 2,
         "exgBlue": 1,
@@ -916,13 +919,33 @@ def test_running_tool_on_data_product(
         "ndvi": False,
         "ndviNIR": 4,
         "ndviRed": 3,
-        "vari": True,
+        "vari": False,
         "variRed": 3,
         "variGreen": 2,
         "variBlue": 1,
         "zonal": False,
         "zonal_layer_id": "",
     }
+    processing_request.update(overrides)
+    return processing_request
+
+
+def get_tools_url(data_product: SampleDataProduct) -> str:
+    return (
+        f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+        f"/flights/{data_product.flight.id}"
+        f"/data_products/{data_product.obj.id}/tools"
+    )
+
+
+def test_running_tool_on_data_product(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    rgb_data_product = SampleDataProduct(
+        db, data_type="ortho", multispectral=True, user=current_user
+    )
+    processing_request = get_processing_request(exg=True, vari=True)
 
     response = client.post(
         f"{settings.API_V1_STR}/projects/{rgb_data_product.project.id}"
@@ -1037,3 +1060,263 @@ def test_get_zonal_statistics_by_layer_id(
     # check that original feature collection properties are present
     for key in properties:
         assert key in response_first_feature.properties
+
+
+def test_running_zonal_tool_on_data_product(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    zones = get_zonal_feature_collection()
+    vector_layer = create_vector_layer_with_provided_feature_collection(
+        db, feature_collection=zones, project_id=data_product.project.id
+    )
+    layer_id = vector_layer.features[0].properties["layer_id"]
+
+    with patch(
+        "app.tasks.toolbox_tasks.calculate_bulk_zonal_statistics.apply_async"
+    ) as mock_apply_async:
+        response = client.post(
+            get_tools_url(data_product),
+            json=get_processing_request(zonal=True, zonal_layer_id=layer_id),
+        )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    response_jobs = response.json()["jobs"]
+    assert len(response_jobs) == 1
+    assert response_jobs[0]["name"] == "zonal"
+    assert response_jobs[0]["layer_id"] == layer_id
+
+    # job record created with layer id in extra
+    job = crud.job.get(db, id=UUID(response_jobs[0]["id"]))
+    assert job is not None
+    assert job.status == JobStatus.WAITING
+    assert job.extra == {"layer_id": layer_id}
+    assert job.data_product_id == data_product.obj.id
+
+    # task dispatched with raster path, data product id, features, and job id
+    mock_apply_async.assert_called_once()
+    task_args = mock_apply_async.call_args.kwargs["args"]
+    assert task_args[0] == data_product.obj.filepath
+    assert task_args[1] == data_product.obj.id
+    assert len(task_args[2]["features"]) == len(vector_layer.features)
+    assert task_args[3] == job.id
+
+
+def test_running_zonal_tool_without_layer_id(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    response = client.post(
+        get_tools_url(data_product),
+        json=get_processing_request(zonal=True, zonal_layer_id=""),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_running_zonal_tool_with_unknown_layer_id(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    response = client.post(
+        get_tools_url(data_product),
+        json=get_processing_request(zonal=True, zonal_layer_id="nonexistent"),
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_running_zonal_tool_with_layer_from_other_project(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    other_project = create_project(db)
+    zones = get_zonal_feature_collection()
+    vector_layer = create_vector_layer_with_provided_feature_collection(
+        db, feature_collection=zones, project_id=other_project.id
+    )
+    layer_id = vector_layer.features[0].properties["layer_id"]
+    response = client.post(
+        get_tools_url(data_product),
+        json=get_processing_request(zonal=True, zonal_layer_id=layer_id),
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_running_zonal_tool_with_non_polygon_layer(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    point_layer = create_feature_collection(
+        db, "point", project_id=data_product.project.id
+    )
+    layer_id = point_layer.features[0].properties["layer_id"]
+    response = client.post(
+        get_tools_url(data_product),
+        json=get_processing_request(zonal=True, zonal_layer_id=layer_id),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_running_tool_with_no_product_selected(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    response = client.post(
+        get_tools_url(data_product), json=get_processing_request()
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_running_tool_with_project_viewer_role(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm")
+    create_project_member(
+        db,
+        role=Role.VIEWER,
+        member_id=current_user.id,
+        project_uuid=data_product.project.id,
+    )
+    response = client.post(
+        get_tools_url(data_product), json=get_processing_request(hillshade=True)
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_read_data_product_jobs(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    zonal_job = create_job(
+        db,
+        data_product_id=data_product.obj.id,
+        name="zonal",
+        extra={"layer_id": "abc12345"},
+    )
+    create_job(db, data_product_id=data_product.obj.id, name="hillshade")
+
+    url = (
+        f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+        f"/flights/{data_product.flight.id}"
+        f"/data_products/{data_product.obj.id}/jobs"
+    )
+
+    # all jobs for data product (SampleDataProduct also creates an upload job)
+    response = client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    response_job_names = [job["name"] for job in response.json()]
+    assert "zonal" in response_job_names
+    assert "hillshade" in response_job_names
+
+    # filtered by job name
+    response = client.get(url, params={"name": "zonal"})
+    assert response.status_code == status.HTTP_200_OK
+    response_jobs = response.json()
+    assert len(response_jobs) == 1
+    assert response_jobs[0]["id"] == str(zonal_job.id)
+    assert response_jobs[0]["name"] == "zonal"
+    assert response_jobs[0]["status"] == "WAITING"
+    assert response_jobs[0]["extra"] == {"layer_id": "abc12345"}
+
+
+def test_read_data_product_jobs_with_non_project_member(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    create_job(db, data_product_id=data_product.obj.id, name="zonal")
+    response = client.get(
+        f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+        f"/flights/{data_product.flight.id}"
+        f"/data_products/{data_product.obj.id}/jobs"
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_read_data_product_jobs_with_data_product_from_other_flight(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """A data product id from another project must not be readable through a
+    flight the user can access.
+    """
+    current_user = get_current_user(db, normal_user_access_token)
+    own_data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    other_data_product = SampleDataProduct(db, data_type="dsm")
+    create_job(db, data_product_id=other_data_product.obj.id, name="zonal")
+    response = client.get(
+        f"{settings.API_V1_STR}/projects/{own_data_product.project.id}"
+        f"/flights/{own_data_product.flight.id}"
+        f"/data_products/{other_data_product.obj.id}/jobs"
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get_zonal_statistics_ignores_feature_id_not_in_project(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    """A stale feature_id embedded in the submitted zone (e.g., from a
+    re-uploaded export) that does not resolve to a vector layer in this
+    project must trigger a fresh computation for the submitted geometry
+    instead of returning another feature's cached stats.
+    """
+    current_user = get_current_user(db, normal_user_access_token)
+    # cached zonal stats for a feature that lives in a different project
+    other_project = create_project(db)
+    other_data_product = SampleDataProduct(db, data_type="dsm", project=other_project)
+    other_metadata, _, _ = create_zonal_metadata(
+        db, data_product_id=other_data_product.obj.id, project_id=other_project.id
+    )
+    foreign_feature_id = str(other_metadata[0].vector_layer_feature_id)
+
+    # current user's own project and data product
+    data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
+    zone_feature = get_zonal_feature_collection(single_feature=True)
+    zone_dict = zone_feature.model_dump()
+    zone_dict["properties"] = {
+        **(zone_dict.get("properties") or {}),
+        "feature_id": foreign_feature_id,
+    }
+
+    mocked_stats = {
+        "min": 187.371,
+        "max": 187.444,
+        "mean": 187.404,
+        "count": 576,
+        "std": 0.0135,
+        "median": 187.402,
+    }
+    with patch(
+        "app.tasks.toolbox_tasks.calculate_zonal_statistics.apply_async"
+    ) as mock_apply_async:
+        mock_task = MagicMock()
+        mock_task.get.return_value = [mocked_stats]
+        mock_apply_async.return_value = mock_task
+        response = client.post(
+            f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+            f"/flights/{data_product.flight.id}"
+            f"/data_products/{data_product.obj.id}/zonal_statistics",
+            json=zone_dict,
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    # a fresh computation ran; the foreign cache was not used
+    mock_apply_async.assert_called_once()
+    response_feature = Feature(**response.json())
+    assert response_feature.properties is not None
+    assert response_feature.properties["mean"] == mocked_stats["mean"]
+    # the submitted geometry is returned, not the foreign feature's geometry
+    assert response_feature.geometry == zone_feature.geometry
+    # no metadata cached against the foreign feature id for this data product
+    metadata = crud.data_product_metadata.get_by_data_product(
+        db,
+        category="zonal",
+        data_product_id=data_product.obj.id,
+        vector_layer_feature_id=other_metadata[0].vector_layer_feature_id,
+    )
+    assert len(metadata) == 0

--- a/backend/app/tests/crud/test_vector_layer.py
+++ b/backend/app/tests/crud/test_vector_layer.py
@@ -323,3 +323,64 @@ def test_remove_vector_layer_removes_metadata_associated_with_layer(
         isinstance(metadata_other_after_remove, list)
         and len(metadata_other_after_remove) == 1
     )
+
+
+def test_create_vector_layer_strips_reserved_property_keys(db: Session) -> None:
+    """Uploaded features must not carry D2S-internal keys (e.g., from a
+    re-uploaded export) into the stored properties JSONB, where they would
+    shadow the real columns in map tiles.
+    """
+    project = create_project(db)
+    stale_feature_id = "6e0e6b9e-52d5-4c31-a9c4-949b90ce9d29"
+    feature: Dict[str, Any] = {
+        "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+        "properties": {
+            "plot": "A1",
+            "id": "stale-id",
+            "feature_id": stale_feature_id,
+            "layer_name": "old_name.geojson",
+            "layer_id": "OLDLAYERID12",
+            "is_active": False,
+            "project_id": "stale-project-id",
+            "flight_id": "stale-flight-id",
+            "data_product_id": "stale-data-product-id",
+        },
+    }
+    gdf = gpd.GeoDataFrame.from_features([feature], crs="EPSG:4326")
+
+    created = crud.vector_layer.create_with_project(
+        db, file_name="new_name.geojson", gdf=gdf, project_id=project.id
+    )
+
+    assert len(created) == 1
+    props = created[0].properties
+    assert props
+    # feature keeps its own identity columns, not the embedded stale values
+    assert props.get("layer_name") == "new_name.geojson"
+    assert props.get("feature_id") != stale_feature_id
+    # user attributes survive; a user-supplied "id" is preserved as "fid";
+    # reserved keys are dropped from stored properties
+    assert props.get("properties") == {"plot": "A1", "fid": "stale-id"}
+
+
+def test_create_vector_layer_preserves_existing_fid_property(db: Session) -> None:
+    """A feature carrying both "fid" and "id" attributes must keep its
+    original "fid" value rather than have it overwritten by the renamed "id".
+    """
+    project = create_project(db)
+    feature: Dict[str, Any] = {
+        "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+        "properties": {"plot": "A1", "fid": "plot-42", "id": "internal-uuid"},
+    }
+    gdf = gpd.GeoDataFrame.from_features([feature], crs="EPSG:4326")
+
+    created = crud.vector_layer.create_with_project(
+        db, file_name="plots.geojson", gdf=gdf, project_id=project.id
+    )
+
+    assert len(created) == 1
+    props = created[0].properties
+    assert props
+    assert props.get("properties") == {"plot": "A1", "fid": "plot-42"}

--- a/backend/app/tests/tasks/test_toolbox_tasks.py
+++ b/backend/app/tests/tasks/test_toolbox_tasks.py
@@ -14,7 +14,7 @@ from rasterio.warp import transform_bounds
 from rasterstats import zonal_stats
 from sqlalchemy.orm import Session
 
-from app import crud
+from app import crud, schemas
 from app.schemas.job import Status
 from app.tasks.toolbox_tasks import (
     calculate_bulk_zonal_statistics,
@@ -36,6 +36,31 @@ def create_zonal_vector_layer(db: Session, project_id) -> FeatureCollection:
     return create_vector_layer_with_provided_feature_collection(
         db, feature_collection=zones, project_id=project_id
     )
+
+
+def outside_polygon_feature(raster_path: str) -> dict:
+    """Return a GeoJSON polygon feature that lies entirely to the left of the
+    raster's extent (in EPSG:4326), so it overlaps no valid raster pixels.
+    """
+    with rasterio.open(raster_path) as src:
+        minx, miny, maxx, maxy = transform_bounds(src.crs, "EPSG:4326", *src.bounds)
+    width = maxx - minx
+    return {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [minx - 2 * width, miny],
+                    [minx - width, miny],
+                    [minx - width, maxy],
+                    [minx - 2 * width, maxy],
+                    [minx - 2 * width, miny],
+                ]
+            ],
+        },
+        "properties": {},
+    }
 
 
 def test_calculate_bulk_zonal_statistics(db: Session) -> None:
@@ -73,7 +98,10 @@ def test_calculate_bulk_zonal_statistics(db: Session) -> None:
     assert job_in_db is not None
     assert job_in_db.status == Status.SUCCESS
     # layer id passed at job creation must be preserved
-    assert job_in_db.extra == {"layer_id": layer_id}
+    assert job_in_db.extra["layer_id"] == layer_id
+    # every zone overlaps the raster, so the summary reports full coverage
+    assert job_in_db.extra["zones_total"] == len(vector_layer.features)
+    assert job_in_db.extra["zones_with_data"] == len(vector_layer.features)
     # task must not create a second (orphaned) job for the same run
     jobs = crud.job.get_multi_by_data_product(
         db, data_product_id=data_product.obj.id, job_name="zonal"
@@ -236,3 +264,140 @@ def test_compute_zonal_statistics_with_unsigned_raster_without_nodata(
     assert stats[0]["count"] == 50
     assert stats[0]["min"] == 100
     assert stats[0]["max"] == 100
+
+
+def test_calculate_bulk_zonal_statistics_all_zones_outside_raster(
+    db: Session,
+) -> None:
+    """When no zone overlaps the raster, the job still succeeds but the
+    summary reports zero zones with data and nothing is persisted.
+    """
+    data_product = SampleDataProduct(db, data_type="dsm")
+    outside_fc = FeatureCollection(
+        type="FeatureCollection",
+        features=[
+            outside_polygon_feature(data_product.obj.filepath),
+            outside_polygon_feature(data_product.obj.filepath),
+        ],
+    )
+    vector_layer = create_vector_layer_with_provided_feature_collection(
+        db, feature_collection=outside_fc, project_id=data_product.project.id
+    )
+    layer_id = vector_layer.features[0].properties["layer_id"]
+    fc_dict = jsonable_encoder(vector_layer.__dict__)
+    job = JobManager(
+        data_product_id=data_product.obj.id,
+        job_name="zonal",
+        extra={"layer_id": layer_id},
+        db=db,
+    )
+
+    with patch("app.tasks.toolbox_tasks.get_db", side_effect=lambda: iter([db])):
+        calculate_bulk_zonal_statistics(
+            data_product.obj.filepath, data_product.obj.id, fc_dict, job.job_id
+        )
+
+    job_in_db = crud.job.get(db, id=job.job_id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.SUCCESS
+    assert job_in_db.extra["layer_id"] == layer_id
+    assert job_in_db.extra["zones_total"] == len(vector_layer.features)
+    assert job_in_db.extra["zones_with_data"] == 0
+    # no empty-zone metadata should be persisted
+    for feature in vector_layer.features:
+        metadata = crud.data_product_metadata.get_by_data_product(
+            db,
+            category="zonal",
+            data_product_id=data_product.obj.id,
+            vector_layer_feature_id=feature.properties["feature_id"],
+        )
+        assert len(metadata) == 0
+
+
+def test_calculate_bulk_zonal_statistics_partial_overlap(db: Session) -> None:
+    """A run where only some zones overlap the raster persists metadata for
+    the overlapping zones only and reports the partial count.
+    """
+    data_product = SampleDataProduct(db, data_type="dsm")
+    inside_feature = get_zonal_feature_collection(single_feature=True).model_dump()
+    mixed_fc = FeatureCollection(
+        type="FeatureCollection",
+        features=[
+            inside_feature,
+            outside_polygon_feature(data_product.obj.filepath),
+        ],
+    )
+    vector_layer = create_vector_layer_with_provided_feature_collection(
+        db, feature_collection=mixed_fc, project_id=data_product.project.id
+    )
+    fc_dict = jsonable_encoder(vector_layer.__dict__)
+    job = JobManager(data_product_id=data_product.obj.id, job_name="zonal", db=db)
+
+    with patch("app.tasks.toolbox_tasks.get_db", side_effect=lambda: iter([db])):
+        calculate_bulk_zonal_statistics(
+            data_product.obj.filepath, data_product.obj.id, fc_dict, job.job_id
+        )
+
+    job_in_db = crud.job.get(db, id=job.job_id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.SUCCESS
+    assert job_in_db.extra["zones_total"] == 2
+    assert job_in_db.extra["zones_with_data"] == 1
+
+    # metadata persisted for the inside zone, absent for the outside zone
+    inside_metadata = crud.data_product_metadata.get_by_data_product(
+        db,
+        category="zonal",
+        data_product_id=data_product.obj.id,
+        vector_layer_feature_id=vector_layer.features[0].properties["feature_id"],
+    )
+    outside_metadata = crud.data_product_metadata.get_by_data_product(
+        db,
+        category="zonal",
+        data_product_id=data_product.obj.id,
+        vector_layer_feature_id=vector_layer.features[1].properties["feature_id"],
+    )
+    assert len(inside_metadata) == 1
+    assert len(outside_metadata) == 0
+
+
+def test_calculate_bulk_zonal_statistics_removes_stale_empty_metadata(
+    db: Session,
+) -> None:
+    """A zone that no longer overlaps the raster has its previously stored
+    stats removed rather than left behind to poison the download endpoint.
+    """
+    data_product = SampleDataProduct(db, data_type="dsm")
+    outside_fc = FeatureCollection(
+        type="FeatureCollection",
+        features=[outside_polygon_feature(data_product.obj.filepath)],
+    )
+    vector_layer = create_vector_layer_with_provided_feature_collection(
+        db, feature_collection=outside_fc, project_id=data_product.project.id
+    )
+    feature_id = vector_layer.features[0].properties["feature_id"]
+    # pre-seed a stale zonal metadata row for the (now-outside) zone
+    crud.data_product_metadata.create_with_data_product(
+        db,
+        obj_in=schemas.DataProductMetadataCreate(
+            category="zonal",
+            properties={"stats": {"count": 5, "min": 1, "max": 2}},
+            vector_layer_feature_id=feature_id,
+        ),
+        data_product_id=data_product.obj.id,
+    )
+    fc_dict = jsonable_encoder(vector_layer.__dict__)
+    job = JobManager(data_product_id=data_product.obj.id, job_name="zonal", db=db)
+
+    with patch("app.tasks.toolbox_tasks.get_db", side_effect=lambda: iter([db])):
+        calculate_bulk_zonal_statistics(
+            data_product.obj.filepath, data_product.obj.id, fc_dict, job.job_id
+        )
+
+    stale_metadata = crud.data_product_metadata.get_by_data_product(
+        db,
+        category="zonal",
+        data_product_id=data_product.obj.id,
+        vector_layer_feature_id=feature_id,
+    )
+    assert len(stale_metadata) == 0

--- a/backend/app/tests/tasks/test_toolbox_tasks.py
+++ b/backend/app/tests/tasks/test_toolbox_tasks.py
@@ -1,0 +1,238 @@
+"""Tests for zonal statistics toolbox tasks."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import geopandas as gpd
+import numpy as np
+import pytest
+import rasterio
+from fastapi.encoders import jsonable_encoder
+from geojson_pydantic import FeatureCollection
+from rasterio.transform import from_bounds
+from rasterio.warp import transform_bounds
+from rasterstats import zonal_stats
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.schemas.job import Status
+from app.tasks.toolbox_tasks import (
+    calculate_bulk_zonal_statistics,
+    compute_zonal_statistics,
+)
+from app.tests.utils.data_product import SampleDataProduct
+from app.tests.utils.data_product_metadata import get_zonal_feature_collection
+from app.tests.utils.vector_layers import (
+    create_vector_layer_with_provided_feature_collection,
+)
+from app.utils.job_manager import JobManager
+
+REQUIRED_STATS = {"count", "min", "max", "mean", "median", "std"}
+
+
+def create_zonal_vector_layer(db: Session, project_id) -> FeatureCollection:
+    zones = get_zonal_feature_collection()
+    assert isinstance(zones, FeatureCollection)
+    return create_vector_layer_with_provided_feature_collection(
+        db, feature_collection=zones, project_id=project_id
+    )
+
+
+def test_calculate_bulk_zonal_statistics(db: Session) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    vector_layer = create_zonal_vector_layer(db, data_product.project.id)
+    layer_id = vector_layer.features[0].properties["layer_id"]
+    fc_dict = jsonable_encoder(vector_layer.__dict__)
+    job = JobManager(
+        data_product_id=data_product.obj.id,
+        job_name="zonal",
+        extra={"layer_id": layer_id},
+        db=db,
+    )
+
+    with patch(
+        "app.tasks.toolbox_tasks.get_db", side_effect=lambda: iter([db])
+    ):
+        stats = calculate_bulk_zonal_statistics(
+            data_product.obj.filepath, data_product.obj.id, fc_dict, job.job_id
+        )
+
+    assert len(stats) == len(vector_layer.features)
+    # metadata record created for each zone feature
+    for feature in vector_layer.features:
+        metadata = crud.data_product_metadata.get_by_data_product(
+            db,
+            category="zonal",
+            data_product_id=data_product.obj.id,
+            vector_layer_feature_id=feature.properties["feature_id"],
+        )
+        assert len(metadata) == 1
+        assert REQUIRED_STATS.issubset(metadata[0].properties["stats"].keys())
+
+    job_in_db = crud.job.get(db, id=job.job_id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.SUCCESS
+    # layer id passed at job creation must be preserved
+    assert job_in_db.extra == {"layer_id": layer_id}
+    # task must not create a second (orphaned) job for the same run
+    jobs = crud.job.get_multi_by_data_product(
+        db, data_product_id=data_product.obj.id, job_name="zonal"
+    )
+    assert len(jobs) == 1
+
+
+def test_calculate_bulk_zonal_statistics_updates_existing_metadata(
+    db: Session,
+) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    vector_layer = create_zonal_vector_layer(db, data_product.project.id)
+    fc_dict = jsonable_encoder(vector_layer.__dict__)
+
+    for _ in range(2):
+        job = JobManager(data_product_id=data_product.obj.id, job_name="zonal", db=db)
+        with patch(
+            "app.tasks.toolbox_tasks.get_db", side_effect=lambda: iter([db])
+        ):
+            stats = calculate_bulk_zonal_statistics(
+                data_product.obj.filepath, data_product.obj.id, fc_dict, job.job_id
+            )
+        assert len(stats) == len(vector_layer.features)
+        job_in_db = crud.job.get(db, id=job.job_id)
+        assert job_in_db is not None
+        assert job_in_db.status == Status.SUCCESS
+
+    # second run must update metadata in place, not duplicate it
+    for feature in vector_layer.features:
+        metadata = crud.data_product_metadata.get_by_data_product(
+            db,
+            category="zonal",
+            data_product_id=data_product.obj.id,
+            vector_layer_feature_id=feature.properties["feature_id"],
+        )
+        assert len(metadata) == 1
+
+
+def test_calculate_bulk_zonal_statistics_failure_marks_job_failed(
+    db: Session,
+) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    vector_layer = create_zonal_vector_layer(db, data_product.project.id)
+    fc_dict = jsonable_encoder(vector_layer.__dict__)
+    job = JobManager(
+        data_product_id=data_product.obj.id,
+        job_name="zonal",
+        extra={"layer_id": "abc12345"},
+        db=db,
+    )
+
+    with patch(
+        "app.tasks.toolbox_tasks.get_db", side_effect=lambda: iter([db])
+    ):
+        stats = calculate_bulk_zonal_statistics(
+            "/nonexistent/raster.tif", data_product.obj.id, fc_dict, job.job_id
+        )
+
+    assert stats == []
+    job_in_db = crud.job.get(db, id=job.job_id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.FAILED
+    # failure reason recorded without clobbering existing extra
+    assert "detail" in job_in_db.extra
+    assert job_in_db.extra["layer_id"] == "abc12345"
+
+
+def test_compute_zonal_statistics_with_no_features(db: Session) -> None:
+    data_product = SampleDataProduct(db, data_type="dsm")
+    assert compute_zonal_statistics(data_product.obj.filepath, {"features": []}) == []
+
+
+def test_compute_zonal_statistics_with_zone_extending_past_raster_edge(
+    db: Session,
+) -> None:
+    """Stats for a zone must not change when another zone in the same
+    collection pushes the read window beyond the raster's extent.
+    """
+    data_product = SampleDataProduct(db, data_type="dsm")
+    raster_path = data_product.obj.filepath
+    inside_feature = get_zonal_feature_collection(single_feature=True).model_dump()
+
+    # polygon extending well past the raster's left edge (EPSG:4326)
+    with rasterio.open(raster_path) as src:
+        src_crs = src.crs
+        minx, miny, maxx, maxy = transform_bounds(src.crs, "EPSG:4326", *src.bounds)
+    width = maxx - minx
+    outside_feature = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [minx - width, miny],
+                    [minx + 0.25 * width, miny],
+                    [minx + 0.25 * width, maxy],
+                    [minx - width, maxy],
+                    [minx - width, miny],
+                ]
+            ],
+        },
+        "properties": {},
+    }
+
+    # ground truth: rasterstats run against the full raster, no windowing
+    zones = gpd.GeoDataFrame.from_features([inside_feature], crs="EPSG:4326").to_crs(
+        src_crs
+    )
+    truth = zonal_stats(zones, raster_path, stats="count min max mean median std")[0]
+
+    expected = compute_zonal_statistics(raster_path, {"features": [inside_feature]})
+    actual = compute_zonal_statistics(
+        raster_path, {"features": [inside_feature, outside_feature]}
+    )
+
+    assert len(expected) == 1
+    assert len(actual) == 2
+    for stat in REQUIRED_STATS:
+        assert expected[0][stat] == pytest.approx(truth[stat])
+        assert actual[0][stat] == pytest.approx(truth[stat])
+
+
+def test_compute_zonal_statistics_with_unsigned_raster_without_nodata(
+    tmp_path: Path,
+) -> None:
+    """A raster whose dtype cannot represent the -999 fallback sentinel
+    (e.g., uint8 without a nodata value) must still produce correct stats
+    for a zone extending past the raster's edge.
+    """
+    raster_path = str(tmp_path / "uint8.tif")
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=10,
+        width=10,
+        count=1,
+        dtype="uint8",
+        crs="EPSG:4326",
+        transform=from_bounds(0.0, 0.0, 1.0, 1.0, 10, 10),
+    ) as dst:
+        dst.write(np.full((10, 10), 100, dtype="uint8"), 1)
+
+    # zone covering the left half of the raster and extending past its edge
+    feature = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [[-0.5, 0.0], [0.5, 0.0], [0.5, 1.0], [-0.5, 1.0], [-0.5, 0.0]]
+            ],
+        },
+        "properties": {},
+    }
+
+    stats = compute_zonal_statistics(raster_path, {"features": [feature]})
+
+    assert len(stats) == 1
+    # only the 50 in-raster pixels count; boundless fill pixels are nodata
+    assert stats[0]["count"] == 50
+    assert stats[0]["min"] == 100
+    assert stats[0]["max"] == 100

--- a/backend/app/tests/utils/data_product_metadata.py
+++ b/backend/app/tests/utils/data_product_metadata.py
@@ -13,7 +13,7 @@ from app import crud
 from app.models.data_product_metadata import DataProductMetadata
 from app.models.vector_layer import VectorLayer
 from app.schemas.data_product_metadata import DataProductMetadataCreate, ZonalStatistics
-from app.tasks.toolbox_tasks import calculate_zonal_statistics
+from app.tasks.toolbox_tasks import compute_zonal_statistics
 from app.tests.utils.data_product import SampleDataProduct
 from app.tests.utils.project import create_project
 from app.tests.utils.vector_layers import (
@@ -34,7 +34,7 @@ def get_zonal_statistics(
     Returns:
         list[ZonalStatistics]: List of zonal statistic dictionaries for each zone.
     """
-    stats = calculate_zonal_statistics(in_raster, feature_collection.__dict__)
+    stats = compute_zonal_statistics(in_raster, feature_collection.__dict__)
 
     return stats
 

--- a/backend/app/utils/job_manager.py
+++ b/backend/app/utils/job_manager.py
@@ -3,6 +3,8 @@ from datetime import datetime, timezone
 from typing import Dict, Optional
 from uuid import UUID
 
+from sqlalchemy.orm import Session
+
 from app import crud
 from app.api.deps import get_db
 from app.models import Job as JobModel
@@ -18,23 +20,28 @@ class JobManager:
         job_id: Optional[UUID] = None,
         job_name: Optional[str] = None,
         raw_data_id: Optional[UUID] = None,
+        extra: Optional[Dict] = None,
+        db: Optional[Session] = None,
     ) -> None:
         """Initialize the JobManager instance.
 
         Args:
             data_product_id (Optional[UUID], optional): ID of the associated data product.
-            job_id (Optional[UUID], optional): Existing jbo ID to lookup. If provided, the job will be retrieved from the DB.
+            job_id (Optional[UUID], optional): Existing job ID to lookup. If provided, the job will be retrieved from the DB.
             job_name (Optional[str], optional): Name of the job. If not provided, defaults to 'default-job'.
             raw_data_id (Optional[UUID], optional): ID of the raw data associated with the job.
+            extra (Optional[Dict], optional): Extra details stored with a newly created job.
+            db (Optional[Session], optional): Database session. A new session is created if not provided.
 
         Raises:
             ValueError: Raised if a job_id is provided but the job is not found in the database.
         """
         self.data_product_id = data_product_id
         self.raw_data_id = raw_data_id
+        self.extra = extra
 
-        # Retrieve a database session from the dependency injection.
-        self.db = next(get_db())
+        # Use provided session or retrieve one from the dependency injection.
+        self.db = db if db is not None else next(get_db())
 
         self.job_id = job_id
         self.job_name = job_name
@@ -70,6 +77,9 @@ class JobManager:
 
         if self.raw_data_id:
             job_obj_in.raw_data_id = self.raw_data_id
+
+        if self.extra:
+            job_obj_in.extra = self.extra
 
         # Create the job using the CRUD utility and update the job_id attribute
         job = crud.job.create(self.db, obj_in=job_obj_in)

--- a/frontend/src/components/maps/ZonalStatistics.tsx
+++ b/frontend/src/components/maps/ZonalStatistics.tsx
@@ -7,7 +7,10 @@ import StripedTable from '../StripedTable';
 import { download as downloadGeoJSON } from '../pages/workspace/projects/mapLayers/utils';
 import { downloadFile as downloadCSV } from '../pages/workspace/projects/fieldCampaigns/utils';
 import { isSingleBand } from './utils';
-import { removeKeysFromFeatureProperties } from '../pages/workspace/projects/mapLayers/utils';
+import {
+  removeKeysFromFeatureProperties,
+  RESERVED_FEATURE_PROPERTY_KEYS,
+} from '../pages/workspace/projects/mapLayers/utils';
 
 export type ZonalStatistics = {
   min: number;
@@ -81,15 +84,7 @@ export const DownloadZonalStatistic = ({
           const csvData = Papa.unparse([
             Object.fromEntries(
               Object.entries(zonalFeature.properties).filter(
-                ([key]) =>
-                  ![
-                    'id',
-                    'layer_id',
-                    'is_active',
-                    'project_id',
-                    'flight_id',
-                    'data_product_id',
-                  ].includes(key)
+                ([key]) => !RESERVED_FEATURE_PROPERTY_KEYS.includes(key)
               )
             ),
           ]);
@@ -111,15 +106,7 @@ export const DownloadZonalStatistic = ({
                 type: 'FeatureCollection',
                 features: [zonalFeature],
               },
-              [
-                'id',
-                'feature_id',
-                'layer_id',
-                'is_active',
-                'project_id',
-                'flight_id',
-                'data_product_id',
-              ]
+              RESERVED_FEATURE_PROPERTY_KEYS
             ),
             'zonal_statistics.geojson'
           );

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/ToolboxModal.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/ToolboxModal.tsx
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios';
 import { Form, Formik } from 'formik';
 import { useEffect, useState } from 'react';
 import { useParams, useRevalidator } from 'react-router';
@@ -156,17 +157,23 @@ export default function ToolboxModal({
                     if (response) {
                       setStatus({
                         type: 'success',
-                        msg: 'Processing has begun. You may close this window.',
+                        msg: values.zonal
+                          ? 'Processing has begun. Zonal statistics status will update next to the selected layer.'
+                          : 'Processing has begun. You may close this window.',
                       });
                       actions.resetForm({ values: values });
                       setTimeout(() => {
                         revalidator.revalidate();
                       }, 3000);
                     }
-                  } catch {
+                  } catch (err) {
                     setStatus({
                       type: 'error',
-                      msg: 'Unable to complete request',
+                      msg:
+                        isAxiosError(err) &&
+                        typeof err.response?.data?.detail === 'string'
+                          ? err.response.data.detail
+                          : 'Unable to complete request',
                     });
                   }
                 } else {

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/ToolboxTools.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/ToolboxTools.tsx
@@ -424,7 +424,12 @@ interface ZonalJob {
   status: 'WAITING' | 'INPROGRESS' | 'SUCCESS' | 'FAILED';
   start_time: string;
   end_time: string | null;
-  extra: { layer_id?: string; detail?: string } | null;
+  extra: {
+    layer_id?: string;
+    detail?: string;
+    zones_total?: number;
+    zones_with_data?: number;
+  } | null;
 }
 
 const isActiveJob = (job: ZonalJob) =>
@@ -448,6 +453,30 @@ const ZonalLayerStatus = ({
     );
   }
 
+  // per-run zone summary (present on jobs run after zone-summary tracking)
+  const zonesTotal = job?.extra?.zones_total;
+  const zonesWithData = job?.extra?.zones_with_data;
+  const summaryKnown =
+    job?.status === 'SUCCESS' &&
+    typeof zonesTotal === 'number' &&
+    typeof zonesWithData === 'number';
+  const noOverlap = summaryKnown && zonesWithData === 0;
+  const partialOverlap =
+    summaryKnown && zonesWithData > 0 && zonesWithData < zonesTotal;
+
+  // no zone overlapped the raster: a retry won't help, so report it as an
+  // informational outcome rather than a failure and skip the download links
+  if (noOverlap) {
+    return (
+      <span
+        className="ml-2 inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700"
+        title="The selected zones fall outside this data product's extent or cover only no-data pixels."
+      >
+        No overlapping raster data
+      </span>
+    );
+  }
+
   // job finished (or predates job tracking); offer downloads for any
   // previously computed results, alongside the latest run's outcome
   return (
@@ -461,10 +490,18 @@ const ZonalLayerStatus = ({
         </span>
       )}
       <DownloadZonalStatistics dataProduct={dataProduct} layerId={layerId} />
-      {job && job.status === 'SUCCESS' && job.end_time && (
-        <span className="ml-2 text-xs font-normal text-gray-400">
-          computed {new Date(job.end_time).toLocaleString()}
+      {partialOverlap ? (
+        <span className="ml-2 text-xs font-normal text-amber-700">
+          {zonesWithData} of {zonesTotal} zones had data
         </span>
+      ) : (
+        job &&
+        job.status === 'SUCCESS' &&
+        job.end_time && (
+          <span className="ml-2 text-xs font-normal text-gray-400">
+            computed {new Date(job.end_time).toLocaleString()}
+          </span>
+        )
       )}
     </span>
   );

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/ToolboxTools.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/ToolboxTools.tsx
@@ -1,14 +1,18 @@
 import { AxiosResponse } from 'axios';
 import { Field, useFormikContext } from 'formik';
 import Papa from 'papaparse';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import HintText from '../../../../../HintText';
+import { useInterval } from '../../../../../hooks';
 import { SelectField } from '../../../../../InputFields';
 import { DataProduct, ZonalFeatureCollection } from '../../Project';
 import { ToolboxFields } from './ToolboxModal';
-import { removeKeysFromFeatureProperties } from '../../mapLayers/utils';
+import {
+  removeKeysFromFeatureProperties,
+  RESERVED_FEATURE_PROPERTY_KEYS,
+} from '../../mapLayers/utils';
 import { useProjectContext } from '../../ProjectContext';
 import { downloadFile as downloadCSV } from '../../fieldCampaigns/utils';
 import { download as downloadGeoJSON } from '../../mapLayers/utils';
@@ -307,14 +311,7 @@ const DownloadZonalStatistics = ({
   const { projectId, flightId } = useParams();
   const { project, flights } = useProjectContext();
 
-  const keysToSkip = [
-    'id',
-    'layer_id',
-    'is_active',
-    'project_id',
-    'flight_id',
-    'data_product_id',
-  ];
+  const keysToSkip = RESERVED_FEATURE_PROPERTY_KEYS;
 
   const generateFilename = (extension: string): string => {
     // Helper function to sanitize filename parts
@@ -420,9 +417,90 @@ const DownloadZonalStatistics = ({
   );
 };
 
+interface ZonalJob {
+  id: string;
+  name: string;
+  state: string;
+  status: 'WAITING' | 'INPROGRESS' | 'SUCCESS' | 'FAILED';
+  start_time: string;
+  end_time: string | null;
+  extra: { layer_id?: string; detail?: string } | null;
+}
+
+const isActiveJob = (job: ZonalJob) =>
+  job.status === 'WAITING' || job.status === 'INPROGRESS';
+
+const ZonalLayerStatus = ({
+  dataProduct,
+  layerId,
+  job,
+}: {
+  dataProduct: DataProduct;
+  layerId: string;
+  job: ZonalJob | null;
+}) => {
+  if (job && isActiveJob(job)) {
+    return (
+      <span className="ml-2 inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+        <span className="h-2 w-2 animate-pulse rounded-full bg-amber-500"></span>
+        Processing...
+      </span>
+    );
+  }
+
+  // job finished (or predates job tracking); offer downloads for any
+  // previously computed results, alongside the latest run's outcome
+  return (
+    <span className="inline-flex items-center">
+      {job && job.status === 'FAILED' && (
+        <span
+          className="ml-2 inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800"
+          title={job.extra?.detail || 'Zonal statistics could not be calculated'}
+        >
+          Failed &mdash; select the layer and click Start to retry
+        </span>
+      )}
+      <DownloadZonalStatistics dataProduct={dataProduct} layerId={layerId} />
+      {job && job.status === 'SUCCESS' && job.end_time && (
+        <span className="ml-2 text-xs font-normal text-gray-400">
+          computed {new Date(job.end_time).toLocaleString()}
+        </span>
+      )}
+    </span>
+  );
+};
+
 const ZonalStatisticTools = ({ dataProduct }: { dataProduct: DataProduct }) => {
-  const { values } = useFormikContext<ToolboxFields>();
+  const { isSubmitting, submitCount, values } =
+    useFormikContext<ToolboxFields>();
   const { mapLayers } = useProjectContext();
+  const { projectId, flightId } = useParams();
+
+  const [jobs, setJobs] = useState<ZonalJob[]>([]);
+
+  const fetchJobs = useCallback(async () => {
+    if (!projectId || !flightId || !dataProduct.id) return;
+    try {
+      const response: AxiosResponse<ZonalJob[]> = await api.get(
+        `/projects/${projectId}/flights/${flightId}/data_products/${dataProduct.id}/jobs`,
+        { params: { name: 'zonal' } }
+      );
+      setJobs(response.data);
+    } catch {
+      console.log('Unable to check status of zonal statistics jobs');
+    }
+  }, [projectId, flightId, dataProduct.id]);
+
+  // fetch on reveal and after each form submission completes
+  useEffect(() => {
+    if (values.zonal && !isSubmitting) {
+      fetchJobs();
+    }
+  }, [values.zonal, isSubmitting, submitCount, fetchJobs]);
+
+  // poll while any zonal job is still running
+  const hasActiveJob = jobs.some(isActiveJob);
+  useInterval(fetchJobs, values.zonal && hasActiveJob ? 5000 : null);
 
   const filteredAndSortedMapLayers = useMemo(() => {
     return mapLayers
@@ -450,28 +528,31 @@ const ZonalStatisticTools = ({ dataProduct }: { dataProduct: DataProduct }) => {
           {values.zonal && (
             <div>
               <span className="text-sm">Select Layer with Zonal Features:</span>
-              {filteredAndSortedMapLayers.map(
-                ({ layer_id, layer_name, geom_type }) => (
-                  <label
+              {filteredAndSortedMapLayers.map(({ layer_id, layer_name }) => {
+                // jobs are returned newest first
+                const layerJob =
+                  jobs.find((job) => job.extra?.layer_id === layer_id) ?? null;
+                return (
+                  <div
                     key={layer_id}
-                    className="block text-sm text-gray-600 font-bold pb-1"
+                    className="flex items-center text-sm text-gray-600 font-bold pb-1"
                   >
-                    <Field
-                      type="radio"
-                      name="zonal_layer_id"
-                      value={layer_id}
-                    />
-                    <span className="ml-2">{layer_name}</span>
-                    {(geom_type.toLowerCase() === 'polygon' ||
-                      geom_type.toLowerCase() === 'multipolygon') && (
-                      <DownloadZonalStatistics
-                        dataProduct={dataProduct}
-                        layerId={layer_id}
+                    <label className="inline-flex items-center">
+                      <Field
+                        type="radio"
+                        name="zonal_layer_id"
+                        value={layer_id}
                       />
-                    )}
-                  </label>
-                )
-              )}
+                      <span className="ml-2">{layer_name}</span>
+                    </label>
+                    <ZonalLayerStatus
+                      dataProduct={dataProduct}
+                      layerId={layer_id}
+                      job={layerJob}
+                    />
+                  </div>
+                );
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/components/pages/workspace/projects/mapLayers/utils.tsx
+++ b/frontend/src/components/pages/workspace/projects/mapLayers/utils.tsx
@@ -212,6 +212,21 @@ export function createAndClickDownloadLink(blob: Blob, filename: string) {
 }
 
 /**
+ * Internal D2S property keys excluded from user-facing downloads
+ * (mirrors RESERVED_VECTOR_PROPERTY_KEYS in backend/app/models/constants.py).
+ */
+export const RESERVED_FEATURE_PROPERTY_KEYS = [
+  'id',
+  'feature_id',
+  'layer_id',
+  'layer_name',
+  'is_active',
+  'project_id',
+  'flight_id',
+  'data_product_id',
+];
+
+/**
  * Removes provided array of key names from feature properties.
  * @param {ZonalFeatureCollection} featureCollection Feature collection with features.
  * @param {string[]} unwantedKeys Array of unwanted keys in feature properties.


### PR DESCRIPTION
## Summary

Bulk zonal statistics ran fire-and-forget: the toolbox said "processing has begun" and gave no way to tell whether a run succeeded, failed, or was still going, so failures were invisible and results only appeared after reopening the modal. This adds a job record per zonal run, a jobs lookup endpoint, and per-layer status chips in the toolbox that poll while a run is active.

Along the way it fixes a stats-correctness bug (zones extending past the raster edge desynced the read window from its affine transform, producing wrong values for *every* zone in the run) and a data-integrity bug where internal keys in downloaded exports could leak back through re-uploads and shadow real columns in map tiles.

## Changes

**Backend**

- `POST /data_products/{id}/tools` now creates a `zonal` job up front, passes its id to the Celery task, and returns `{"jobs": [{id, name, layer_id}]}`; a failed dispatch marks the job `FAILED` instead of leaving it `WAITING` forever.
- Added `GET /data_products/{id}/jobs?name=zonal`, backed by `crud.job.get_multi_by_data_product` (newest first).
- Validated zonal input up front: missing `zonal_layer_id` → 400, unknown/other-project layer → 404, non-polygon layer → 400. Zonal runs are no longer skipped under `RUNNING_TESTS`.
- Fixed window/transform desync in `compute_zonal_statistics`: snap the window to whole pixels and use a boundless read so the array stays aligned with `window_affine` when zones extend past the raster's edge. Nodata fallback now uses the band dtype's max when `-999` would overflow an unsigned band.
- Split the shared computation out of the `calculate_zonal_statistics` task so the bulk task calls a plain function rather than a task body; the single-zone task now re-raises on failure instead of returning an empty result.
- Job failures record a sanitized reason in `extra.detail` (exception class only — `str(e)` can contain server paths); successful runs record `zones_total` / `zones_with_data`.
- Zones with no valid raster data are no longer persisted, and stale rows from earlier runs are removed, so a partial-overlap run still returns the zones that do have data.
- Reserved internal property keys (`feature_id`, `layer_name`, `layer_id`, `project_id`, …) are stripped from uploaded vector layer properties via a new `RESERVED_VECTOR_PROPERTY_KEYS` constant; a user-supplied `id` is preserved as `fid`.
- `create_zonal_statistics` now validates that a claimed `feature_id` resolves to an active vector layer in the requesting project before returning cached stats; unmatched zones get stats merged onto the submitted feature without caching.
- `JobManager` accepts an injected `Session` and an `extra` dict at creation.
- Raised `botocore.credentials` to `WARNING` (rasterio builds a fresh GDAL env per rasterize call, logging "Found credentials in environment variables." once per zone). Wired into the Celery worker via `after_setup_logger` since the worker never imports `app.main`.
- Switched `run_processing_tool` and `create_zonal_statistics` off `async def` — they do blocking DB/IO work and were tying up the event loop.

**Frontend**

- New `ZonalLayerStatus` chip per layer in the toolbox: "Processing…" while active (polls every 5s via `useInterval`), "Failed — select the layer and click Start to retry" with the reason as a tooltip, download links plus a "computed …" timestamp on success.
- Runs where no zone overlapped the raster show an informational "No overlapping raster data" chip instead of empty downloads; partial overlap shows "N of M zones had data".
- Toolbox modal surfaces the server's validation `detail` instead of a generic "Unable to complete request".
- Extracted `RESERVED_FEATURE_PROPERTY_KEYS` in `mapLayers/utils.tsx` (mirrors the backend constant) and replaced the three duplicated inline key lists; exports now also exclude `layer_name`.

**Database**

- None. Uses the existing `job.extra` JSONB column.

## Testing

- `docker compose exec backend pytest` — all passing, including 23 new tests:
  - `backend/app/tests/tasks/test_toolbox_tasks.py` (new file): bulk run success, metadata update, failure marking, empty feature collection, zone extending past the raster edge, unsigned raster without nodata, all-zones-outside, partial overlap, stale empty metadata removal.
  - `backend/app/tests/api/api_v1/test_data_products.py`: zonal tool validation (missing / unknown / other-project / non-polygon layer), jobs endpoint (happy path, non-member, data product from another flight), and `feature_id` not in project.
  - `backend/app/tests/crud/test_vector_layer.py`: reserved key stripping and `fid` preservation.
- `docker compose exec frontend npx tsc --noEmit` — clean.
- Manual QA:
  1. Open a flight's data product toolbox → Zonal Statistics, select a polygon layer, click Start. Verify an amber "Processing…" chip appears next to that layer and flips to download links + "computed <timestamp>" without reopening the modal.
  2. Run against a layer whose zones sit outside the raster → verify the "No overlapping raster data" chip and no download links.
  3. Run against a layer partially overlapping the raster → verify "N of M zones had data" and that the download contains only the zones with data.
  4. Download a zonal GeoJSON, re-upload it as a new map layer, click a polygon on the new layer → verify it returns its own stats, not another feature's.

## Breaking Changes

- `POST /data_products/{id}/tools` now returns `{"jobs": [...]}` instead of an empty body. Existing frontend callers only check for a response, so no client change was required.
- Uploaded vector layers no longer keep an `id` property under that name — it is stored as `fid`. Reserved D2S keys in uploaded properties are dropped.

## Related Issues

NA
