### PR TITLE
[Bug] Fix point cloud upload succeeding with empty COPC output

### DIFF
--- a/backend/app/tasks/upload_tasks.py
+++ b/backend/app/tasks/upload_tasks.py
@@ -32,7 +32,6 @@ from app.schemas.job import Status
 from app.tasks.utils import validate_3dgs_image, validate_panoramic_image
 from app.utils.lcc_validator import unpack_lcc_zip
 
-
 logger = get_task_logger(__name__)
 
 # 32 MB buffer size for copying files
@@ -751,6 +750,40 @@ def upload_panoramic(
     return None
 
 
+def run_untwine(input_las: Path, output_copc: Path, a_srs: str | None = None) -> bool:
+    """Run untwine to convert a las/laz point cloud to COPC format.
+
+    Args:
+        input_las (Path): Filepath for input las/laz point cloud.
+        output_copc (Path): Filepath for output COPC.
+        a_srs (str | None): Optional EPSG code to assign to the output.
+
+    Returns:
+        bool: True if untwine succeeded and wrote a non-empty COPC.
+    """
+    untwine_cmd: list[str] = ["untwine", "-i", str(input_las), "-o", str(output_copc)]
+    if a_srs:
+        untwine_cmd.extend(["--a_srs", a_srs])
+
+    result = subprocess.run(untwine_cmd, capture_output=True, text=True)
+
+    # clean up temp directory created by untwine
+    if os.path.exists(f"{output_copc}_tmp"):
+        shutil.rmtree(f"{output_copc}_tmp")
+
+    if result.returncode != 0:
+        logger.error(
+            f"untwine exited with code {result.returncode}: {result.stderr.strip()}"
+        )
+        return False
+
+    if not os.path.exists(output_copc) or os.path.getsize(output_copc) == 0:
+        logger.error("untwine exited cleanly but produced an empty or missing COPC")
+        return False
+
+    return True
+
+
 @celery_app.task(name="upload_point_cloud_task")
 def upload_point_cloud(
     storage_path: str,
@@ -768,8 +801,8 @@ def upload_point_cloud(
         job_id (UUID): Job ID for job associated with upload process.
         data_product_id (UUID): Data product ID for uploaded point cloud.
 
-    Raises:
-        Exception: Raise if EPT or COPG subprocesses fail.
+    Returns:
+        str | None: Filepath for original point cloud, or None if the task failed.
     """
     in_las = Path(las_filepath)
 
@@ -784,7 +817,7 @@ def upload_point_cloud(
 
     # retrieve job associated with this task
     try:
-        job = JobManager(job_id=job_id)
+        job = JobManager(job_id=job_id, db=db)
     except ValueError:
         # remove uploaded file and raise exception
         if os.path.exists(in_las):
@@ -820,6 +853,7 @@ def upload_point_cloud(
             copc_laz_filepath = in_las.parents[1] / in_las.name
         else:
             copc_laz_filepath = in_las.parents[1] / in_las.with_suffix(".copc.laz").name
+            epsg_code: str | None = None
             # get UTM EPSG code if needed
             if project_to_utm:
                 # read the point cloud metadata
@@ -854,25 +888,46 @@ def upload_point_cloud(
                 else:
                     epsg_code = get_utm_epsg_from_latlon(mean_y, mean_x)
 
-            # use pdal info to find the EPSG code of the point cloud
-            untwine_cmd: list[str] = [
-                "untwine",
-                "-i",
-                str(in_las),
-                "-o",
-                str(copc_laz_filepath),
-            ]
-
-            # project to UTM if flag set and UTM EPSG code found
-            if project_to_utm and epsg_code:
-                untwine_cmd.extend(["--a_srs", epsg_code])
-
             # run untwine command
-            subprocess.run(untwine_cmd)
+            if not run_untwine(in_las, copc_laz_filepath, a_srs=epsg_code):
+                # untwine crashes on files with corrupt headers (e.g. an unset
+                # bounding box); rewrite the file with pdal to rebuild the
+                # header from the actual points, then retry once
+                logger.info("Retrying COPC build with repaired point cloud")
+                repaired_las = in_las.parent / f"repaired_{in_las.name}"
+                try:
+                    repair_result = subprocess.run(
+                        [
+                            "pdal",
+                            "translate",
+                            str(in_las),
+                            str(repaired_las),
+                            "--writers.las.forward=all",
+                        ],
+                        capture_output=True,
+                        text=True,
+                    )
+                    if repair_result.returncode != 0:
+                        logger.error(
+                            f"pdal translate exited with code "
+                            f"{repair_result.returncode}: "
+                            f"{repair_result.stderr.strip()}"
+                        )
+                        raise RuntimeError("Failed to repair uploaded point cloud")
+                    if not run_untwine(
+                        repaired_las, copc_laz_filepath, a_srs=epsg_code
+                    ):
+                        raise RuntimeError("Failed to convert point cloud to COPC")
+                finally:
+                    if repaired_las.exists():
+                        repaired_las.unlink()
 
-            # clean up temp directory created by untwine
-            if os.path.exists(f"{copc_laz_filepath}_tmp"):
-                shutil.rmtree(f"{copc_laz_filepath}_tmp")
+        # never publish a missing or empty COPC
+        if (
+            not os.path.exists(copc_laz_filepath)
+            or os.path.getsize(copc_laz_filepath) == 0
+        ):
+            raise RuntimeError("COPC output is missing or empty")
     except Exception:
         logger.exception("Failed to build COPC from uploaded point cloud")
         shutil.rmtree(in_las.parents[1])

--- a/backend/app/tests/tasks/test_upload_point_cloud.py
+++ b/backend/app/tests/tasks/test_upload_point_cloud.py
@@ -1,0 +1,231 @@
+"""Tests for the upload_point_cloud Celery task (las/laz to COPC via untwine)."""
+
+import struct
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import laspy
+import numpy as np
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.schemas.job import Status
+from app.tasks.upload_tasks import upload_point_cloud
+from app.tests.utils.data_product import SampleDataProduct
+
+POINT_COUNT = 1000
+
+
+def create_test_las(las_path: Path, zero_header_bbox: bool = False) -> None:
+    """Write a small LAS 1.4 (point format 7) file with RGB points.
+
+    Args:
+        las_path (Path): Destination for the LAS file.
+        zero_header_bbox (bool): Zero out the header bounding box to mimic
+            files whose generating software never set it. Points remain far
+            from the origin, so the header no longer contains them.
+    """
+    rng = np.random.default_rng(42)
+    header = laspy.LasHeader(point_format=7, version="1.4")
+    header.offsets = [496000.0, 4475000.0, 0.0]
+    header.scales = [0.001, 0.001, 0.001]
+    las = laspy.LasData(header)
+    las.x = rng.uniform(496533.0, 496684.0, POINT_COUNT)
+    las.y = rng.uniform(4475638.0, 4475726.0, POINT_COUNT)
+    las.z = rng.uniform(100.0, 157.0, POINT_COUNT)
+    las.red = rng.integers(0, 65280, POINT_COUNT, dtype=np.uint16)
+    las.green = rng.integers(0, 65280, POINT_COUNT, dtype=np.uint16)
+    las.blue = rng.integers(0, 65280, POINT_COUNT, dtype=np.uint16)
+    las.write(str(las_path))
+
+    if zero_header_bbox:
+        # bytes 179-226 of a LAS 1.4 header hold max/min x, y, z
+        with open(las_path, "r+b") as f:
+            f.seek(179)
+            f.write(struct.pack("<6d", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+
+
+def setup_upload_dirs(
+    tmp_path: Path, filename: str = "upload.las"
+) -> tuple[Path, Path, Path]:
+    """Create the directory layout upload_point_cloud expects.
+
+    Returns:
+        tuple[Path, Path, Path]: Fake tusd storage path, destination las
+            filepath inside a work subdirectory, and the data product
+            directory that receives the COPC.
+    """
+    storage_path = tmp_path / "tusd" / filename
+    storage_path.parent.mkdir()
+    data_product_dir = tmp_path / "data_product"
+    work_dir = data_product_dir / "tmp"
+    work_dir.mkdir(parents=True)
+    return storage_path, work_dir / filename, data_product_dir
+
+
+def test_upload_point_cloud_success(db: Session, tmp_path: Path) -> None:
+    """A valid LAS converts to a non-empty COPC and the job succeeds."""
+    data_product = SampleDataProduct(db, data_type="point_cloud")
+    storage_path, las_filepath, data_product_dir = setup_upload_dirs(tmp_path)
+    create_test_las(storage_path)
+
+    with patch("app.tasks.upload_tasks.get_db", side_effect=lambda: iter([db])):
+        result = upload_point_cloud(
+            str(storage_path),
+            str(las_filepath),
+            data_product.job.id,
+            data_product.obj.id,
+        )
+
+    assert result == str(las_filepath)
+
+    copc_filepath = data_product_dir / "upload.copc.laz"
+    assert copc_filepath.exists()
+    assert copc_filepath.stat().st_size > 0
+    with laspy.open(str(copc_filepath)) as copc:
+        assert copc.header.point_count == POINT_COUNT
+
+    job_in_db = crud.job.get(db, id=data_product.job.id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.SUCCESS
+
+    data_product_in_db = crud.data_product.get(db, id=data_product.obj.id)
+    assert data_product_in_db is not None
+    assert data_product_in_db.filepath == str(copc_filepath)
+    assert data_product_in_db.is_initial_processing_completed
+
+    # uploaded file must be removed from tusd storage after success
+    assert not storage_path.exists()
+
+
+def test_upload_point_cloud_repairs_invalid_header_bbox(
+    db: Session, tmp_path: Path
+) -> None:
+    """A LAS with an unset header bounding box crashes untwine; the task must
+    repair the header and still produce a valid, non-empty COPC.
+
+    Regression test: this used to leave a 0-byte copc.laz while reporting
+    SUCCESS because untwine's exit code was never checked.
+    """
+    data_product = SampleDataProduct(db, data_type="point_cloud")
+    storage_path, las_filepath, data_product_dir = setup_upload_dirs(tmp_path)
+    create_test_las(storage_path, zero_header_bbox=True)
+
+    with patch("app.tasks.upload_tasks.get_db", side_effect=lambda: iter([db])):
+        result = upload_point_cloud(
+            str(storage_path),
+            str(las_filepath),
+            data_product.job.id,
+            data_product.obj.id,
+        )
+
+    assert result == str(las_filepath)
+
+    copc_filepath = data_product_dir / "upload.copc.laz"
+    assert copc_filepath.exists()
+    assert copc_filepath.stat().st_size > 0
+    with laspy.open(str(copc_filepath)) as copc:
+        assert copc.header.point_count == POINT_COUNT
+
+    job_in_db = crud.job.get(db, id=data_product.job.id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.SUCCESS
+
+    # temporary repaired copy must not be left behind
+    assert not (las_filepath.parent / f"repaired_{las_filepath.name}").exists()
+
+
+def test_upload_point_cloud_untwine_failure_marks_job_failed(
+    db: Session, tmp_path: Path
+) -> None:
+    """When untwine and the repair retry both fail, the job must be marked
+    FAILED and the data product directory removed."""
+    data_product = SampleDataProduct(db, data_type="point_cloud")
+    storage_path, las_filepath, data_product_dir = setup_upload_dirs(tmp_path)
+    create_test_las(storage_path)
+    original_filepath = data_product.obj.filepath
+
+    crashed = subprocess.CompletedProcess(
+        args=["untwine"], returncode=134, stdout="", stderr="assertion failed"
+    )
+    with patch("app.tasks.upload_tasks.get_db", side_effect=lambda: iter([db])), patch(
+        "app.tasks.upload_tasks.subprocess.run", return_value=crashed
+    ):
+        result = upload_point_cloud(
+            str(storage_path),
+            str(las_filepath),
+            data_product.job.id,
+            data_product.obj.id,
+        )
+
+    assert result is None
+
+    job_in_db = crud.job.get(db, id=data_product.job.id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.FAILED
+
+    # data product must not point at a COPC and its directory must be removed
+    data_product_in_db = crud.data_product.get(db, id=data_product.obj.id)
+    assert data_product_in_db is not None
+    assert data_product_in_db.filepath == original_filepath
+    assert not data_product_dir.exists()
+
+
+def test_upload_point_cloud_empty_output_marks_job_failed(
+    db: Session, tmp_path: Path
+) -> None:
+    """A clean untwine exit that leaves an empty COPC must fail the job
+    instead of publishing a 0-byte file."""
+    data_product = SampleDataProduct(db, data_type="point_cloud")
+    storage_path, las_filepath, data_product_dir = setup_upload_dirs(tmp_path)
+    create_test_las(storage_path)
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+        if cmd[0] == "untwine":
+            # simulate untwine exiting cleanly but writing an empty file
+            Path(cmd[cmd.index("-o") + 1]).touch()
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    with patch("app.tasks.upload_tasks.get_db", side_effect=lambda: iter([db])), patch(
+        "app.tasks.upload_tasks.subprocess.run", side_effect=fake_run
+    ):
+        result = upload_point_cloud(
+            str(storage_path),
+            str(las_filepath),
+            data_product.job.id,
+            data_product.obj.id,
+        )
+
+    assert result is None
+
+    job_in_db = crud.job.get(db, id=data_product.job.id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.FAILED
+    assert not data_product_dir.exists()
+
+
+def test_upload_point_cloud_empty_copc_upload_marks_job_failed(
+    db: Session, tmp_path: Path
+) -> None:
+    """An empty .copc.laz uploaded directly must never be published."""
+    data_product = SampleDataProduct(db, data_type="point_cloud")
+    storage_path, las_filepath, data_product_dir = setup_upload_dirs(
+        tmp_path, filename="upload.copc.laz"
+    )
+    storage_path.touch()
+
+    with patch("app.tasks.upload_tasks.get_db", side_effect=lambda: iter([db])):
+        result = upload_point_cloud(
+            str(storage_path),
+            str(las_filepath),
+            data_product.job.id,
+            data_product.obj.id,
+        )
+
+    assert result is None
+
+    job_in_db = crud.job.get(db, id=data_product.job.id)
+    assert job_in_db is not None
+    assert job_in_db.status == Status.FAILED
+    assert not data_product_dir.exists()


### PR DESCRIPTION
## Summary
`upload_point_cloud_task` reported SUCCESS even when untwine crashed, publishing a 0-byte `copc.laz` as the data product. Uploads of LAS files with an unset header bounding box (a spec violation some generating software produces) now either convert successfully via an automatic header repair, or fail the job cleanly — never a false success.

## Changes
- Backend: `run_untwine()` helper in `upload_tasks.py` runs untwine with its exit code checked and stderr captured, verifies the output COPC exists and is non-empty, and cleans up untwine's `_tmp` directory even after a crash
- Backend: on untwine failure the task repairs the LAS with `pdal translate --writers.las.forward=all` (rebuilds header bounds from actual points, preserving LAS version/point format) and retries once; the repaired temp copy is always removed
- Backend: final guard refuses to publish a missing or empty COPC, covering the direct `.copc.laz` upload path as well; failures route through the existing cleanup + FAILED-job path
- Backend: `JobManager` now reuses the task's DB session, matching the `toolbox_tasks` pattern
- Tests: new `backend/app/tests/tasks/test_upload_point_cloud.py` with laspy-synthesized LAS fixtures (no binary files committed)

## Root cause
untwine sizes its octree grid from the LAS header bounds. With a header bbox of all zeros and points ~496 km away, grid indices overflow the one byte per axis `GridKey` allows, tripping `assert(k < 255)` and killing untwine with SIGABRT. The task ran `subprocess.run(untwine_cmd)` without checking the exit code or validating output, so the job was still marked SUCCESS. The chained preview task reads the original `.las` (not the COPC), so a good preview masked the failure.

## Testing
- Commands run: `docker compose exec backend pytest` — all 1148 tests passing; `docker compose exec frontend npx tsc --noEmit` — clean
- Added 5 tests: happy path with real untwine, regression test that byte-patches a zero header bbox and asserts repair + valid COPC, untwine crash → job FAILED + cleanup, clean exit with empty output → FAILED, empty direct `.copc.laz` upload → FAILED
- Verified end-to-end with the real-world 20.2M-point LAS that triggered the bug: previously exit 134 + 0-byte COPC with SUCCESS status; now produces a valid 152 MB `copc.laz` containing all 20,207,343 points with correct bounds
- Manual QA: upload a `.las` file to a flight, verify the job completes, the point cloud opens in the viewer, and the stored `copc.laz` is non-empty

## Related Issues
None
