### PR TITLE
[Enhancement] Make admin dashboard mobile friendly and add project storage search

### DIFF
--- a/backend/app/scripts/seed_demo_projects.py
+++ b/backend/app/scripts/seed_demo_projects.py
@@ -1,0 +1,256 @@
+"""Seed projects for existing demo users so the engagement leaderboard fills up.
+
+Development helper only. Gives every demo account (see ``seed_demo_activity.py``,
+which creates users at ``DEMO_EMAIL_DOMAIN``) a handful of active projects so the
+admin engagement leaderboard has enough ranked owners to page through.
+
+Each project gets a real ``Location`` polygon and an owner ``ProjectMember`` row,
+mirroring ``crud.project.create_with_owner``, but skips flights, data products,
+and module rows — the leaderboard only counts projects here, and the lean shape
+keeps ``--purge`` simple. Projects are identified as "demo" by their owner's
+email domain, so nothing marks real users' projects.
+
+Run ``--purge`` here BEFORE purging demo users in ``seed_demo_activity.py``:
+``projects.owner_id`` has no cascade, so deleting a user who still owns projects
+fails on the foreign key.
+
+Examples:
+    python /app/app/scripts/seed_demo_projects.py
+    python /app/app/scripts/seed_demo_projects.py --min-projects 1 --max-projects 10 --seed 7
+    python /app/app/scripts/seed_demo_projects.py --purge
+"""
+
+import argparse
+import json
+import logging
+import sys
+import uuid
+import warnings
+from datetime import datetime, timezone
+
+from faker import Faker
+from sqlalchemy import delete, func, select
+
+warnings.filterwarnings("ignore", message="relationship .* will copy column")
+
+from app.db.session import SessionLocal
+from app.models.location import Location
+from app.models.project import Project
+from app.models.project_member import ProjectMember
+from app.models.user import User
+from app.models.enums.project_type import ProjectType
+from app.schemas.role import Role
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Kept in sync with seed_demo_activity.py: the same accounts this script targets.
+DEMO_EMAIL_DOMAIN = "d2s-demo.example.com"
+
+# Bounding box the random project footprints fall inside (roughly the contiguous
+# US). The exact location is irrelevant for dashboard counts; it only needs to be
+# a valid polygon so the NOT NULL location_id can be satisfied.
+_LON_RANGE = (-120.0, -80.0)
+_LAT_RANGE = (30.0, 48.0)
+_FOOTPRINT_DEGREES = 0.01
+
+
+def _random_polygon(faker: Faker) -> dict:
+    """Return a small closed square polygon as a GeoJSON geometry dict."""
+    rng = faker.random
+    lon = rng.uniform(*_LON_RANGE)
+    lat = rng.uniform(*_LAT_RANGE)
+    d = _FOOTPRINT_DEGREES
+    ring = [
+        [lon, lat],
+        [lon + d, lat],
+        [lon + d, lat + d],
+        [lon, lat + d],
+        [lon, lat],  # GeoJSON rings must close on the first vertex
+    ]
+    return {"type": "Polygon", "coordinates": [ring]}
+
+
+def _project_created_at(faker: Faker, user_created_at: datetime) -> datetime:
+    """Pick a project creation time between the owner's signup and now."""
+    now = datetime.now(timezone.utc)
+    owner_created = user_created_at
+    if owner_created.tzinfo is None:
+        owner_created = owner_created.replace(tzinfo=timezone.utc)
+    # Clamp defensively in case a user's created_at is in the future.
+    if owner_created >= now:
+        return now
+    return faker.date_time_between(
+        start_date=owner_created, end_date=now, tzinfo=timezone.utc
+    )
+
+
+def seed(min_projects: int, max_projects: int, seed_value: int | None) -> None:
+    if min_projects < 1 or max_projects < min_projects:
+        logger.error("Require 1 <= --min-projects <= --max-projects.")
+        sys.exit(1)
+
+    faker = Faker()
+    if seed_value is not None:
+        faker.seed_instance(seed_value)
+    rng = faker.random
+
+    with SessionLocal() as session:
+        try:
+            with session.begin():
+                demo_users = session.scalars(
+                    select(User).where(User.email.like(f"%@{DEMO_EMAIL_DOMAIN}"))
+                ).all()
+                if not demo_users:
+                    logger.error(
+                        "No demo users found. Run seed_demo_activity.py first."
+                    )
+                    sys.exit(1)
+
+                owners_with_projects = set(
+                    session.scalars(
+                        select(Project.owner_id).where(
+                            Project.owner_id.in_([u.id for u in demo_users])
+                        )
+                    ).all()
+                )
+
+                total = 0
+                skipped = 0
+                for user in demo_users:
+                    # Idempotent: don't stack more projects onto a user that a
+                    # previous run already seeded.
+                    if user.id in owners_with_projects:
+                        skipped += 1
+                        continue
+
+                    for _ in range(rng.randint(min_projects, max_projects)):
+                        # Assign ids up front so the project can reference the
+                        # location without an intermediate flush.
+                        location_id = uuid.uuid4()
+                        project_id = uuid.uuid4()
+                        geometry = _random_polygon(faker)
+                        geom = func.ST_Force2D(
+                            func.ST_GeomFromGeoJSON(json.dumps(geometry))
+                        )
+                        session.add(Location(id=location_id, geom=geom))
+                        session.add(
+                            Project(
+                                id=project_id,
+                                title=f"{faker.city()} {faker.word()} survey"[:255],
+                                description=faker.sentence(nb_words=8)[:300],
+                                location_id=location_id,
+                                owner_id=user.id,
+                                is_active=True,
+                                created_at=_project_created_at(
+                                    faker, user.created_at
+                                ),
+                            )
+                        )
+                        session.add(
+                            ProjectMember(
+                                member_id=user.id,
+                                project_type=ProjectType.PROJECT,
+                                project_uuid=project_id,
+                                role=Role.OWNER,
+                            )
+                        )
+                        total += 1
+        except SystemExit:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to seed demo projects: {e}")
+            sys.exit(1)
+
+    logger.info(
+        "Seeded %d projects across %d demo users (%d already had projects, "
+        "left untouched).",
+        total,
+        len(demo_users) - skipped,
+        skipped,
+    )
+
+
+def purge() -> None:
+    """Delete every project owned by a demo user, plus its location and members.
+
+    Ordered to respect foreign keys: project_members and the projects themselves
+    go before the locations they reference (``projects.location_id``).
+    """
+    with SessionLocal() as session:
+        try:
+            with session.begin():
+                demo_user_ids = session.scalars(
+                    select(User.id).where(User.email.like(f"%@{DEMO_EMAIL_DOMAIN}"))
+                ).all()
+                if not demo_user_ids:
+                    logger.info("No demo users found; nothing to purge.")
+                    return
+
+                rows = session.execute(
+                    select(Project.id, Project.location_id).where(
+                        Project.owner_id.in_(demo_user_ids)
+                    )
+                ).all()
+                project_ids = [row[0] for row in rows]
+                location_ids = [row[1] for row in rows]
+
+                if not project_ids:
+                    logger.info("No demo projects found; nothing to purge.")
+                    return
+
+                session.execute(
+                    delete(ProjectMember).where(
+                        ProjectMember.project_uuid.in_(project_ids)
+                    )
+                )
+                session.execute(delete(Project).where(Project.id.in_(project_ids)))
+                session.execute(
+                    delete(Location).where(Location.id.in_(location_ids))
+                )
+        except Exception as e:
+            logger.error(f"Failed to purge demo projects: {e}")
+            sys.exit(1)
+
+    logger.info("Removed %d demo projects and their locations.", len(project_ids))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed projects for demo users to populate the engagement leaderboard"
+    )
+    parser.add_argument(
+        "--min-projects",
+        type=int,
+        default=1,
+        help="Minimum projects per demo user (default: 1)",
+    )
+    parser.add_argument(
+        "--max-projects",
+        type=int,
+        default=10,
+        help="Maximum projects per demo user (default: 10)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=None, help="RNG seed for reproducible output"
+    )
+    parser.add_argument(
+        "--purge",
+        action="store_true",
+        help="Delete all projects owned by demo users instead of seeding",
+    )
+
+    args = parser.parse_args()
+
+    if args.purge:
+        purge()
+    else:
+        seed(
+            min_projects=args.min_projects,
+            max_projects=args.max_projects,
+            seed_value=args.seed,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/components/hooks/index.tsx
+++ b/frontend/src/components/hooks/index.tsx
@@ -1,3 +1,4 @@
 export { useInterval } from './useInterval';
 export { useIsMobile } from './useIsMobile';
+export { usePaginatedList } from './usePaginatedList';
 export { usePrevious } from './usePrevious';

--- a/frontend/src/components/hooks/usePaginatedList.ts
+++ b/frontend/src/components/hooks/usePaginatedList.ts
@@ -1,0 +1,42 @@
+import { useEffect, useMemo, useState } from 'react';
+
+type PaginatedList<T> = {
+  pageItems: T[];
+  currentPage: number;
+  totalPages: number;
+  updateCurrentPage: (newPage: number) => void;
+};
+
+/**
+ * Slices a list into pages and tracks the active page.
+ * @param items Full list to paginate.
+ * @param maxItems Maximum number of items per page.
+ * @returns Items on the current page plus the state needed by Pagination.
+ */
+export function usePaginatedList<T>(
+  items: T[],
+  maxItems: number
+): PaginatedList<T> {
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const totalPages = Math.ceil(items.length / maxItems);
+
+  // Pull the page back in bounds when the list shrinks beneath it, e.g. after a
+  // search term filters out everything on the current page.
+  useEffect(() => {
+    if (currentPage > 0 && currentPage >= totalPages) {
+      setCurrentPage(Math.max(0, totalPages - 1));
+    }
+  }, [currentPage, totalPages]);
+
+  function updateCurrentPage(newPage: number): void {
+    setCurrentPage(Math.max(0, Math.min(newPage, totalPages - 1)));
+  }
+
+  const pageItems = useMemo(
+    () => items.slice(currentPage * maxItems, maxItems + currentPage * maxItems),
+    [items, currentPage, maxItems]
+  );
+
+  return { pageItems, currentPage, totalPages, updateCurrentPage };
+}

--- a/frontend/src/components/pages/admin/DashboardActivity.tsx
+++ b/frontend/src/components/pages/admin/DashboardActivity.tsx
@@ -16,6 +16,7 @@ import Pagination from '../../Pagination';
 import { User } from '../../../AuthContext';
 
 import api from '../../../api';
+import { bytesToGB } from '../../utils';
 
 const MAX_ITEMS = 10; // leaderboard rows per page
 const LEADERBOARD_LIMIT = 50;
@@ -39,10 +40,6 @@ const METRIC_TO_FIELD: Record<LeaderboardMetric, keyof EngagementLeaderRow> = {
   likes: 'total_likes',
   storage: 'total_storage',
 };
-
-function bytesToGB(bytes: number): string {
-  return (bytes / 1024 ** 3).toFixed(2);
-}
 
 type InfoKey = 'active' | 'trend' | 'funnel' | 'signups' | 'leaderboard';
 
@@ -402,10 +399,11 @@ function EngagementLeaderboard({
     }
   }
 
-  const pageRows = rows.slice(
-    currentPage * MAX_ITEMS,
-    MAX_ITEMS + currentPage * MAX_ITEMS,
-  );
+  // Rank reflects standing across the whole ranked list, so it carries the
+  // page offset rather than restarting at 1 on each page.
+  const pageRows = rows
+    .slice(currentPage * MAX_ITEMS, MAX_ITEMS + currentPage * MAX_ITEMS)
+    .map((row, idx) => ({ ...row, rank: currentPage * MAX_ITEMS + idx + 1 }));
 
   const columns: {
     label: string;
@@ -455,6 +453,7 @@ function EngagementLeaderboard({
           <table className="hidden w-full border-separate border-spacing-y-1 border-spacing-x-1 md:table">
             <thead>
               <tr className="h-12 text-slate-700 bg-slate-300">
+                <th className="w-16 p-2">#</th>
                 <th className="p-2 text-left">User</th>
                 {columns.map((column) => (
                   <th
@@ -471,6 +470,9 @@ function EngagementLeaderboard({
             <tbody>
               {pageRows.map((row) => (
                 <tr key={row.user_id} className="text-center">
+                  <td className="w-16 bg-slate-100 p-2 font-semibold text-gray-500">
+                    {row.rank}
+                  </td>
                   <td className="max-w-96 truncate bg-slate-100 p-2 text-left">
                     <span className="font-medium">{row.name}</span>
                     <span className="ml-2 text-sm text-gray-500">
@@ -499,11 +501,11 @@ function EngagementLeaderboard({
           {/* The table's seven columns cannot fit a phone without horizontal
               scrolling, so the same rows render as cards below `md`. */}
           <div className="flex flex-col gap-3 md:hidden">
-            {pageRows.map((row, idx) => (
+            {pageRows.map((row) => (
               <div key={row.user_id} className="rounded-sm bg-slate-100 p-3">
                 <div className="flex items-baseline gap-2">
                   <span className="shrink-0 text-sm font-semibold text-gray-500">
-                    #{currentPage * MAX_ITEMS + idx + 1}
+                    #{row.rank}
                   </span>
                   <div className="min-w-0">
                     <div className="truncate font-medium">{row.name}</div>

--- a/frontend/src/components/pages/admin/DashboardActivity.tsx
+++ b/frontend/src/components/pages/admin/DashboardActivity.tsx
@@ -603,7 +603,7 @@ export default function DashboardActivity() {
   }, [trends]);
 
   return (
-    <section className="h-full w-full overflow-y-auto bg-white p-4">
+    <section className="w-full bg-white p-4">
       <div className="flex flex-col gap-10">
         <div>
           <SectionHeading infoKey="active" onInfo={setActiveInfo} />

--- a/frontend/src/components/pages/admin/DashboardExtensions/ExtensionList.tsx
+++ b/frontend/src/components/pages/admin/DashboardExtensions/ExtensionList.tsx
@@ -82,7 +82,7 @@ export default function ExtensionList({
   }
 
   return (
-    <div className="flex justify-center gap-4">
+    <div className="flex flex-wrap justify-center gap-x-4 gap-y-2">
       {extensions.map((extension) => (
         <div key={extension.id} className="flex items-center">
           <Checkbox

--- a/frontend/src/components/pages/admin/DashboardExtensions/TeamExtensions.tsx
+++ b/frontend/src/components/pages/admin/DashboardExtensions/TeamExtensions.tsx
@@ -1,12 +1,16 @@
 import { useMemo, useState } from 'react';
 
 import { Status } from '../../../Alert';
+import { DataCard } from '../DataCards';
 import ExtensionList, { Extension } from './ExtensionList';
 import Pagination from '../../../Pagination';
 import { Team } from '../../teams/Teams';
 import SearchBar from '../SearchBar';
 
+import { usePaginatedList } from '../../../hooks';
 import { sorter } from '../../../utils';
+
+const MAX_ITEMS = 10; // max number of teams per page
 
 type TeamExtensionsProps = {
   extensions: Extension[];
@@ -19,14 +23,13 @@ export default function TeamExtensions({
   setStatus,
   teams,
 }: TeamExtensionsProps) {
-  const [currentPage, setCurrentPage] = useState(0);
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   const updateSearchTerm = (newSearchTerm: string): void =>
     setSearchTerm(newSearchTerm);
 
   const filteredTeams = useMemo(() => {
-    // If searchTerm is empty, return all users
+    // If searchTerm is empty, return all teams
     if (searchTerm === '') {
       return teams
         .slice()
@@ -44,85 +47,80 @@ export default function TeamExtensions({
       .sort((a, b) => sorter(a.title.toLowerCase(), b.title.toLowerCase()));
   }, [searchTerm, teams]);
 
-  const MAX_ITEMS = 10; // max number of users per page
-  const TOTAL_PAGES = Math.ceil(filteredTeams.length / MAX_ITEMS);
-
-  /**
-   * Updates the current selected pagination page.
-   * @param newPage Index of new page.
-   */
-  function updateCurrentPage(newPage: number): void {
-    const total_pages = Math.ceil(
-      filteredTeams ? filteredTeams.length : 0 / MAX_ITEMS
-    );
-
-    if (newPage + 1 > total_pages) {
-      setCurrentPage(total_pages - 1);
-    } else if (newPage < 0) {
-      setCurrentPage(0);
-    } else {
-      setCurrentPage(newPage);
-    }
-  }
-
-  /**
-   * Filters users or teams by search text and limits to current page.
-   * @param items Users or teams to filter.
-   * @returns
-   */
-  function filterAndSlice(items: Team[]) {
-    return items.slice(
-      currentPage * MAX_ITEMS,
-      MAX_ITEMS + currentPage * MAX_ITEMS
-    );
-  }
-
-  /**
-   * Returns available users or teams on page limitations.
-   * @param items Users or teams to filter, limit, and sort.
-   * @returns Array of filtered users or teams.
-   */
-  function getAvailableUsers(items: Team[]): Team[] {
-    return filterAndSlice(items);
-  }
+  const { pageItems, totalPages, currentPage, updateCurrentPage } =
+    usePaginatedList(filteredTeams, MAX_ITEMS);
 
   return (
     <div className="max-h-[60vh] flex flex-col gap-4">
       <h2>Teams</h2>
-      <SearchBar searchTerm={searchTerm} updateSearchTerm={updateSearchTerm} />
-      <table className="relative border-separate border-spacing-y-1 border-spacing-x-1">
-        <thead>
-          <tr className="h-12 sticky top-0 text-slate-700 bg-slate-300">
-            <th className="w-1/2">Name</th>
-            <th className="w-1/2">Extensions</th>
-          </tr>
-        </thead>
-      </table>
-      <div className="max-h-96 overflow-y-auto">
-        <table className="relative border-separate border-spacing-y-1 border-spacing-x-1">
-          <tbody>
-            {getAvailableUsers(filteredTeams).map((team) => (
-              <tr key={team.id} className="text-center">
-                <td className="w-1/2 p-1.5 bg-slate-100">{team.title}</td>
-                <td className="w-1/2 p-1.5 bg-white">
+      <SearchBar
+        searchTerm={searchTerm}
+        updateSearchTerm={updateSearchTerm}
+        placeholder="Search by team name or description"
+      />
+
+      {filteredTeams.length === 0 ? (
+        <p className="text-gray-500">No teams match your search.</p>
+      ) : (
+        <>
+          {/* Header and body live in one table so the columns stay aligned; the
+              sticky header pins to the top of the shared scroll container. */}
+          <div className="hidden max-h-96 overflow-y-auto md:block">
+            <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
+              <thead>
+                <tr className="h-12 text-slate-700">
+                  <th className="sticky top-0 z-10 w-1/2 bg-slate-300">Name</th>
+                  <th className="sticky top-0 z-10 w-1/2 bg-slate-300">
+                    Extensions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageItems.map((team) => (
+                  <tr key={team.id} className="text-center">
+                    <td className="w-1/2 p-1.5 bg-slate-100">{team.title}</td>
+                    <td className="w-1/2 p-1.5 bg-white">
+                      <ExtensionList
+                        extensions={extensions}
+                        selectedExtensions={team.exts}
+                        setStatus={setStatus}
+                        teamId={team.id}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* The name column plus a checkbox row cannot fit a phone, so the same
+              rows render as cards below `md`. */}
+          <div className="flex flex-col gap-3 md:hidden">
+            {pageItems.map((team) => (
+              <DataCard
+                key={team.id}
+                title={team.title}
+                subtitle={team.description}
+              >
+                <div className="mt-3">
                   <ExtensionList
                     extensions={extensions}
                     selectedExtensions={team.exts}
                     setStatus={setStatus}
                     teamId={team.id}
                   />
-                </td>
-              </tr>
+                </div>
+              </DataCard>
             ))}
-          </tbody>
-        </table>
-      </div>
+          </div>
 
-      <Pagination
-        currentPage={currentPage}
-        updateCurrentPage={updateCurrentPage}
-        totalPages={TOTAL_PAGES}
-      />
+          <Pagination
+            currentPage={currentPage}
+            updateCurrentPage={updateCurrentPage}
+            totalPages={totalPages}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/pages/admin/DashboardExtensions/UserExtensions.tsx
+++ b/frontend/src/components/pages/admin/DashboardExtensions/UserExtensions.tsx
@@ -1,12 +1,16 @@
 import { useMemo, useState } from 'react';
 
 import { Status } from '../../../Alert';
+import { DataCard } from '../DataCards';
 import ExtensionList, { Extension } from './ExtensionList';
 import Pagination from '../../../Pagination';
 import SearchBar from '../SearchBar';
 import { User } from '../../../../AuthContext';
 
+import { usePaginatedList } from '../../../hooks';
 import { sorter } from '../../../utils';
+
+const MAX_ITEMS = 10; // max number of users per page
 
 type UserExtensionsProps = {
   extensions: Extension[];
@@ -19,7 +23,6 @@ export default function UserExtensions({
   setStatus,
   users,
 }: UserExtensionsProps) {
-  const [currentPage, setCurrentPage] = useState(0);
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   const updateSearchTerm = (newSearchTerm: string): void =>
@@ -42,95 +45,93 @@ export default function UserExtensions({
         (user) =>
           user.first_name.toLowerCase().includes(lowerSearchTerm) ||
           user.last_name.toLowerCase().includes(lowerSearchTerm) ||
-          user.email.toLowerCase().includes(searchTerm)
+          user.email.toLowerCase().includes(lowerSearchTerm)
       )
       .sort((a, b) =>
         sorter(a.last_name.toLowerCase(), b.last_name.toLowerCase())
       );
   }, [searchTerm, users]);
 
-  const MAX_ITEMS = 10; // max number of users per page
-  const TOTAL_PAGES = Math.ceil(filteredUsers.length / MAX_ITEMS);
-
-  /**
-   * Updates the current selected pagination page.
-   * @param newPage Index of new page.
-   */
-  function updateCurrentPage(newPage: number): void {
-    const total_pages = Math.ceil(
-      filteredUsers ? filteredUsers.length : 0 / MAX_ITEMS
-    );
-
-    if (newPage + 1 > total_pages) {
-      setCurrentPage(total_pages - 1);
-    } else if (newPage < 0) {
-      setCurrentPage(0);
-    } else {
-      setCurrentPage(newPage);
-    }
-  }
-
-  /**
-   * Filters users or teams by search text and limits to current page.
-   * @param items Users or teams to filter.
-   * @returns
-   */
-  function filterAndSlice(items: User[]) {
-    return items.slice(
-      currentPage * MAX_ITEMS,
-      MAX_ITEMS + currentPage * MAX_ITEMS
-    );
-  }
-
-  /**
-   * Returns available users or teams on page limitations.
-   * @param items Users or teams to filter, limit, and sort.
-   * @returns Array of filtered users or teams.
-   */
-  function getAvailableUsers(items: User[]): User[] {
-    return filterAndSlice(items);
-  }
+  const { pageItems, totalPages, currentPage, updateCurrentPage } =
+    usePaginatedList(filteredUsers, MAX_ITEMS);
 
   return (
     <div className="max-h-[60vh] flex flex-col gap-4">
       <h2>Users</h2>
-      <SearchBar searchTerm={searchTerm} updateSearchTerm={updateSearchTerm} />
-      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
-        <thead>
-          <tr className="h-12 sticky top-0 text-slate-700 bg-slate-300">
-            <th className="w-1/3">Name</th>
-            <th className="w-1/3">Email</th>
-            <th className="w-1/3">Extensions</th>
-          </tr>
-        </thead>
-      </table>
-      <div className="max-h-96 overflow-y-auto">
-        <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
-          <tbody>
-            {getAvailableUsers(filteredUsers).map((user) => (
-              <tr key={user.id} className="text-center">
-                <td className="w-1/3 p-1.5 bg-white">
-                  {user.first_name} {user.last_name}
-                </td>
-                <td className="w-1/3 p-1.5 bg-white">{user.email}</td>
-                <td className="w-1/3 p-1.5 bg-white">
+      <SearchBar
+        searchTerm={searchTerm}
+        updateSearchTerm={updateSearchTerm}
+        placeholder="Search by name or email"
+      />
+
+      {filteredUsers.length === 0 ? (
+        <p className="text-gray-500">No users match your search.</p>
+      ) : (
+        <>
+          {/* Header and body live in one table so the columns stay aligned; the
+              sticky header pins to the top of the shared scroll container. */}
+          <div className="hidden max-h-96 overflow-y-auto md:block">
+            <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
+              <thead>
+                <tr className="h-12 text-slate-700">
+                  <th className="sticky top-0 z-10 w-1/3 bg-slate-300">Name</th>
+                  <th className="sticky top-0 z-10 w-1/3 bg-slate-300">
+                    Email
+                  </th>
+                  <th className="sticky top-0 z-10 w-1/3 bg-slate-300">
+                    Extensions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageItems.map((user) => (
+                  <tr key={user.id} className="text-center">
+                    <td className="w-1/3 p-1.5 bg-white">
+                      {user.first_name} {user.last_name}
+                    </td>
+                    <td className="w-1/3 p-1.5 bg-white">{user.email}</td>
+                    <td className="w-1/3 p-1.5 bg-white">
+                      <ExtensionList
+                        extensions={extensions}
+                        selectedExtensions={user.exts}
+                        setStatus={setStatus}
+                        userId={user.id}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Three columns plus a checkbox row cannot fit a phone, so the same
+              rows render as cards below `md`. */}
+          <div className="flex flex-col gap-3 md:hidden">
+            {pageItems.map((user) => (
+              <DataCard
+                key={user.id}
+                title={`${user.first_name} ${user.last_name}`}
+                subtitle={user.email}
+              >
+                <div className="mt-3">
                   <ExtensionList
                     extensions={extensions}
                     selectedExtensions={user.exts}
                     setStatus={setStatus}
                     userId={user.id}
                   />
-                </td>
-              </tr>
+                </div>
+              </DataCard>
             ))}
-          </tbody>
-        </table>
-      </div>
-      <Pagination
-        currentPage={currentPage}
-        updateCurrentPage={updateCurrentPage}
-        totalPages={TOTAL_PAGES}
-      />
+          </div>
+
+          <Pagination
+            currentPage={currentPage}
+            updateCurrentPage={updateCurrentPage}
+            totalPages={totalPages}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/pages/admin/DashboardProjectStorage.tsx
+++ b/frontend/src/components/pages/admin/DashboardProjectStorage.tsx
@@ -40,8 +40,10 @@ export default function DashboardProjectStorage() {
             User Project Storage
           </h2>
           <p className="mt-4 text-gray-500 sm:text-xl">
-            Summary of total disk usage by user based on project ownership.
+            Summary of disk usage by user based on active project ownership.
           </p>
+        </div>
+        <div className="mx-auto max-w-3xl">
           <Suspense fallback={<DashboardProjectStorageTableSkeleton />}>
             <Await
               resolve={projectStatisticsApiResponse.response}

--- a/frontend/src/components/pages/admin/DashboardProjectStorageTable.tsx
+++ b/frontend/src/components/pages/admin/DashboardProjectStorageTable.tsx
@@ -1,105 +1,127 @@
 import { useMemo, useState } from 'react';
 
+import { DataCard, MetricTile, MetricTileGrid } from './DataCards';
 import { ProjectStatistics } from './DashboardTypes';
 import Pagination from '../../Pagination';
+import SearchBar from './SearchBar';
+
+import { usePaginatedList } from '../../hooks';
+import { bytesToGB } from '../../utils';
+
+const MAX_ITEMS = 10; // max number of users per page
 
 export default function DashboardProjectStorageTable({
   userProjectStats,
 }: {
   userProjectStats: ProjectStatistics[];
 }) {
-  const [currentPage, setCurrentPage] = useState(0);
+  const [searchTerm, setSearchTerm] = useState<string>('');
 
-  const MAX_ITEMS = 5; // max number of users per page
-  const TOTAL_PAGES = Math.ceil(userProjectStats.length / MAX_ITEMS);
+  const updateSearchTerm = (newSearchTerm: string): void =>
+    setSearchTerm(newSearchTerm);
 
-  /**
-   * Updates the current selected pagination page.
-   * @param newPage Index of new page.
-   */
-  function updateCurrentPage(newPage: number): void {
-    const total_pages = Math.ceil(
-      userProjectStats ? userProjectStats.length : 0 / MAX_ITEMS
+  // Rank against every user before filtering so a searched user keeps the
+  // position they hold overall rather than being renumbered within the results.
+  const rankedStats = useMemo(
+    () =>
+      [...userProjectStats]
+        .sort((a, b) => b.total_active_storage - a.total_active_storage)
+        .map((stats, idx) => ({ ...stats, rank: idx + 1 })),
+    [userProjectStats]
+  );
+
+  const visibleStats = useMemo(() => {
+    const lowerSearchTerm = searchTerm.trim().toLowerCase();
+    if (!lowerSearchTerm) return rankedStats;
+
+    return rankedStats.filter((stats) =>
+      stats.user.toLowerCase().includes(lowerSearchTerm)
     );
+  }, [searchTerm, rankedStats]);
 
-    if (newPage + 1 > total_pages) {
-      setCurrentPage(total_pages - 1);
-    } else if (newPage < 0) {
-      setCurrentPage(0);
-    } else {
-      setCurrentPage(newPage);
-    }
-  }
-
-  /**
-   * Filters users by search text and limits to current page.
-   * @param users Users to filter.
-   * @returns
-   */
-  function filterAndSlice(stats: ProjectStatistics[]) {
-    return stats.slice(
-      currentPage * MAX_ITEMS,
-      MAX_ITEMS + currentPage * MAX_ITEMS
-    );
-  }
-
-  /**
-   * Returns available users on page limitations.
-   * @param users Users to filter, limit, and sort.
-   * @returns Array of filtered users.
-   */
-  function getAvailableUsers(stats): ProjectStatistics[] {
-    return filterAndSlice(stats);
-  }
-
-  const userProjectStatsSorted = useMemo(() => {
-    return [...userProjectStats].sort(
-      (a, b) => b.total_storage - a.total_storage
-    );
-  }, [userProjectStats]);
+  const { pageItems, currentPage, totalPages, updateCurrentPage } =
+    usePaginatedList(visibleStats, MAX_ITEMS);
 
   if (userProjectStats.length === 0) {
     return <section className="w-full bg-white">No data</section>;
   }
 
   return (
-    <div className="relative mt-12">
-      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
-        <thead>
-          <tr className="h-12 sticky top-0 text-slate-700 bg-slate-300">
-            <th className="p-2">Name</th>
-            <th className="p-2">Projects*</th>
-            <th className="p-2">Total storage GB**</th>
-          </tr>
-        </thead>
-        <tbody className="max-h-96 overflow-y-auto">
-          {getAvailableUsers(userProjectStatsSorted).map((stats) => (
-            <tr key={stats.id} className="text-center">
-              <td className="p-2 bg-slate-100 w-96 max-w-96 truncate">
-                {stats.user}
-              </td>
-              <td className="p-2 bg-slate-50 w-44">
-                {stats.total_projects} ({stats.total_active_projects})
-              </td>
-              <td className="p-2 bg-slate-50 w-48">
-                {(stats.total_storage / 1024 ** 3).toFixed(3)} (
-                {(stats.total_active_storage / 1024 ** 3).toFixed(3)})
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <Pagination
-        currentPage={currentPage}
-        updateCurrentPage={updateCurrentPage}
-        totalPages={TOTAL_PAGES}
+    <div className="relative mt-12 flex flex-col gap-4">
+      <SearchBar
+        searchTerm={searchTerm}
+        updateSearchTerm={updateSearchTerm}
+        placeholder="Search by user name"
       />
-      <div className="mt-4 text-left">
-        <div className="relative">* Total projects (total active projects)</div>
-        <div className="relative">
-          ** Total storage (total storage from active projects)
-        </div>
-      </div>
+
+      {visibleStats.length === 0 ? (
+        <p className="text-gray-500">No users match your search.</p>
+      ) : (
+        <>
+          <table className="relative hidden w-full border-separate border-spacing-y-1 border-spacing-x-1 md:table">
+            <thead>
+              <tr className="h-12 text-slate-700 bg-slate-300">
+                <th className="p-2 w-16">#</th>
+                <th className="p-2">Name</th>
+                <th className="p-2">Projects</th>
+                <th className="p-2">Storage (GB)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pageItems.map((stats) => (
+                <tr key={stats.id} className="text-center">
+                  <td className="p-2 bg-slate-100 w-16 font-semibold text-gray-500">
+                    {stats.rank}
+                  </td>
+                  <td className="p-2 bg-slate-100 w-96 max-w-96 truncate">
+                    {stats.user}
+                  </td>
+                  <td className="p-2 bg-slate-50 w-44">
+                    {stats.total_active_projects}
+                  </td>
+                  <td className="p-2 bg-slate-50 w-48">
+                    {bytesToGB(stats.total_active_storage)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* The table's fixed column widths cannot fit a phone without
+              horizontal scrolling, so the same rows render as cards below `md`. */}
+          <div className="flex flex-col gap-3 md:hidden">
+            {pageItems.map((stats) => (
+              <DataCard
+                key={stats.id}
+                leading={
+                  <span className="shrink-0 text-sm font-semibold text-gray-500">
+                    #{stats.rank}
+                  </span>
+                }
+                title={stats.user}
+              >
+                <MetricTileGrid>
+                  <MetricTile
+                    label="Projects"
+                    value={stats.total_active_projects}
+                  />
+                  <MetricTile
+                    label="Storage (GB)"
+                    value={bytesToGB(stats.total_active_storage)}
+                    highlight
+                  />
+                </MetricTileGrid>
+              </DataCard>
+            ))}
+          </div>
+
+          <Pagination
+            currentPage={currentPage}
+            updateCurrentPage={updateCurrentPage}
+            totalPages={totalPages}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/pages/admin/DashboardProjectStorageTableSkeleton.tsx
+++ b/frontend/src/components/pages/admin/DashboardProjectStorageTableSkeleton.tsx
@@ -1,17 +1,21 @@
 export default function DashboardProjectStorageTableSkeleton() {
   return (
-    <div className="relative mt-12">
-      <table className="relative w-full border-separate border-spacing-y-1 border-spacing-x-1">
+    <div className="relative mt-12 flex flex-col gap-4">
+      <div className="h-10 w-full animate-pulse rounded-md bg-slate-100"></div>
+
+      <table className="relative hidden w-full border-separate border-spacing-y-1 border-spacing-x-1 md:table">
         <thead>
-          <tr className="h-12 sticky top-0 text-slate-700 bg-slate-300">
+          <tr className="h-12 text-slate-700 bg-slate-300">
+            <th className="p-2 w-16">#</th>
             <th className="p-2">Name</th>
-            <th className="p-2">Total projects</th>
-            <th className="p-2">Total storage (GB)</th>
+            <th className="p-2">Projects</th>
+            <th className="p-2">Storage (GB)</th>
           </tr>
         </thead>
-        <tbody className="max-h-96 overflow-y-auto">
-          {new Array(5).fill(0).map((_, idx) => (
+        <tbody>
+          {new Array(10).fill(0).map((_, idx) => (
             <tr key={idx} className="text-center">
+              <td className="p-2 bg-slate-100 h-14 w-16 animate-pulse"></td>
               <td className="p-2 bg-slate-100 h-14 w-96 animate-pulse"></td>
               <td className="p-2 bg-slate-50 h-14 w-44 animate-pulse"></td>
               <td className="p-2 bg-slate-50 h-14 w-48 animate-pulse"></td>
@@ -19,6 +23,15 @@ export default function DashboardProjectStorageTableSkeleton() {
           ))}
         </tbody>
       </table>
+
+      <div className="flex flex-col gap-3 md:hidden">
+        {new Array(3).fill(0).map((_, idx) => (
+          <div
+            key={idx}
+            className="h-28 animate-pulse rounded-sm bg-slate-100"
+          ></div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/pages/admin/DashboardUserList.tsx
+++ b/frontend/src/components/pages/admin/DashboardUserList.tsx
@@ -4,11 +4,13 @@ import { useContext, useMemo, useState } from 'react';
 import { generateRandomProfileColor } from '../auth/Profile';
 import { Button } from '../../Buttons';
 import Checkbox from '../../Checkbox';
+import { DataCard, MetricTile, MetricTileGrid } from './DataCards';
 import Pagination from '../../Pagination';
 import AuthContext, { User } from '../../../AuthContext';
 import { confirm } from '../../ConfirmationDialog';
 import api from '../../../api';
 
+import { usePaginatedList } from '../../hooks';
 import { downloadFile as downloadCSV } from '../workspace/projects/fieldCampaigns/utils';
 
 const UserProfilePicture = ({ user }: { user: User }) =>
@@ -44,6 +46,56 @@ type SortColumn =
   | 'is_approved';
 type SortDirection = 'asc' | 'desc';
 
+const MAX_ITEMS = 10; // max number of users per page
+
+// Column labels reused by the mobile sort control so it stays in step with the
+// desktop table headers.
+const SORT_OPTIONS: { value: SortColumn; label: string }[] = [
+  { value: 'name', label: 'Name' },
+  { value: 'email', label: 'Email' },
+  { value: 'created_at', label: 'Date Joined' },
+  { value: 'last_login_at', label: 'Last Login' },
+  { value: 'last_activity_at', label: 'Last Activity' },
+];
+
+/**
+ * Approval switch shared by the desktop table cell and the mobile card.
+ */
+function ApprovalToggle({
+  user,
+  loading,
+  onToggle,
+}: {
+  user: User;
+  loading: boolean;
+  onToggle: (user: User) => void;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      <span
+        className={`text-lg ${
+          user.is_approved ? 'text-green-600' : 'text-red-600'
+        }`}
+      >
+        {user.is_approved ? '✓' : '✗'}
+      </span>
+      <label
+        htmlFor={`${user.id}-approval-checkbox`}
+        className="relative inline-flex items-center cursor-pointer"
+      >
+        <Checkbox
+          id={`${user.id}-approval-checkbox`}
+          checked={user.is_approved}
+          onChange={() => onToggle(user)}
+          className="sr-only peer"
+        />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+      </label>
+      {loading && <span className="text-sm text-gray-500">...</span>}
+    </div>
+  );
+}
+
 export default function DashboardUserList({
   users,
   setUsers,
@@ -52,7 +104,6 @@ export default function DashboardUserList({
   setUsers: (users: User[] | ((prevUsers: User[]) => User[])) => void;
 }) {
   const { user: currentUser } = useContext(AuthContext);
-  const [currentPage, setCurrentPage] = useState(0);
   const [sortColumn, setSortColumn] = useState<SortColumn>('created_at');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
@@ -68,25 +119,6 @@ export default function DashboardUserList({
     'last_login_at',
     'last_activity_at',
   ];
-
-  const MAX_ITEMS = 10; // max number of users per page
-  const TOTAL_PAGES = Math.ceil(users.length / MAX_ITEMS);
-
-  /**
-   * Updates the current selected pagination page.
-   * @param newPage Index of new page.
-   */
-  function updateCurrentPage(newPage: number): void {
-    const total_pages = Math.ceil(users ? users.length : 0 / MAX_ITEMS);
-
-    if (newPage + 1 > total_pages) {
-      setCurrentPage(total_pages - 1);
-    } else if (newPage < 0) {
-      setCurrentPage(0);
-    } else {
-      setCurrentPage(newPage);
-    }
-  }
 
   /**
    * Handle column header click to toggle sorting
@@ -133,9 +165,9 @@ export default function DashboardUserList({
   }
 
   /**
-   * Sort and paginate users
+   * Sort users
    */
-  const sortedAndPaginatedUsers = useMemo(() => {
+  const sortedUsers = useMemo(() => {
     const sorted = [...users].sort((a, b) => {
       let comparison = 0;
 
@@ -196,11 +228,11 @@ export default function DashboardUserList({
       return sortDirection === 'asc' ? comparison : -comparison;
     });
 
-    return sorted.slice(
-      currentPage * MAX_ITEMS,
-      MAX_ITEMS + currentPage * MAX_ITEMS
-    );
-  }, [users, sortColumn, sortDirection, currentPage]);
+    return sorted;
+  }, [users, sortColumn, sortDirection]);
+
+  const { pageItems, currentPage, totalPages, updateCurrentPage } =
+    usePaginatedList(sortedUsers, MAX_ITEMS);
 
   /**
    * Render sort indicator
@@ -213,8 +245,94 @@ export default function DashboardUserList({
   }
 
   return (
-    <div className="max-h-[40vh] w-full flex flex-col gap-4">
-      <div className="md:max-h-96 max-h-60 overflow-y-auto overflow-x-auto">
+    <div className="w-full flex flex-col gap-4">
+      {/* The table needs 1200px to fit its six columns, so phones get a sort
+          control and cards instead of a horizontally scrolling table. */}
+      <div className="flex items-center gap-2 md:hidden">
+        <label
+          htmlFor="user-sort"
+          className="shrink-0 text-sm font-medium text-gray-600"
+        >
+          Sort by:
+        </label>
+        <select
+          id="user-sort"
+          value={sortColumn}
+          onChange={(e) => {
+            setSortColumn(e.target.value as SortColumn);
+            setSortDirection('asc');
+          }}
+          className="w-full rounded-md border-gray-200 py-1.5 text-sm shadow-sm"
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+          {currentUser?.is_superuser && (
+            <option value="is_approved">Approval</option>
+          )}
+        </select>
+        <button
+          type="button"
+          aria-label="Toggle sort direction"
+          onClick={() =>
+            setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+          }
+          className="shrink-0 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+        >
+          {sortDirection === 'asc' ? '↑' : '↓'}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-3 md:hidden">
+        {pageItems.map((user) => (
+          <DataCard
+            key={user.id}
+            leading={
+              <div className="shrink-0">
+                <UserProfilePicture user={user} />
+              </div>
+            }
+            title={`${user.first_name} ${user.last_name}`}
+            subtitle={user.email}
+            trailing={
+              currentUser?.is_superuser ? (
+                <ApprovalToggle
+                  user={user}
+                  loading={loadingUserId === user.id}
+                  onToggle={handleApprovalToggle}
+                />
+              ) : undefined
+            }
+          >
+            <MetricTileGrid>
+              <MetricTile
+                label="Date Joined"
+                value={new Date(user.created_at).toLocaleDateString()}
+              />
+              <MetricTile
+                label="Last Login"
+                value={
+                  user.last_login_at
+                    ? new Date(user.last_login_at).toLocaleString()
+                    : '-'
+                }
+              />
+              <MetricTile
+                label="Last Activity"
+                value={
+                  user.last_activity_at
+                    ? new Date(user.last_activity_at).toLocaleString()
+                    : '-'
+                }
+              />
+            </MetricTileGrid>
+          </DataCard>
+        ))}
+      </div>
+
+      <div className="hidden md:block md:max-h-96 overflow-y-auto overflow-x-auto">
         <table className="relative w-full min-w-[1200px] border-collapse">
           <thead>
             <tr className="h-12 sticky top-0 text-slate-700 bg-slate-300 z-10">
@@ -271,7 +389,7 @@ export default function DashboardUserList({
             </tr>
           </thead>
           <tbody>
-            {sortedAndPaginatedUsers.map((user) => (
+            {pageItems.map((user) => (
               <tr
                 key={user.id}
                 className="text-center border-b border-gray-200"
@@ -316,30 +434,11 @@ export default function DashboardUserList({
                 </td>
                 {currentUser?.is_superuser && (
                   <td className="p-1.5 bg-white" style={{ width: '140px' }}>
-                    <div className="flex items-center justify-center gap-2">
-                      <span
-                        className={`text-lg ${
-                          user.is_approved ? 'text-green-600' : 'text-red-600'
-                        }`}
-                      >
-                        {user.is_approved ? '✓' : '✗'}
-                      </span>
-                      <label
-                        htmlFor={`${user.id}-approval-checkbox`}
-                        className="relative inline-flex items-center cursor-pointer"
-                      >
-                        <Checkbox
-                          id={`${user.id}-approval-checkbox`}
-                          checked={user.is_approved}
-                          onChange={() => handleApprovalToggle(user)}
-                          className="sr-only peer"
-                        />
-                        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                      </label>
-                      {loadingUserId === user.id && (
-                        <span className="text-sm text-gray-500">...</span>
-                      )}
-                    </div>
+                    <ApprovalToggle
+                      user={user}
+                      loading={loadingUserId === user.id}
+                      onToggle={handleApprovalToggle}
+                    />
                   </td>
                 )}
               </tr>
@@ -347,12 +446,11 @@ export default function DashboardUserList({
           </tbody>
         </table>
       </div>
-      <div className="flex flex-cols justify-between gap-4">
-        <div></div>
+      <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
         <Pagination
           currentPage={currentPage}
           updateCurrentPage={updateCurrentPage}
-          totalPages={TOTAL_PAGES}
+          totalPages={totalPages}
         />
 
         <Button

--- a/frontend/src/components/pages/admin/DashboardUsers.tsx
+++ b/frontend/src/components/pages/admin/DashboardUsers.tsx
@@ -98,7 +98,7 @@ export default function DashboardUsers() {
         (user) =>
           user.first_name.toLowerCase().includes(lowerSearchTerm) ||
           user.last_name.toLowerCase().includes(lowerSearchTerm) ||
-          user.email.toLowerCase().includes(searchTerm)
+          user.email.toLowerCase().includes(lowerSearchTerm)
       )
       .sort((a, b) =>
         sorter(a.last_name.trim().toLowerCase(), b.last_name.trim().toLowerCase())

--- a/frontend/src/components/pages/admin/DataCards.tsx
+++ b/frontend/src/components/pages/admin/DataCards.tsx
@@ -1,0 +1,62 @@
+import { ReactNode } from 'react';
+
+/**
+ * Stacked card used below `md` in place of a table row. Mirrors the engagement
+ * leaderboard cards in DashboardActivity so every admin list reads the same.
+ */
+export function DataCard({
+  leading,
+  title,
+  subtitle,
+  trailing,
+  children,
+}: {
+  leading?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  trailing?: ReactNode;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="rounded-sm bg-slate-100 p-3 text-left">
+      <div className="flex items-center gap-2">
+        {leading}
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium">{title}</div>
+          {subtitle && (
+            <div className="truncate text-sm text-gray-500">{subtitle}</div>
+          )}
+        </div>
+        {trailing}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function MetricTileGrid({ children }: { children: ReactNode }) {
+  return <div className="mt-3 grid grid-cols-2 gap-1">{children}</div>;
+}
+
+export function MetricTile({
+  label,
+  value,
+  highlight = false,
+}: {
+  label: string;
+  value: ReactNode;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={
+        highlight
+          ? 'rounded-sm bg-blue-50 p-2 text-blue-700'
+          : 'rounded-sm bg-slate-50 p-2'
+      }
+    >
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className={highlight ? 'font-semibold' : undefined}>{value}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/pages/admin/SearchBar.tsx
+++ b/frontend/src/components/pages/admin/SearchBar.tsx
@@ -1,11 +1,13 @@
 type SearchTermProps = {
   searchTerm: string;
   updateSearchTerm: (newSearchTerm: string) => void;
+  placeholder?: string;
 };
 
 export default function SearchBar({
   searchTerm,
   updateSearchTerm,
+  placeholder = 'Search table by keyword',
 }: SearchTermProps) {
   return (
     <div className="relative">
@@ -17,7 +19,7 @@ export default function SearchBar({
       <input
         type="text"
         id="Search"
-        placeholder="Search by table by keyword"
+        placeholder={placeholder}
         className="w-full rounded-md border-gray-200 px-4 py-2.5 pe-10 shadow-sm sm:text-sm"
         value={searchTerm}
         onChange={(e) => updateSearchTerm(e.target.value)}

--- a/frontend/src/components/utils.tsx
+++ b/frontend/src/components/utils.tsx
@@ -34,3 +34,13 @@ export function sorter(a: Date | string, b: Date | string, order: string = 'asc'
 export function getUnique<T>(arr: T[], key: string): string[] {
   return [...new Set(arr.map((elem) => elem[key]))];
 }
+
+/**
+ * Formats a byte count as binary gigabytes (GiB) for the admin storage tables.
+ * Shared so the project storage page and the engagement leaderboard, which sum
+ * the same bytes server-side, cannot drift apart on precision.
+ * Note: StatStorageCard reports filesystem capacity in decimal GB instead.
+ */
+export function bytesToGB(bytes: number): string {
+  return (bytes / 1024 ** 3).toFixed(3);
+}


### PR DESCRIPTION
## Summary

Applies the engagement leaderboard's responsive pattern (table at `md`, stacked cards below) across the Project Storage, Users, and Extensions admin pages, so none of them require horizontal scrolling on a phone. Adds user search to Project Storage and simplifies it to show active data only. Also includes a demo project seeding script for exercising the leaderboard locally.

## Changes

- **Frontend — shared primitives:**
  - New `usePaginatedList<T>` hook (`components/hooks/usePaginatedList.ts`) replacing four copy-pasted clamp/slice blocks. Fixes their shared precedence bug — `Math.ceil(x ? x.length : 0 / MAX_ITEMS)` parsed as `x.length` undivided, so the clamp compared against an item count rather than a page count — and resets the page when a search shrinks the list, which the extensions pages previously did not do.
  - New `DataCards.tsx` (`DataCard`, `MetricTileGrid`, `MetricTile`) extracted from the leaderboard card markup so every mobile list renders identically.
  - `bytesToGB` consolidated into `components/utils.tsx`. Project Storage and the leaderboard sum byte-for-byte identical values server-side but had drifted to 3 vs 2 decimal places.
- **Frontend — Project Storage:**
  - Search by user name; page size raised from 5 to 10.
  - Shows active figures only (`total_active_projects` / `total_active_storage`); the `total (active)` parentheses and their `*` / `**` footnotes are gone. The storage gap could not be labeled honestly, since it also covers deactivated data products and flights inside *active* projects, and it self-clears once the cleanup task runs.
  - Rank column added to desktop and sorted on the displayed field, so ordering matches the Storage column. Rank is computed before search filtering, so a searched user keeps their true standing.
  - Removed a `max-h-96 overflow-y-auto` that sat on `<tbody>`, where it never applied.
- **Frontend — Extensions:** replaced the header-only table stacked above a separately scrolling body-only table (whose column widths could never align) with a single table per tab; `sticky` moved onto the `<th>` cells, since it does not work reliably on `<tr>`.
- **Frontend — Users:** mobile cards with a sort `<select>` and direction toggle wired to the same state as the desktop headers; approval switch extracted so both views drive one PATCH flow.
- **Frontend — bug fixes:** email search in `DashboardUsers` and `UserExtensions` compared a lowercased email against an unlowercased term, so capitalized input never matched. Also fixes a nested scroll container producing a second scrollbar on the User Activity page.
- **Backend:** adds `app/scripts/seed_demo_projects.py`, giving demo users 1–10 active projects each so the engagement leaderboard has enough ranked owners to exercise pagination. `--purge` must run before purging demo users, since `projects.owner_id` has no cascade.
- **Database:** none — no schema or migration changes.
- **Config:** none.

## Testing

Automated:

- `docker compose exec frontend npx tsc --noEmit` — exit 0.
- `docker compose exec backend pytest` — 1114 passed in 80s.

Manual QA (admin account, DevTools at 375px and ≥768px):

- `/admin/dashboard/storage` — search narrows the list; a searched user keeps their overall rank rather than being renumbered 1–3; the Storage (GB) column descends monotonically down the page; single values with no parentheses or footnotes; skeleton headers match the loaded table under network throttling.
- `/admin/dashboard/users` — desktop header sort and the mobile select + direction toggle produce the same order; approval toggle works from a mobile card (confirm → PATCH → optimistic update); Export CSV reachable at 375px.
- `/admin/dashboard/extensions` — header and body columns aligned on both tabs; header stays pinned while the body scrolls; checkbox toggles fire the PUT and revalidate from both table and card views.
- `/admin/dashboard/activity` — leaderboard unchanged apart from the new rank column; Data usage now matches the same user's figure on the Storage page exactly.
- All pages: no horizontal page-body scrolling at 375px.

## Screenshots

<!-- Before/after at 375px for Project Storage, Users, and Extensions -->

## Breaking Changes

None. No migrations, new environment variables, or dependency changes.

## Related Issues
NA