### PR TITLE
[Bug] Fix tusd post-finish failure when upload record is missing

### DIFF
--- a/backend/app/api/api_v1/endpoints/tusd.py
+++ b/backend/app/api/api_v1/endpoints/tusd.py
@@ -21,7 +21,6 @@ from app.utils.tusd.post_processing import (
     process_raw_data_uploaded_to_tusd,
 )
 
-
 router = APIRouter()
 
 
@@ -86,6 +85,57 @@ def _get_approved_user_from_token(db: Session, token: str) -> models.User:
     user = security.get_user_from_token_payload(db, token_payload)
     approved_user = deps.verify_user_account(user)
     return approved_user
+
+
+def _get_or_create_upload_for_post_finish(
+    payload: TUSDHook,
+    db: Session,
+    upload_id: str,
+    existing_upload: models.Upload | None,
+) -> tuple[models.Upload, bool]:
+    """Return the upload record for a post-finish hook, creating it if missing.
+
+    The upload record is normally created by the post-create hook, but it can
+    be missing at post-finish time: post-create and post-finish are both
+    non-blocking tusd notifications that can race for small files, post-create
+    skips record creation when its token validation fails, and a resumed
+    upload never triggers post-create at all. In those cases the user is
+    resolved from the access token cookie forwarded with the final PATCH
+    request and a record is created with the upload marked as finished.
+
+    Args:
+        payload (TUSDHook): TUSD hook payload.
+        db (Session): Database session.
+        upload_id (str): Upload event ID from tusd.
+        existing_upload (models.Upload | None): Existing upload record if any.
+
+    Returns:
+        tuple[models.Upload, bool]: Upload record and whether it was created
+            just now because post-create never recorded this upload.
+
+    Raises:
+        HTTPException: If no record exists and the access token is missing,
+            invalid, or expired, or the user account is not approved.
+    """
+    if existing_upload:
+        return existing_upload, False
+
+    cookies_list = payload.Event.HTTPRequest.Header.Cookie or []
+    access_token_value = _extract_access_token_from_cookie_headers(cookies_list)
+    if not access_token_value:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Upload record not found and access token missing",
+        )
+
+    approved_user = _get_approved_user_from_token(db, access_token_value)
+    created_upload = crud.upload.create_with_user(
+        db,
+        upload_id=upload_id,
+        user_id=approved_user.id,
+        is_uploading=False,
+    )
+    return created_upload, True
 
 
 def _handle_pre_create_authorization(
@@ -275,28 +325,19 @@ def _handle_post_create_indoor(
 
 
 def _update_upload_record_to_finished(
-    db: Session, existing_upload: models.Upload | None
+    db: Session, existing_upload: models.Upload
 ) -> None:
     """Update upload record to indicate upload has finished.
 
     Args:
         db: Database session
         existing_upload: Existing upload record
-
-    Raises:
-        HTTPException: If upload record not found
     """
-    if existing_upload:
-        # update record to indicate upload has finished
-        upload_update_in = UploadUpdate(
-            is_uploading=False, last_updated_at=datetime.now(timezone.utc)
-        )
-        crud.upload.update(db, db_obj=existing_upload, obj_in=upload_update_in)
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Upload record not found",
-        )
+    # update record to indicate upload has finished
+    upload_update_in = UploadUpdate(
+        is_uploading=False, last_updated_at=datetime.now(timezone.utc)
+    )
+    crud.upload.update(db, db_obj=existing_upload, obj_in=upload_update_in)
 
 
 @router.post("", status_code=status.HTTP_202_ACCEPTED)
@@ -420,9 +461,7 @@ def _handle_uas_project_hooks(
                     detail="Uploaded file not found",
                 )
             x_annotation_id = payload.Event.HTTPRequest.Header.X_Annotation_ID
-            x_data_product_id = (
-                payload.Event.HTTPRequest.Header.X_Data_Product_ID
-            )
+            x_data_product_id = payload.Event.HTTPRequest.Header.X_Data_Product_ID
             if not x_annotation_id or len(x_annotation_id) != 1:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -436,9 +475,7 @@ def _handle_uas_project_hooks(
             process_annotation_attachment_uploaded_to_tusd(
                 db,
                 storage_path=Path(storage.Path),
-                original_filename=Path(
-                    payload.Event.Upload.MetaData.filename
-                ),
+                original_filename=Path(payload.Event.Upload.MetaData.filename),
                 project_id=project.id,
                 flight_id=flight.id,
                 data_product_id=x_data_product_id[0],
@@ -449,19 +486,32 @@ def _handle_uas_project_hooks(
                 _update_upload_record_to_finished(db, existing_upload)
             return {"status": "ok"}
 
-        _update_upload_record_to_finished(db, existing_upload)
-        # After _update_upload_record_to_finished, existing_upload is guaranteed not None
-        assert existing_upload is not None
+        upload_record, created_now = _get_or_create_upload_for_post_finish(
+            payload, db, upload_id, existing_upload
+        )
+        if created_now:
+            # record was created outside post-create, so re-check project access
+            project_response = crud.project.get_user_project(
+                db,
+                user_id=upload_record.user_id,
+                project_id=project_id,
+                permission="rw",
+            )
+            if project_response.get("response_code") != status.HTTP_200_OK:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied"
+                )
+        _update_upload_record_to_finished(db, upload_record)
 
         # only run post processing if upload was in progress
-        if is_uploading == True or not existing_upload:
+        if is_uploading == True or created_now:
             storage = payload.Event.Upload.Storage
             if storage and os.path.exists(storage.Path):
                 if data_type != "raw":
                     # post-processing for geotiffs and point clouds
                     process_data_product_uploaded_to_tusd(
                         db,
-                        user_id=existing_upload.user_id,
+                        user_id=upload_record.user_id,
                         storage_path=Path(storage.Path),
                         original_filename=Path(payload.Event.Upload.MetaData.filename),
                         dtype=data_type,
@@ -471,7 +521,7 @@ def _handle_uas_project_hooks(
                 else:
                     process_raw_data_uploaded_to_tusd(
                         db,
-                        user_id=existing_upload.user_id,
+                        user_id=upload_record.user_id,
                         storage_path=Path(storage.Path),
                         original_filename=Path(payload.Event.Upload.MetaData.filename),
                         project_id=project.id,
@@ -495,31 +545,6 @@ def _handle_indoor_project_hooks(
     indoor_project_id: UUID,
 ) -> Any:
     """Handle TUSD hooks for indoor projects."""
-    # For pre-create and post-create, we may not have existing_upload yet
-    # For post-finish, we need existing_upload for user_id
-    if payload.Type in ["post-finish"] and not existing_upload:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Upload record not found",
-        )
-
-    # For post-finish, check if user has permission to read/write to indoor project
-    if payload.Type == "post-finish":
-        # Type narrowing: existing_upload is guaranteed not None by guard above
-        assert existing_upload is not None
-        try:
-            crud.indoor_project.get_with_permission(
-                db,
-                indoor_project_id=indoor_project_id,
-                user_id=existing_upload.user_id,
-                required_permission=Role.MANAGER,
-            )
-        except (PermissionDenied, ResourceNotFound):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Permission denied",
-            )
-
     # Handle hook types
     if payload.Type == "pre-create":
         return _handle_pre_create_authorization_indoor(payload, db, indoor_project_id)
@@ -539,12 +564,28 @@ def _handle_indoor_project_hooks(
         return {"status": "ok"}
 
     if payload.Type == "post-finish":
-        # Type narrowing: existing_upload is guaranteed not None by guard above
-        assert existing_upload is not None
-        _update_upload_record_to_finished(db, existing_upload)
+        upload_record, created_now = _get_or_create_upload_for_post_finish(
+            payload, db, upload_id, existing_upload
+        )
+
+        # check if user has permission to read/write to indoor project
+        try:
+            crud.indoor_project.get_with_permission(
+                db,
+                indoor_project_id=indoor_project_id,
+                user_id=upload_record.user_id,
+                required_permission=Role.MANAGER,
+            )
+        except (PermissionDenied, ResourceNotFound):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
+            )
+
+        _update_upload_record_to_finished(db, upload_record)
 
         # only run post processing if upload was in progress
-        if is_uploading == True or not existing_upload:
+        if is_uploading == True or created_now:
             storage = payload.Event.Upload.Storage
             if storage and os.path.exists(storage.Path):
                 # extract treatment from custom header
@@ -555,7 +596,7 @@ def _handle_indoor_project_hooks(
 
                 process_indoor_data_uploaded_to_tusd(
                     db,
-                    user_id=existing_upload.user_id,
+                    user_id=upload_record.user_id,
                     storage_path=Path(storage.Path),
                     original_filename=Path(payload.Event.Upload.MetaData.filename),
                     indoor_project_id=indoor_project_id,

--- a/backend/app/tests/api/api_v1/test_tusd_post_finish.py
+++ b/backend/app/tests/api/api_v1/test_tusd_post_finish.py
@@ -1,0 +1,408 @@
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api.deps import get_current_user
+from app.core.config import settings
+from app.tests.utils.flight import create_flight
+from app.tests.utils.indoor_project import create_indoor_project
+from app.tests.utils.project import create_project
+from app.tests.utils.user import create_user, login_and_get_access_token
+
+
+def _build_tusd_post_finish_payload(
+    *,
+    upload_id: str,
+    storage_path: str,
+    cookie: list[str],
+    project_id: str | None = None,
+    flight_id: str | None = None,
+    data_type: str | None = None,
+    indoor_project_id: str | None = None,
+    treatment: str | None = None,
+) -> dict:
+    """Build a minimal tusd post-finish hook payload."""
+    return {
+        "Type": "post-finish",
+        "Event": {
+            "Upload": {
+                "ID": upload_id,
+                "Size": 1024,
+                "SizeIsDeferred": False,
+                "Offset": 1024,
+                "MetaData": {
+                    "filename": "test.tif",
+                    "filetype": "image/tiff",
+                    "name": "test.tif",
+                    "relativePath": "null",
+                    "type": "image/tiff",
+                },
+                "IsPartial": False,
+                "IsFinal": False,
+                "PartialUploads": None,
+                "Storage": {"Path": storage_path, "Type": "filestore"},
+            },
+            "HTTPRequest": {
+                "Method": "PATCH",
+                "URI": "/files/",
+                "RemoteAddr": "127.0.0.1",
+                "Header": {
+                    "Accept": ["*/*"],
+                    "Accept-Encoding": ["gzip"],
+                    "Accept-Language": ["en-US"],
+                    "Connection": ["keep-alive"],
+                    "Cookie": cookie,
+                    "Host": ["localhost"],
+                    "Origin": ["http://localhost"],
+                    "Tus-Resumable": ["1.0.0"],
+                    "User-Agent": ["test"],
+                    "X-Forwarded-Host": ["localhost"],
+                    "X-Forwarded-Proto": ["http"],
+                    **({"X-Project-Id": [project_id]} if project_id else {}),
+                    **({"X-Flight-Id": [flight_id]} if flight_id else {}),
+                    **({"X-Data-Type": [data_type]} if data_type else {}),
+                    **(
+                        {"X-Indoor-Project-Id": [indoor_project_id]}
+                        if indoor_project_id
+                        else {}
+                    ),
+                    **({"X-Treatment": [treatment]} if treatment else {}),
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def process_data_product_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Capture calls to the UAS data product post-processing function."""
+    calls: list[dict] = []
+
+    def fake_process(db: Session, **kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.tusd.process_data_product_uploaded_to_tusd",
+        fake_process,
+    )
+    return calls
+
+
+@pytest.fixture
+def process_indoor_data_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Capture calls to the indoor data post-processing function."""
+    calls: list[dict] = []
+
+    def fake_process(db: Session, **kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.tusd.process_indoor_data_uploaded_to_tusd",
+        fake_process,
+    )
+    return calls
+
+
+def _create_uploaded_file(tmp_path: Path) -> str:
+    """Create a dummy uploaded file in tusd storage and return its path."""
+    uploaded_file = tmp_path / uuid4().hex
+    uploaded_file.write_bytes(b"fake geotiff bytes")
+    return str(uploaded_file)
+
+
+def test_post_finish_without_upload_record_creates_record_and_processes(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Post-finish arriving before post-create recorded the upload (hook race)
+    should create the record from the forwarded cookie and still process."""
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id, pilot_id=current_user.id)
+    upload_id = uuid4().hex
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[f"access_token=Bearer {normal_user_access_token}"],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    upload_record = crud.upload.get_upload_by_upload_id(db, upload_id=upload_id)
+    assert upload_record is not None
+    assert upload_record.is_uploading is False
+    assert upload_record.user_id == current_user.id
+    assert len(process_data_product_calls) == 1
+    call = process_data_product_calls[0]
+    assert call["user_id"] == current_user.id
+    assert call["project_id"] == project.id
+    assert call["flight_id"] == flight.id
+    assert call["dtype"] == "dsm"
+
+
+def test_post_finish_without_upload_record_and_missing_token_returns_error(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Post-finish with no upload record and no access token cannot resolve a
+    user for ownership and must fail without processing."""
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id, pilot_id=current_user.id)
+    upload_id = uuid4().hex
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert crud.upload.get_upload_by_upload_id(db, upload_id=upload_id) is None
+    assert len(process_data_product_calls) == 0
+
+
+def test_post_finish_without_upload_record_and_invalid_token_returns_error(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Post-finish with no upload record and an invalid token must fail
+    without creating a record or processing."""
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id, pilot_id=current_user.id)
+    upload_id = uuid4().hex
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=["access_token=Bearer not-a-valid-jwt"],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert crud.upload.get_upload_by_upload_id(db, upload_id=upload_id) is None
+    assert len(process_data_product_calls) == 0
+
+
+def test_post_finish_created_record_requires_project_permission(
+    client: TestClient,
+    db: Session,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """When post-finish creates the missing record, the resolved user must
+    still have read/write access to the project."""
+    password = "SecurePassword123"
+    other_user = create_user(db, password=password)
+    other_token = login_and_get_access_token(
+        client=client, email=other_user.email, password=password
+    )
+    project = create_project(db)  # owned by a different random user
+    flight = create_flight(db, project_id=project.id)
+    upload_id = uuid4().hex
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[f"access_token=Bearer {other_token}"],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert len(process_data_product_calls) == 0
+
+
+def test_post_finish_with_in_progress_upload_record_processes(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Post-finish with an in-progress upload record (normal hook order)
+    marks it finished and runs post-processing."""
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id, pilot_id=current_user.id)
+    upload_id = uuid4().hex
+    crud.upload.create_with_user(
+        db, upload_id=upload_id, user_id=current_user.id, is_uploading=True
+    )
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[f"access_token=Bearer {normal_user_access_token}"],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    upload_record = crud.upload.get_upload_by_upload_id(db, upload_id=upload_id)
+    assert upload_record is not None
+    assert upload_record.is_uploading is False
+    assert len(process_data_product_calls) == 1
+
+
+def test_post_finish_with_existing_record_does_not_require_token(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Post-finish with an existing upload record must not depend on the
+    cookie (e.g., token expired mid-upload)."""
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id, pilot_id=current_user.id)
+    upload_id = uuid4().hex
+    crud.upload.create_with_user(
+        db, upload_id=upload_id, user_id=current_user.id, is_uploading=True
+    )
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert len(process_data_product_calls) == 1
+
+
+def test_post_finish_with_finished_upload_record_skips_processing(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_data_product_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Post-finish for an upload already marked finished (replayed hook) must
+    not process the file again."""
+    current_user = get_current_user(db, normal_user_access_token)
+    project = create_project(db, owner_id=current_user.id)
+    flight = create_flight(db, project_id=project.id, pilot_id=current_user.id)
+    upload_id = uuid4().hex
+    crud.upload.create_with_user(
+        db, upload_id=upload_id, user_id=current_user.id, is_uploading=False
+    )
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[f"access_token=Bearer {normal_user_access_token}"],
+        project_id=str(project.id),
+        flight_id=str(flight.id),
+        data_type="dsm",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert len(process_data_product_calls) == 0
+
+
+def test_post_finish_indoor_without_upload_record_creates_record_and_processes(
+    client: TestClient,
+    db: Session,
+    normal_user_access_token: str,
+    process_indoor_data_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Indoor post-finish with a missing upload record should create it from
+    the forwarded cookie and still process."""
+    current_user = get_current_user(db, normal_user_access_token)
+    indoor_project = create_indoor_project(db, owner_id=current_user.id)
+    upload_id = uuid4().hex
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[f"access_token=Bearer {normal_user_access_token}"],
+        indoor_project_id=str(indoor_project.id),
+        treatment="control",
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    upload_record = crud.upload.get_upload_by_upload_id(db, upload_id=upload_id)
+    assert upload_record is not None
+    assert upload_record.is_uploading is False
+    assert upload_record.user_id == current_user.id
+    assert len(process_indoor_data_calls) == 1
+    call = process_indoor_data_calls[0]
+    assert call["user_id"] == current_user.id
+    assert call["indoor_project_id"] == indoor_project.id
+    assert call["treatment"] == "control"
+
+
+def test_post_finish_indoor_created_record_requires_project_permission(
+    client: TestClient,
+    db: Session,
+    process_indoor_data_calls: list[dict],
+    tmp_path: Path,
+) -> None:
+    """Indoor post-finish resolving a user without access to the indoor
+    project must fail without processing."""
+    password = "SecurePassword123"
+    other_user = create_user(db, password=password)
+    other_token = login_and_get_access_token(
+        client=client, email=other_user.email, password=password
+    )
+    indoor_project = create_indoor_project(db)  # owned by a different random user
+    upload_id = uuid4().hex
+
+    payload = _build_tusd_post_finish_payload(
+        upload_id=upload_id,
+        storage_path=_create_uploaded_file(tmp_path),
+        cookie=[f"access_token=Bearer {other_token}"],
+        indoor_project_id=str(indoor_project.id),
+    )
+
+    response = client.post(f"{settings.API_V1_STR}/tusd", json=payload)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert len(process_indoor_data_calls) == 0


### PR DESCRIPTION
## Summary
Uploading small data products (e.g., a single-band CHM GeoTIFF) could silently fail: the tusd `post-finish` hook raised `404: Upload record not found` and aborted post-processing before the data product was created, while the client still reported a successful upload. This restores resilient handling of the missing-record case so small-file uploads process reliably.

## Root Cause
The upload tracking record is created only by the `post-create` hook. Both `post-create` and `post-finish` are non-blocking tusd notifications, so for small files the final PATCH completes milliseconds after the creation POST and the two hook requests race — including across backend replicas. When `post-finish` won the race, the record lookup came up empty. Since 0225a520, that raised a hard 404 (previously the record was created on the spot), turning a tolerated race into silent upload loss. Two rarer paths hit the same failure: `post-create` skipping record creation on token failure, and resumed tus uploads that never fire `post-create` at all.

## Changes
- Backend: Added `_get_or_create_upload_for_post_finish` in `tusd.py` — returns the existing upload record, or resolves the user from the access-token cookie forwarded with the final PATCH and creates the record as finished; fails 401 only when there is no record and no valid token
- Backend: UAS `post-finish` now uses the helper and re-checks project rw permission when the record was created via fallback (parity with the pre-0225a520 `can_read_write_project` check); indoor `post-finish` restructured the same way with its permission check moved inside the block
- Backend: Removed the 404 branch from `_update_upload_record_to_finished` (parameter tightened to non-Optional)
- Tests: New `test_tusd_post_finish.py` with 9 tests covering the hook race regression, missing/invalid token, fallback permission checks, existing-record behavior without a token, and replayed-hook dedupe for both UAS and indoor paths

## Testing
- `docker compose exec backend pytest app/tests/api/api_v1/test_tusd_post_finish.py -v` — 9 passed
- `docker compose exec backend pytest` — full suite, 1139 passed
- `docker compose exec backend mypy app/api/api_v1/endpoints/tusd.py` — only the 4 pre-existing errors also present on `main`
- Manual QA: Data Products → upload modal → "Other" → name "CHM" → upload a small single-band GeoTIFF against a multi-replica stack; verify the data product appears and backend logs show no `404: Upload record not found`

## Follow-up (out of scope)
Duplicate `uploads` rows are possible if a straggler `post-create` lands after the `post-finish` fallback creates the record (inert bookkeeping; reads tolerate duplicates). Proper fix is a separate PR: dedupe migration + unique constraint on `uploads.upload_id` + `ON CONFLICT` handling in `create_with_user`.
