### PR TITLE
[Feature] Track data product provenance from source raw data uploads

### DIFF
--- a/backend/alembic/versions/db4a6ae51d8b_add_raw_data_id_to_data_products.py
+++ b/backend/alembic/versions/db4a6ae51d8b_add_raw_data_id_to_data_products.py
@@ -1,0 +1,36 @@
+"""add raw_data_id to data_products
+
+Revision ID: db4a6ae51d8b
+Revises: 8a820e756cbd
+Create Date: 2026-07-24 14:54:31.660169
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'db4a6ae51d8b'
+down_revision: str | None = '8a820e756cbd'
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Source raw data upload a data product was derived from by the external
+    # image processing service. SET NULL on delete so raw data cleanup jobs can
+    # hard-delete deactivated raw data without hitting FK violations.
+    op.add_column('data_products', sa.Column('raw_data_id', sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        'fk_data_products_raw_data',
+        'data_products',
+        'raw_data',
+        ['raw_data_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_data_products_raw_data', 'data_products', type_='foreignkey')
+    op.drop_column('data_products', 'raw_data_id')

--- a/backend/app/api/api_v1/endpoints/data_products.py
+++ b/backend/app/api/api_v1/endpoints/data_products.py
@@ -608,9 +608,47 @@ def process_data_product_from_external_storage(
                     detail="Unable to locate data product on disk",
                 )
 
+        # source raw data these products were derived from; the processing job
+        # row always carries raw_data_id (report is optional), so prefer it
+        source_raw_data_id = job.job.raw_data_id if job.job else None
+        if source_raw_data_id is None and payload.report:
+            source_raw_data_id = payload.report.raw_data_id
+
+        # create each data product and spawn its own post-processing job; done
+        # before marking this job SUCCESS so the created ids can be recorded and
+        # so a failure here fails this job instead of stranding it INPROGRESS
+        created_products = []
+        try:
+            for data_product in payload.products:
+                result = process_data_product_uploaded_to_tusd(
+                    db=db,
+                    user_id=user.id,
+                    storage_path=Path(data_product.storage_path),
+                    original_filename=Path(data_product.filename),
+                    dtype=data_product.data_type,
+                    project_id=project_id,
+                    flight_id=flight_id,
+                    project_to_utm=True,
+                    raw_data_id=source_raw_data_id,
+                )
+                created_products.append(
+                    {
+                        "id": result["data_product_id"],
+                        "data_type": result["data_type"],
+                    }
+                )
+        except Exception as e:
+            logger.exception(f"Unable to create data product from raw data: {e}")
+            fail_job(job, "Processing failed on the processing service.")
+            crud.user.remove_single_use_token(db, db_obj=token_db_obj)
+            raise
+
+        # merge into existing extra; JobManager.update replaces extra wholesale
+        # and skips falsy values, so always build a full dict
+        success_extra = dict(job.job.extra) if job.job and job.job.extra else {}
+
         # copy report using a per-job filename so reports from earlier runs
         # are preserved for the processing history
-        success_extra = None
         try:
             if payload.report and os.path.exists(payload.report.storage_path):
                 raw_data_dir = os.path.join(
@@ -627,9 +665,6 @@ def process_data_product_from_external_storage(
                         raw_data_dir, f"report_{payload.job_id}.pdf"
                     )
                     shutil.copyfile(payload.report.storage_path, report_path)
-                    success_extra = (
-                        dict(job.job.extra) if job.job and job.job.extra else {}
-                    )
                     # store the static path only; the jobs endpoint composes
                     # the absolute URL at read time
                     success_extra["report"] = report_path
@@ -640,21 +675,13 @@ def process_data_product_from_external_storage(
         except Exception as e:
             logger.exception(f"Unable to copy report to raw data directory: {e}")
 
-        # data products successfully derived from raw data
-        job.update(status=Status.SUCCESS, extra=success_extra)
+        # record the products this run produced so the processing history can
+        # show which data products came from this raw data upload
+        if created_products:
+            success_extra["data_products"] = created_products
 
-        # new jobs will be spawned for each data product as its processed further
-        for data_product in payload.products:
-            process_data_product_uploaded_to_tusd(
-                db=db,
-                user_id=user.id,
-                storage_path=Path(data_product.storage_path),
-                original_filename=Path(data_product.filename),
-                dtype=data_product.data_type,
-                project_id=project_id,
-                flight_id=flight_id,
-                project_to_utm=True,
-            )
+        # data products successfully derived from raw data
+        job.update(status=Status.SUCCESS, extra=success_extra or None)
 
     # remove token from database
     crud.user.remove_single_use_token(db, db_obj=token_db_obj)
@@ -1052,10 +1079,7 @@ def create_zonal_statistics(
             )
         )
         with db as session:
-            if (
-                session.execute(feature_in_project_query).scalar_one_or_none()
-                is None
-            ):
+            if session.execute(feature_in_project_query).scalar_one_or_none() is None:
                 vector_layer_feature_id = None
     else:
         vector_layer_feature_id = None

--- a/backend/app/models/data_product.py
+++ b/backend/app/models/data_product.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from .file_permission import FilePermission
     from .flight import Flight
     from .job import Job
+    from .raw_data import RawData
     from .user_style import UserStyle
     from .vector_layer import VectorLayer
 
@@ -62,6 +63,12 @@ class DataProduct(Base):
     flight_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("flights.id"), nullable=False
     )
+    # Source raw data upload this product was derived from by the external image
+    # processing service. Null for directly uploaded products. SET NULL on delete
+    # so cleanup jobs can hard-delete deactivated raw data without FK violations.
+    raw_data_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("raw_data.id", ondelete="SET NULL"), nullable=True
+    )
     # relationships
     annotations: Mapped[List["Annotation"]] = relationship(
         back_populates="data_product",
@@ -75,6 +82,7 @@ class DataProduct(Base):
         back_populates="file", cascade="all, delete"
     )
     flight: Mapped["Flight"] = relationship(back_populates="data_products")
+    raw_data: Mapped[Optional["RawData"]] = relationship(back_populates="data_products")
     jobs: Mapped[List["Job"]] = relationship(
         back_populates="data_product", cascade="all, delete"
     )

--- a/backend/app/models/raw_data.py
+++ b/backend/app/models/raw_data.py
@@ -10,6 +10,7 @@ from app.db.base_class import Base
 from app.models.utils.utcnow import utcnow
 
 if TYPE_CHECKING:
+    from .data_product import DataProduct
     from .flight import Flight
     from .job import Job
     from .file_permission import FilePermission
@@ -48,6 +49,9 @@ class RawData(Base):
     )
 
     flight: Mapped["Flight"] = relationship(back_populates="raw_data")
+    # Products derived from this raw data by the external processing service. No
+    # cascade: deleting raw data must never delete the products it produced.
+    data_products: Mapped[List["DataProduct"]] = relationship(back_populates="raw_data")
     jobs: Mapped[List["Job"]] = relationship(
         back_populates="raw_data", cascade="all, delete"
     )

--- a/backend/app/schemas/data_product.py
+++ b/backend/app/schemas/data_product.py
@@ -34,6 +34,7 @@ class DataProductCreate(DataProductBase):
     filepath: str
     original_filename: str
     stac_properties: Optional[STACProperties] = None
+    raw_data_id: Optional[UUID4] = None
 
 
 # properties to receive via API on update
@@ -51,6 +52,7 @@ class DataProductInDBBase(DataProductBase, from_attributes=True):
     data_type: str
     filepath: str
     flight_id: UUID4
+    raw_data_id: Optional[UUID4] = None
     original_filename: str
     stac_properties: Optional[STACProperties] = None
     user_style: Optional[dict] = None

--- a/backend/app/scripts/backfill_data_product_raw_data.py
+++ b/backend/app/scripts/backfill_data_product_raw_data.py
@@ -1,0 +1,235 @@
+"""Backfill data_products.raw_data_id for products created before provenance tracking.
+
+Existing data products carry no link to the raw data upload they were derived
+from. This script reconstructs that link heuristically: for each successful
+``processing-raw-data`` job (which records its source ``raw_data_id``), it matches
+data products in the same flight that were created just after the job finished.
+
+Products are created in the same request that marks the processing job SUCCESS,
+so the real gap between the job's ``end_time`` and each product's ``created_at`` is
+milliseconds; ``--window`` only exists to absorb clock skew on old rows. A product
+matched by more than one job is ambiguous and left untouched.
+
+Runs as a dry run by default (prints proposed changes, writes nothing). Pass
+``--apply`` to persist. The same pass also records the matched product ids in each
+job's ``extra["data_products"]`` so the processing history can show its outputs.
+
+Examples:
+    python /app/app/scripts/backfill_data_product_raw_data.py
+    python /app/app/scripts/backfill_data_product_raw_data.py --window 300
+    python /app/app/scripts/backfill_data_product_raw_data.py --flight <uuid> --apply
+"""
+
+import argparse
+import logging
+import sys
+from datetime import timedelta
+from typing import Dict, List, NamedTuple, Optional, Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.models.data_product import DataProduct
+from app.models.job import Job
+from app.models.raw_data import RawData
+from app.schemas.job import Status
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Data product types the external processing service produces from raw data.
+TARGET_DATA_TYPES = ("point_cloud", "dem", "ortho")
+
+PROCESSING_JOB_NAME = "processing-raw-data"
+
+
+class Match(NamedTuple):
+    product: DataProduct
+    job: Job
+
+
+def compute_matches(
+    jobs: Sequence[Job],
+    products: Sequence[DataProduct],
+    window_seconds: int,
+) -> tuple[List[Match], Dict[UUID, List[Job]]]:
+    """Match products to the processing job that produced them.
+
+    A product matches a job when it belongs to the job's flight and was created
+    in the window ``[job.end_time, job.end_time + window_seconds]``. Products
+    matched by exactly one job are returned as confident matches; products
+    matched by more than one job are returned as ambiguous and left unlinked.
+
+    Args:
+        jobs: Successful processing-raw-data jobs, each with raw_data loaded.
+        products: Candidate products (raw_data_id currently NULL).
+        window_seconds: Seconds after a job's end_time a product may appear.
+
+    Returns:
+        Tuple of (confident matches, ambiguous product_id -> [jobs]).
+    """
+    window = timedelta(seconds=window_seconds)
+    # product id -> jobs whose window contains it
+    candidates: Dict[UUID, List[Job]] = {}
+    products_by_id: Dict[UUID, DataProduct] = {p.id: p for p in products}
+
+    for job in jobs:
+        if job.end_time is None or job.raw_data is None:
+            continue
+        job_flight_id = job.raw_data.flight_id
+        for product in products:
+            if product.flight_id != job_flight_id:
+                continue
+            if product.created_at < job.end_time:
+                continue
+            if product.created_at > job.end_time + window:
+                continue
+            candidates.setdefault(product.id, []).append(job)
+
+    matches: List[Match] = []
+    ambiguous: Dict[UUID, List[Job]] = {}
+    for product_id, matched_jobs in candidates.items():
+        if len(matched_jobs) == 1:
+            matches.append(Match(products_by_id[product_id], matched_jobs[0]))
+        else:
+            ambiguous[product_id] = matched_jobs
+
+    return matches, ambiguous
+
+
+def _load_jobs(db: Session, flight_id: Optional[UUID]) -> List[Job]:
+    stmt = (
+        select(Job)
+        .join(RawData, Job.raw_data_id == RawData.id)
+        .where(
+            Job.name == PROCESSING_JOB_NAME,
+            Job.status == Status.SUCCESS,
+            Job.raw_data_id.is_not(None),
+            Job.end_time.is_not(None),
+        )
+    )
+    if flight_id is not None:
+        stmt = stmt.where(RawData.flight_id == flight_id)
+    return list(db.scalars(stmt).all())
+
+
+def _load_candidate_products(
+    db: Session, flight_id: Optional[UUID]
+) -> List[DataProduct]:
+    stmt = select(DataProduct).where(
+        DataProduct.raw_data_id.is_(None),
+        DataProduct.data_type.in_(TARGET_DATA_TYPES),
+    )
+    if flight_id is not None:
+        stmt = stmt.where(DataProduct.flight_id == flight_id)
+    return list(db.scalars(stmt).all())
+
+
+def backfill(window_seconds: int, flight_id: Optional[UUID], apply: bool) -> None:
+    with SessionLocal() as session:
+        jobs = _load_jobs(session, flight_id)
+        products = _load_candidate_products(session, flight_id)
+
+        matches, ambiguous = compute_matches(jobs, products, window_seconds)
+
+        for match in matches:
+            product = match.product
+            job = match.job
+            delta = int((product.created_at - job.end_time).total_seconds())
+            logger.info(
+                "MATCH  job=%s raw_data=%s (%s) ended=%s -> product=%s type=%s "
+                "created=+%ss",
+                job.id,
+                job.raw_data_id,
+                job.raw_data.original_filename if job.raw_data else "?",
+                job.end_time.isoformat(),
+                product.id,
+                product.data_type,
+                delta,
+            )
+
+        for product_id, matched_jobs in ambiguous.items():
+            product = next(p for p in products if p.id == product_id)
+            logger.info(
+                "SKIP-AMBIGUOUS product=%s type=%s jobs=%s",
+                product_id,
+                product.data_type,
+                [str(j.id) for j in matched_jobs],
+            )
+
+        matched_count = len(matches)
+        ambiguous_count = len(ambiguous)
+        unmatched_count = len(products) - matched_count - ambiguous_count
+
+        if apply and matches:
+            # group product ids by job so we can also record outputs in extra
+            products_by_job: Dict[UUID, List[Match]] = {}
+            for match in matches:
+                match.product.raw_data_id = match.job.raw_data_id
+                products_by_job.setdefault(match.job.id, []).append(match)
+
+            for job_id, job_matches in products_by_job.items():
+                job = job_matches[0].job
+                existing_extra = dict(job.extra) if job.extra else {}
+                existing_extra["data_products"] = [
+                    {"id": str(m.product.id), "data_type": m.product.data_type}
+                    for m in job_matches
+                ]
+                job.extra = existing_extra
+
+            session.commit()
+            logger.info("Applied %d links.", matched_count)
+
+        logger.info(
+            "Summary: %d matched, %d ambiguous-skipped, %d products left unmatched.%s",
+            matched_count,
+            ambiguous_count,
+            unmatched_count,
+            "" if apply else " Re-run with --apply to write.",
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill data_products.raw_data_id from successful processing jobs"
+        )
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=120,
+        help=(
+            "Seconds after a job's end_time a product may be created to count as "
+            "its output (default: 120)"
+        ),
+    )
+    parser.add_argument(
+        "--flight",
+        type=str,
+        default=None,
+        help="Limit backfill to a single flight id",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Persist the matches (default is a dry run that writes nothing)",
+    )
+
+    args = parser.parse_args()
+
+    flight_id: Optional[UUID] = None
+    if args.flight:
+        try:
+            flight_id = UUID(args.flight)
+        except ValueError:
+            logger.error("Invalid --flight id: %s", args.flight)
+            sys.exit(1)
+
+    backfill(window_seconds=args.window, flight_id=flight_id, apply=args.apply)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/tests/api/api_v1/test_data_products.py
+++ b/backend/app/tests/api/api_v1/test_data_products.py
@@ -1170,9 +1170,7 @@ def test_running_tool_with_no_product_selected(
 ) -> None:
     current_user = get_current_user(db, normal_user_access_token)
     data_product = SampleDataProduct(db, data_type="dsm", user=current_user)
-    response = client.post(
-        get_tools_url(data_product), json=get_processing_request()
-    )
+    response = client.post(get_tools_url(data_product), json=get_processing_request())
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
@@ -1362,9 +1360,7 @@ def test_create_from_ext_storage_stores_per_job_report(
             "raw_data_id": str(raw_data.obj.id),
         },
     }
-    with patch(
-        "app.utils.job_manager.get_db", side_effect=lambda: iter([db])
-    ):
+    with patch("app.utils.job_manager.get_db", side_effect=lambda: iter([db])):
         response = client.post(
             f"{settings.API_V1_STR}/projects/{raw_data.project.id}"
             f"/flights/{raw_data.flight.id}/data_products/create_from_ext_storage",
@@ -1373,9 +1369,7 @@ def test_create_from_ext_storage_stores_per_job_report(
     assert response.status_code == status.HTTP_202_ACCEPTED
 
     # report copied with per-job filename
-    expected_report = (
-        Path(raw_data.obj.filepath).parent / f"report_{job.id}.pdf"
-    )
+    expected_report = Path(raw_data.obj.filepath).parent / f"report_{job.id}.pdf"
     assert expected_report.exists()
     assert expected_report.read_bytes() == b"%PDF-1.4 test report"
 
@@ -1392,9 +1386,89 @@ def test_create_from_ext_storage_stores_per_job_report(
         f"/flights/{raw_data.flight.id}/raw_data/{raw_data.obj.id}/jobs"
     )
     assert response.status_code == status.HTTP_200_OK
-    response_job = next(
-        j for j in response.json() if j["id"] == str(job.id)
-    )
+    response_job = next(j for j in response.json() if j["id"] == str(job.id))
     assert response_job["extra"]["report"] == (
         f"{settings.API_DOMAIN}{expected_report}"
     )
+
+
+def test_create_from_ext_storage_links_products_to_raw_data(
+    client: TestClient, db: Session, tmp_path, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    raw_data = SampleRawData(db, user=current_user)
+    job = create_job(
+        db,
+        name="processing-raw-data",
+        raw_data_id=raw_data.obj.id,
+        status=JobStatus.INPROGRESS,
+        extra={"backend": "odm", "settings": {"orthoResolution": 4.0}},
+    )
+    token = secrets.token_urlsafe()
+    crud.user.create_single_use_token(
+        db,
+        obj_in=schemas.SingleUseTokenCreate(
+            token=security.get_token_hash(token, salt="rawdata")
+        ),
+        user_id=raw_data.user.id,
+    )
+    # data product produced by the external processing service
+    product_file = tmp_path / "ortho.tif"
+    product_file.write_bytes(b"fake tif")
+
+    payload = {
+        "token": token,
+        "job_id": str(job.id),
+        "status": {"code": 1, "message": "completed"},
+        "products": [
+            {
+                "data_type": "ortho",
+                "filename": "ortho.tif",
+                "storage_path": str(product_file),
+            }
+        ],
+        "report": None,
+    }
+    with patch(
+        "app.utils.tusd.post_processing.upload_geotiff.apply_async"
+    ) as mock_apply, patch(
+        "app.utils.job_manager.get_db", side_effect=lambda: iter([db])
+    ):
+        response = client.post(
+            f"{settings.API_V1_STR}/projects/{raw_data.project.id}"
+            f"/flights/{raw_data.flight.id}/data_products/create_from_ext_storage",
+            json=payload,
+        )
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    # the post-processing celery task was dispatched for the product
+    mock_apply.assert_called_once()
+
+    # job marked successful with outputs recorded and existing extra preserved
+    updated_job = crud.job.get(db, id=job.id)
+    assert updated_job
+    assert updated_job.status == JobStatus.SUCCESS
+    assert updated_job.extra["settings"] == {"orthoResolution": 4.0}
+    outputs = updated_job.extra["data_products"]
+    assert len(outputs) == 1
+    assert outputs[0]["data_type"] == "ortho"
+
+    # the created data product links back to the source raw data
+    created = crud.data_product.get(db, id=UUID(outputs[0]["id"]))
+    assert created is not None
+    assert created.raw_data_id == raw_data.obj.id
+
+
+def test_read_data_products_includes_raw_data_id(
+    client: TestClient, db: Session, normal_user_access_token: str
+) -> None:
+    current_user = get_current_user(db, normal_user_access_token)
+    data_product = SampleDataProduct(db, user=current_user, data_type="ortho")
+    response = client.get(
+        f"{settings.API_V1_STR}/projects/{data_product.project.id}"
+        f"/flights/{data_product.flight.id}/data_products"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    products = response.json()
+    match = next(p for p in products if p["id"] == str(data_product.obj.id))
+    # directly uploaded products carry no raw data source
+    assert match["raw_data_id"] is None

--- a/backend/app/tests/crud/test_data_product.py
+++ b/backend/app/tests/crud/test_data_product.py
@@ -8,11 +8,13 @@ from app import crud
 from app.core.config import settings
 from app.models.data_product import DataProduct
 from app.models.job import Job
+from app.schemas.data_product import DataProductCreate
 from app.schemas.file_permission import FilePermissionUpdate
 from app.schemas.job import State, Status
 from app.tests.utils.flight import create_flight
 from app.tests.utils.data_product import SampleDataProduct, test_stac_props_dsm
 from app.tests.utils.job import create_job
+from app.tests.utils.raw_data import SampleRawData
 from app.tests.utils.user import create_user
 
 
@@ -28,6 +30,26 @@ def test_create_data_product(db: Session) -> None:
     assert data_product.obj.created_at is not None
     assert data_product.obj.updated_at is not None
     assert data_product.obj.updated_at >= data_product.obj.created_at
+
+
+def test_create_data_product_with_raw_data_id(db: Session) -> None:
+    raw_data = SampleRawData(db)
+    data_product = crud.data_product.create_with_flight(
+        db,
+        obj_in=DataProductCreate(
+            data_type="ortho",
+            filepath="null",
+            original_filename="ortho.tif",
+            raw_data_id=raw_data.obj.id,
+        ),
+        flight_id=raw_data.flight.id,
+    )
+    assert data_product.raw_data_id == raw_data.obj.id
+
+
+def test_create_data_product_defaults_raw_data_id_to_null(db: Session) -> None:
+    data_product = SampleDataProduct(db, data_type="ortho")
+    assert data_product.obj.raw_data_id is None
 
 
 def test_read_data_product(db: Session) -> None:
@@ -473,18 +495,14 @@ def test_clear_s3_urls_for_project_only_clears_matching_project(db: Session) -> 
 
 def test_clear_s3_urls_for_project_zero_when_nothing_to_clear(db: Session) -> None:
     dp = SampleDataProduct(db)
-    rowcount = crud.data_product.clear_s3_urls_for_project(
-        db, project_id=dp.project.id
-    )
+    rowcount = crud.data_product.clear_s3_urls_for_project(db, project_id=dp.project.id)
     assert rowcount == 0
 
 
 def test_get_data_products_with_s3_urls_for_project(db: Session) -> None:
     dp_uploaded = SampleDataProduct(db)
     flight = create_flight(db, project_id=dp_uploaded.project.id)
-    dp_not_uploaded = SampleDataProduct(
-        db, project=dp_uploaded.project, flight=flight
-    )
+    dp_not_uploaded = SampleDataProduct(db, project=dp_uploaded.project, flight=flight)
 
     crud.data_product.update_s3_url(
         db,
@@ -503,9 +521,7 @@ def test_get_data_products_with_s3_urls_for_project(db: Session) -> None:
 
 def test_get_data_products_with_s3_urls_excludes_inactive(db: Session) -> None:
     dp = SampleDataProduct(db)
-    crud.data_product.update_s3_url(
-        db, data_product_id=dp.obj.id, s3_url="https://x"
-    )
+    crud.data_product.update_s3_url(db, data_product_id=dp.obj.id, s3_url="https://x")
     crud.data_product.deactivate(db, data_product_id=dp.obj.id)
 
     results = crud.data_product.get_data_products_with_s3_urls_for_project(

--- a/backend/app/utils/tusd/post_processing.py
+++ b/backend/app/utils/tusd/post_processing.py
@@ -73,6 +73,7 @@ def process_data_product_uploaded_to_tusd(
     project_id: UUID,
     flight_id: UUID,
     project_to_utm: bool = False,
+    raw_data_id: Optional[UUID] = None,
 ) -> Dict:
     """Post-processing method for data product uploaded to tus file server. Creates job
     for converting GeoTIFF (.tif) to Cloud Optimized GeoTIFF or converting point cloud
@@ -88,13 +89,16 @@ def process_data_product_uploaded_to_tusd(
         project_id (UUID): Project ID for data product's project.
         flight_id (UUID): Flight ID for data product's flight.
         project_to_utm (bool): Whether to project the GeoTIFF to UTM.
+        raw_data_id (Optional[UUID]): Source raw data upload this product was
+            derived from by the external processing service. None for directly
+            uploaded data products.
 
     Raises:
         HTTPException: Raised if file extension is not supported.
         HTTPException: Raised if unable to create job.
 
     Returns:
-        dict: Processing status.
+        dict: Processing status and the created data product's id and type.
     """
     # create new filename
     new_filename = str(uuid4())
@@ -109,7 +113,10 @@ def process_data_product_uploaded_to_tusd(
     data_product = crud.data_product.create_with_flight(
         db,
         obj_in=schemas.DataProductCreate(
-            data_type=dtype, filepath="null", original_filename=str(original_filename)
+            data_type=dtype,
+            filepath="null",
+            original_filename=str(original_filename),
+            raw_data_id=raw_data_id,
         ),
         flight_id=flight_id,
     )
@@ -146,7 +153,12 @@ def process_data_product_uploaded_to_tusd(
         if extension == ".zip":
             # start 3DGS LCC process in background (zip contains LCC format files)
             upload_3dgs_lcc.apply_async(
-                args=(str(storage_path), str(data_product_dir), job.id, data_product.id),
+                args=(
+                    str(storage_path),
+                    str(data_product_dir),
+                    job.id,
+                    data_product.id,
+                ),
             )
         else:
             # start 3D Gaussian Splatting process in background (.ply file)
@@ -166,7 +178,11 @@ def process_data_product_uploaded_to_tusd(
             ),
         )
 
-    return {"status": "processing"}
+    return {
+        "status": "processing",
+        "data_product_id": str(data_product.id),
+        "data_type": dtype,
+    }
 
 
 def process_raw_data_uploaded_to_tusd(

--- a/frontend/src/components/pages/workspace/projects/Project.d.ts
+++ b/frontend/src/components/pages/workspace/projects/Project.d.ts
@@ -38,6 +38,7 @@ export interface DataProduct {
   liked?: boolean;
   original_filename: string;
   public: boolean;
+  raw_data_id?: string | null;
   resolution?: {
     unit: string;
     x: number;

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductCard.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductCard.tsx
@@ -15,6 +15,7 @@ import { formatCount } from '../../../../../../utils/formatCount';
 import { Status } from '../../../../../Alert';
 import Card from '../../../../../Card';
 import { isGeoTIFF } from './DataProductsTable';
+import { resolveRawDataSource } from './rawDataSource';
 import DataProductDeleteModal from './DataProductDeleteModal';
 import DataProductMetadataModal from './DataProductMetadataModal';
 import EditableDataType from './EditableDataType';
@@ -38,12 +39,15 @@ function ProgressBar() {
 export default function DataProductCard({
   dataProduct,
   otherDataProducts,
+  rawDataFilenames,
   setStatus,
 }: {
   dataProduct: DataProduct;
   otherDataProducts: DataProduct[];
+  rawDataFilenames: Map<string, string>;
   setStatus: React.Dispatch<React.SetStateAction<Status | null>>;
 }) {
+  const rawDataSource = resolveRawDataSource(dataProduct, rawDataFilenames);
   const [invalidPreviews, setInvalidPreviews] = useState<string[]>([]);
   const [isCopied, setIsCopied] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -221,6 +225,23 @@ export default function DataProductCard({
                   )}
                 </div>
               )}
+            </div>
+            {/* raw data source: always render the row (empty when absent) so
+                cards with and without a source stay the same height; min-w-0 lets
+                truncate clip long filenames instead of overflowing the card */}
+            <div className="h-4 min-w-0 truncate text-xs leading-4 text-slate-500">
+              {rawDataSource.kind === 'named' ? (
+                <span title={`Generated from ${rawDataSource.filename}`}>
+                  Generated from {rawDataSource.filename}
+                </span>
+              ) : rawDataSource.kind === 'unavailable' ? (
+                <span
+                  className="italic"
+                  title="Generated from raw data (no longer available)"
+                >
+                  Generated from raw data (no longer available)
+                </span>
+              ) : null}
             </div>
             {/* action buttons */}
             <div className="flex items-center justify-around gap-4 relative">

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProducts.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProducts.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useParams, useRevalidator } from 'react-router';
 
 import { DataProduct } from '../../Project';
+import { RawDataProps } from '../RawData/RawData.types';
 import { Button } from '../../../../../Buttons';
 import TableCardRadioInput from '../../../../../TableCardRadioInput';
 import DataProductUploadModal from './DataProductUploadModal';
@@ -28,7 +29,13 @@ function getDataProductsDisplayModeFromLS(): 'table' | 'carousel' {
   }
 }
 
-export default function DataProducts({ data }: { data: DataProduct[] }) {
+export default function DataProducts({
+  data,
+  rawData,
+}: {
+  data: DataProduct[];
+  rawData: RawDataProps[];
+}) {
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState<Status | null>(null);
   const [tableView, toggleTableView] = useState<'table' | 'carousel'>(
@@ -70,6 +77,13 @@ export default function DataProducts({ data }: { data: DataProduct[] }) {
     [data]
   );
 
+  // Resolve a product's source raw_data_id to the upload's original filename so
+  // the card and table can show which raw data it was generated from.
+  const rawDataFilenames = useMemo(
+    () => new Map(rawData.map((rd) => [rd.id, rd.original_filename])),
+    [rawData]
+  );
+
   return (
     <div className="h-full flex flex-col">
       <div className="h-24">
@@ -81,7 +95,11 @@ export default function DataProducts({ data }: { data: DataProduct[] }) {
       </div>
 
       {tableView === 'table' && (
-        <DataProductsTable data={sortedDataProducts} setStatus={setStatus} />
+        <DataProductsTable
+          data={sortedDataProducts}
+          rawDataFilenames={rawDataFilenames}
+          setStatus={setStatus}
+        />
       )}
 
       {tableView === 'carousel' && (
@@ -93,6 +111,7 @@ export default function DataProducts({ data }: { data: DataProduct[] }) {
               otherDataProducts={sortedDataProducts.filter(
                 (dp) => dp.id !== dataProduct.id
               )}
+              rawDataFilenames={rawDataFilenames}
               setStatus={setStatus}
             />
           ))}

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductsTable.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/DataProductsTable.tsx
@@ -21,6 +21,7 @@ import ToolboxModal from './ToolboxModal';
 import XmlMetadataAttachment from './XmlMetadata/XmlMetadataAttachment';
 import DataProductShareModal from './DataProductShareModal';
 import DataProductEngagement from '../../../../../engagement/DataProductEngagement';
+import { resolveRawDataSource } from './rawDataSource';
 import { DataProduct, ProjectDetail } from '../../Project';
 
 export function isGeoTIFF(dataType: string): boolean {
@@ -200,9 +201,11 @@ function DataTypeSelect({
 
 export default function DataProductsTable({
   data,
+  rawDataFilenames,
   setStatus,
 }: {
   data: DataProduct[];
+  rawDataFilenames: Map<string, string>;
   setStatus: React.Dispatch<React.SetStateAction<Status | null>>;
 }) {
   const navigate = useNavigate();
@@ -213,6 +216,7 @@ export default function DataProductsTable({
     'Preview',
     'Likes & Views',
     'File',
+    'Source',
     'Action',
   ];
 
@@ -343,6 +347,30 @@ export default function DataProductsTable({
                         )}
                       </div>
                     ),
+                    (() => {
+                      const source = resolveRawDataSource(
+                        dataset,
+                        rawDataFilenames
+                      );
+                      return (
+                        <div
+                          key={`row-${dataset.id}-source`}
+                          className="h-full flex items-center justify-center text-sm text-slate-600"
+                        >
+                          {source.kind === 'named' ? (
+                            <span className="truncate" title={source.filename}>
+                              {source.filename}
+                            </span>
+                          ) : source.kind === 'unavailable' ? (
+                            <span className="italic text-slate-400">
+                              No longer available
+                            </span>
+                          ) : (
+                            <span className="text-slate-400">&mdash;</span>
+                          )}
+                        </div>
+                      );
+                    })(),
                   ],
                 }))}
                 actions={getDataProductActions(

--- a/frontend/src/components/pages/workspace/projects/flights/DataProducts/rawDataSource.ts
+++ b/frontend/src/components/pages/workspace/projects/flights/DataProducts/rawDataSource.ts
@@ -1,0 +1,28 @@
+import { DataProduct } from '../../Project';
+
+export type RawDataSource =
+  | { kind: 'none' }
+  | { kind: 'named'; filename: string }
+  | { kind: 'unavailable' };
+
+/**
+ * Resolve how a data product's raw data source should be displayed.
+ *
+ * - `none`: product was not generated from raw data (no raw_data_id).
+ * - `named`: the source raw data upload is still present; show its filename.
+ * - `unavailable`: product has a raw_data_id but the upload is gone
+ *   (deactivated or purged), so no filename can be shown.
+ */
+export function resolveRawDataSource(
+  dataProduct: DataProduct,
+  rawDataFilenames: Map<string, string>
+): RawDataSource {
+  if (!dataProduct.raw_data_id) {
+    return { kind: 'none' };
+  }
+  const filename = rawDataFilenames.get(dataProduct.raw_data_id);
+  if (filename) {
+    return { kind: 'named', filename };
+  }
+  return { kind: 'unavailable' };
+}

--- a/frontend/src/components/pages/workspace/projects/flights/FlightDataTabNav.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/FlightDataTabNav.tsx
@@ -57,7 +57,7 @@ export default function FlightDataTabNav({
       <hr className="my-4 border-gray-700" />
       <TabPanels>
         <TabPanel>
-          <DataProducts data={dataProducts} />
+          <DataProducts data={dataProducts} rawData={rawData} />
         </TabPanel>
         <TabPanel>
           <RawData rawData={rawData} />

--- a/frontend/src/components/pages/workspace/projects/flights/RawData/RawData.types.ts
+++ b/frontend/src/components/pages/workspace/projects/flights/RawData/RawData.types.ts
@@ -58,6 +58,7 @@ export type ProcessingJobExtra = {
   detail?: string;
   progress?: number;
   report?: string;
+  data_products?: { id: string; data_type: string }[];
 };
 
 export type ProcessingJob = {

--- a/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataProcessingHistoryModal.tsx
+++ b/frontend/src/components/pages/workspace/projects/flights/RawData/RawDataProcessingHistoryModal.tsx
@@ -87,6 +87,39 @@ function ProcessingJobSettings({ job }: { job: ProcessingJob }) {
   );
 }
 
+const OUTPUT_DATA_TYPE_LABELS: Record<string, string> = {
+  point_cloud: 'Point Cloud',
+  dem: 'DEM',
+  ortho: 'Ortho',
+};
+
+function formatOutputDataType(dataType: string): string {
+  return OUTPUT_DATA_TYPE_LABELS[dataType] ?? dataType;
+}
+
+function ProcessingJobOutputs({ job }: { job: ProcessingJob }) {
+  const outputs = job.extra?.data_products;
+  if (!outputs || outputs.length === 0) {
+    // Runs from before output tracking, or that produced nothing recorded.
+    return (
+      <span className="text-sm italic text-gray-400">Outputs not recorded</span>
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-sm text-gray-600">Outputs:</span>
+      {outputs.map((output) => (
+        <span
+          key={output.id}
+          className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700"
+        >
+          {formatOutputDataType(output.data_type)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export default function RawDataProcessingHistoryModal({
   rawData,
 }: {
@@ -180,6 +213,7 @@ export default function RawDataProcessingHistoryModal({
                     </span>
                   )}
                   <ProcessingJobSettings job={job} />
+                  {job.status === 'SUCCESS' && <ProcessingJobOutputs job={job} />}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
Data products generated by the external processing service now record which raw data upload they were derived from. Users can see the source upload for each data product in the flight data view, and the raw data processing history now lists the data products each successful run produced.

## Changes
- Backend: Added nullable `raw_data_id` FK (`ON DELETE SET NULL`) to `data_products`; `create_from_ext_storage` now creates products before marking the job SUCCESS, links them to the source raw data, and records produced product ids in the job's `extra["data_products"]`
- Backend: Added `app/scripts/backfill_data_product_raw_data.py` — dry-run-by-default script that reconstructs provenance links for existing products by matching product `created_at` against successful processing job `end_time` (ambiguous matches are skipped)
- Frontend: New "Source" column in the data products table and a source line on data product cards, showing the raw data upload's filename (or an "unavailable" note when the upload has been removed)
- Frontend: Processing history modal shows output badges (Point Cloud / DEM / Ortho) for successful runs
- Database: New Alembic migration `db4a6ae51d8b` adding the column and FK constraint

## Testing
- Commands run: `docker compose exec backend pytest` — all 1134 tests passing, including 4 new tests covering product-to-raw-data linking, job output recording in `extra`, the null default for direct uploads, and `raw_data_id` in the API response
- `docker compose exec frontend npx tsc --noEmit` — no errors
- Manual QA: Navigate to a project flight, upload raw data and process it, then open the Data tab — verify the new products show "Generated from `<filename>`" on cards and in the table's Source column; open the raw data Processing History modal and verify the run lists its output badges. Directly uploaded products should show a dash / no source line.

## Breaking Changes
- Migration required: `docker compose exec backend alembic upgrade head`
- Optional: run `python /app/app/scripts/backfill_data_product_raw_data.py` (dry run) then with `--apply` in the backend container to link pre-existing data products to their source raw data
